### PR TITLE
fix(release): support pnpm 11 smoke overrides

### DIFF
--- a/scripts/smoke-core-install.mjs
+++ b/scripts/smoke-core-install.mjs
@@ -49,12 +49,10 @@ try {
             '@types/node': '^20.0.0',
             typescript: '^5.1.3',
         }),
-        pnpm: {
-            overrides: sortObject(packageDependencies),
-        },
     };
 
     writeJson(path.join(consumerDir, 'package.json'), packageJson);
+    writeFileSync(path.join(consumerDir, 'pnpm-workspace.yaml'), pnpmWorkspaceSource(packageDependencies));
     writeJson(path.join(consumerDir, 'tsconfig.json'), {
         compilerOptions: {
             module: 'Node16',
@@ -112,6 +110,16 @@ function writeJson(filePath, value) {
 
 function sortObject(value) {
     return Object.fromEntries(Object.entries(value).sort(([left], [right]) => left.localeCompare(right)));
+}
+
+function pnpmWorkspaceSource(overrides) {
+    const lines = ['packages:', "  - '.'", 'overrides:'];
+
+    for (const [packageName, packagePath] of Object.entries(sortObject(overrides))) {
+        lines.push(`  ${JSON.stringify(packageName)}: ${JSON.stringify(packagePath)}`);
+    }
+
+    return `${lines.join('\n')}\n`;
 }
 
 function smokeTypescriptSource() {


### PR DESCRIPTION
## Summary

- move generated smoke-consumer overrides out of `package.json#pnpm.overrides`
- write them to `pnpm-workspace.yaml`, which pnpm 10 and 11 both recognize
- keep every internal dependency pinned to its local packed tarball during consumer validation

pnpm 11 no longer reads `pnpm.overrides` from `package.json`. In local release validation, the nested smoke install can select pnpm 11 even when the repository command starts under pnpm 10; it then tries to download unpublished internal packages such as `@a3s-lab/http` from the public registry and fails with 404. The workspace-level configuration makes that nested install deterministic.

CI is currently pinned to pnpm 10, so this is not a blocker for #374. This is a release-validation-only fix and does not change any published package, so no Changeset is required.

## Validation

- reproduced the pre-fix `@a3s-lab/http` registry 404 under the nested pnpm 11 install
- `pnpm changeset status --since=origin/main`
- `pnpm release:check`
- `pnpm smoke:core-install`
  - installed all 16 packed framework packages
  - passed TypeScript import checking
  - passed Node import/runtime smoke checks
