### PR TITLE
build(deps): align Kysely 0.28 workspace versions

### DIFF
--- a/.changeset/align-kysely-runtime.md
+++ b/.changeset/align-kysely-runtime.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/kysely": patch
+---
+
+Require Kysely 0.28.14 or newer within the 0.28 release line and keep workspace consumers on one resolved version.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
         "@nestjs/terminus": "^10.0.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
-        "kysely": "^0.28.11",
+        "kysely": "^0.28.14",
         "pg": "^8.18.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",

--- a/packages/kysely/package.json
+++ b/packages/kysely/package.json
@@ -54,7 +54,7 @@
     },
     "dependencies": {
         "dayjs": "^1.11.13",
-        "kysely": "^0.28.9",
+        "kysely": "^0.28.14",
         "pg": "^8.18.0",
         "picocolors": "^1.1.1"
     },

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -58,7 +58,7 @@
         "@types/jest": "^29.5.0",
         "@types/node": "^20.0.0",
         "jest": "^29.5.0",
-        "kysely": "^0.28.11",
+        "kysely": "^0.28.14",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.1.0",

--- a/packages/observability/package.json
+++ b/packages/observability/package.json
@@ -68,7 +68,7 @@
         "@types/node": "^20.0.0",
         "express": "^4.18.0",
         "jest": "^29.5.0",
-        "kysely": "^0.28.11",
+        "kysely": "^0.28.14",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^6.0.1",
         "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^0.14.0
         version: 0.14.3
       kysely:
-        specifier: ^0.28.11
-        version: 0.28.11
+        specifier: ^0.28.14
+        version: 0.28.17
       pg:
         specifier: ^8.18.0
         version: 8.18.0
@@ -384,8 +384,8 @@ importers:
         specifier: ^1.11.13
         version: 1.11.19
       kysely:
-        specifier: ^0.28.9
-        version: 0.28.11
+        specifier: ^0.28.14
+        version: 0.28.17
       pg:
         specifier: ^8.18.0
         version: 8.18.0
@@ -495,8 +495,8 @@ importers:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3))
       kysely:
-        specifier: ^0.28.11
-        version: 0.28.11
+        specifier: ^0.28.14
+        version: 0.28.17
       reflect-metadata:
         specifier: ^0.1.13
         version: 0.1.14
@@ -572,8 +572,8 @@ importers:
         specifier: ^29.5.0
         version: 29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3))
       kysely:
-        specifier: ^0.28.11
-        version: 0.28.11
+        specifier: ^0.28.14
+        version: 0.28.17
       reflect-metadata:
         specifier: ^0.1.13
         version: 0.1.14
@@ -3365,8 +3365,8 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
-  kysely@0.28.11:
-    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
+  kysely@0.28.17:
+    resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
 
   leven@3.1.0:
@@ -7873,7 +7873,7 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  kysely@0.28.11: {}
+  kysely@0.28.17: {}
 
   leven@3.1.0: {}
 


### PR DESCRIPTION
## Summary

- require Kysely `^0.28.14` in the API and framework package
- align the migrations and observability test toolchains with the same compatible range
- deduplicate the lockfile to one Kysely `0.28.17` installation
- add the required patch changeset for the published framework package

This is the conflict-free replacement for #372. It keeps the public peer ranges at `^0.28.0` so downstream compatibility is unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm changeset status --since=origin/main`
- `pnpm release:check`
- `pnpm build`
- `pnpm test` (all 17 workspace projects; API: 118 tests)
- GitHub `Release and workspace checks` CI

Related release-validation hardening for pnpm 11 is isolated in #375 and is not required by this PR.
