### PR TITLE
fix: harden RustFS signing and lifecycle

### DIFF
--- a/.changeset/calm-rustfs-clients.md
+++ b/.changeset/calm-rustfs-clients.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/rustfs": minor
+---
+
+Generate method-correct S3-compatible presigned URLs and real policy-backed POST forms, validate signing and endpoint options, map transport timeouts correctly, report uploaded byte sizes, and gracefully drain and destroy the client during Nest shutdown.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/resilience` | Retry, circuit breaker, cache, rate limiting, distributed lock decorators, services, guards, and interceptors. |
 | `@a3s-lab/bullmq` | NestJS BullMQ module, queue service helpers, worker lifecycle, queue metrics, and cleanup helpers. |
 | `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
-| `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
+| `@a3s-lab/rustfs` | NestJS S3-compatible object storage with method-correct signed URLs, policy-backed POST forms, multipart uploads, health checks, and graceful client shutdown. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run NestJS module integration, and concurrent-safe non-transactional migration support. |

--- a/packages/rustfs/README.md
+++ b/packages/rustfs/README.md
@@ -5,7 +5,7 @@ NestJS module and service helpers for S3-compatible object storage.
 ## Install
 
 ```bash
-pnpm add @a3s-lab/rustfs @nestjs/common @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
+pnpm add @a3s-lab/rustfs @nestjs/common
 ```
 
 ## Use
@@ -21,6 +21,9 @@ import { RustFSModule } from '@a3s-lab/rustfs';
             secretAccessKey: 'secret-key',
             bucket: 'objects',
             forcePathStyle: true,
+            connectionTimeout: 3_000,
+            requestTimeout: 30_000,
+            maxAttempts: 3,
         }),
     ],
 })
@@ -56,8 +59,39 @@ export class ObjectStorage {
             expiresIn: 900,
         });
     }
+
+    async createUploadUrl(key: string, contentType: string) {
+        return this.storage.getPresignedUrl('objects', {
+            key,
+            method: 'PUT',
+            contentType,
+            expiresIn: 900,
+        });
+    }
+
+    async createBrowserUploadForm(key: string, contentType: string) {
+        return this.storage.getPresignedPostUrl('objects', {
+            key,
+            expiresIn: 900,
+            conditions: {
+                contentType,
+                contentLengthRange: { min: 1, max: 10 * 1024 * 1024 },
+                acl: 'private',
+            },
+        });
+    }
 }
 ```
+
+`getPresignedUrl` creates command-specific signatures for `GET`, `PUT`, and `DELETE`. For a browser multipart/form-data upload, use `getPresignedPostUrl`; it returns the URL and every form field that the client must submit. Signed URLs expire after one hour by default and accept values from 1 second through 7 days.
+
+For GET response overrides, `queryParams` supports `versionId`, `response-cache-control`, `response-content-disposition`, `response-content-encoding`, `response-content-language`, `response-content-type`, and `response-expires`. Unsupported parameters fail before signing so callers cannot accidentally receive a URL that omits requested constraints.
+
+## Connection lifecycle
+
+The endpoint must be an absolute `http://` or `https://` URL. Its protocol controls TLS; the legacy `sslEnabled` option is deprecated and, when supplied, must agree with the URL. The legacy `timeout` option still sets both connection and request timeouts, while new code should configure them separately.
+
+The module owns its S3-compatible client. During Nest shutdown it stops accepting new operations, waits for active requests to settle, and then destroys the client and its sockets.
 
 ## Exports
 
@@ -68,4 +102,4 @@ export class ObjectStorage {
 
 ## Notes
 
-The package owns generic S3-compatible client creation, bucket operations, object operations, presigned URLs, multipart upload helpers, error mapping, and health checks. Applications still own bucket names, object key conventions, metadata contracts, retention policy, and access policy.
+The package owns generic S3-compatible client creation, bucket operations, object operations, presigned URLs and POST policies, multipart upload helpers, error mapping, and health checks. Applications still own bucket names, object key conventions, metadata contracts, retention policy, and access policy.

--- a/packages/rustfs/package.json
+++ b/packages/rustfs/package.json
@@ -49,8 +49,9 @@
         "prepublishOnly": "pnpm run build"
     },
     "dependencies": {
-        "@aws-sdk/client-s3": "^3.600.0",
-        "@aws-sdk/s3-request-presigner": "^3.600.0"
+        "@aws-sdk/client-s3": "^3.1091.0",
+        "@aws-sdk/s3-presigned-post": "^3.1091.0",
+        "@aws-sdk/s3-request-presigner": "^3.1091.0"
     },
     "devDependencies": {
         "@nestjs/common": "^11.1.28",

--- a/packages/rustfs/src/__tests__/index.spec.ts
+++ b/packages/rustfs/src/__tests__/index.spec.ts
@@ -1,11 +1,13 @@
-import { MODULE_OPTIONS_TOKEN } from '../rustfs.module-definition';
-import { RustFSModule } from '../rustfs.module';
-import { ObjectNotFoundError } from '../rustfs.types';
 import { RustFSService, RustFSServiceImpl } from '../index';
+import { RustFSModule } from '../rustfs.module';
+import { MODULE_OPTIONS_TOKEN } from '../rustfs.module-definition';
+import { ObjectNotFoundError } from '../rustfs.types';
 
 const mockSend = jest.fn();
 const mockS3Client = jest.fn();
+const mockDestroy = jest.fn();
 const mockGetSignedUrl = jest.fn();
+const mockCreatePresignedPost = jest.fn();
 
 jest.mock('@aws-sdk/client-s3', () => {
     const createCommand = (commandName: string) =>
@@ -20,6 +22,7 @@ jest.mock('@aws-sdk/client-s3', () => {
             return {
                 config,
                 send: mockSend,
+                destroy: mockDestroy,
             };
         }),
         CreateBucketCommand: createCommand('CreateBucketCommand'),
@@ -47,6 +50,10 @@ jest.mock('@aws-sdk/s3-request-presigner', () => ({
     getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
 }));
 
+jest.mock('@aws-sdk/s3-presigned-post', () => ({
+    createPresignedPost: (...args: unknown[]) => mockCreatePresignedPost(...args),
+}));
+
 async function* chunks(...values: string[]) {
     for (const value of values) {
         yield Buffer.from(value);
@@ -61,6 +68,10 @@ describe('rustfs package', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         mockGetSignedUrl.mockResolvedValue('https://storage.example/presigned');
+        mockCreatePresignedPost.mockResolvedValue({
+            url: 'https://storage.example/upload',
+            fields: { key: 'resources/file.txt', policy: 'signed-policy' },
+        });
         mockSend.mockImplementation(async command => {
             switch (command.commandName) {
                 case 'ListBucketsCommand':
@@ -171,11 +182,16 @@ describe('rustfs package', () => {
                     secretAccessKey: 'secret-key',
                 },
                 forcePathStyle: true,
-                requestTimeout: 3000,
+                requestHandler: {
+                    connectionTimeout: 3000,
+                    requestTimeout: 3000,
+                    throwOnRequestTimeout: true,
+                },
                 maxAttempts: 2,
             }),
         );
         expect(mockS3Client.mock.calls[0][0]).not.toHaveProperty('tls');
+        expect(mockS3Client.mock.calls[0][0]).not.toHaveProperty('requestTimeout');
         expect(findCommand('CreateBucketCommand').input).toEqual({
             Bucket: 'objects',
             ACL: 'private',
@@ -215,6 +231,7 @@ describe('rustfs package', () => {
             key: 'resources/file.txt',
             bucket: 'objects',
             etag: '"etag-1"',
+            size: 11,
             versionId: 'version-1',
         });
         expect(body.toString('utf8')).toBe('hello world');
@@ -252,18 +269,133 @@ describe('rustfs package', () => {
         });
     });
 
-    it('creates presigned URLs and handles multipart uploads', async () => {
+    it('creates method-specific presigned URLs', async () => {
         const service = new RustFSServiceImpl({
             endpoint: 'http://storage:9000',
             accessKeyId: 'access-key',
             secretAccessKey: 'secret-key',
         });
 
-        const url = await service.getPresignedUrl('objects', {
+        const getUrl = await service.getPresignedUrl('objects', {
             key: 'resources/file.txt',
             expiresIn: 900,
+            queryParams: {
+                versionId: 'version-1',
+                'response-content-disposition': 'attachment; filename="file.txt"',
+            },
+        });
+        const putUrl = await service.getPresignedUrl('objects', {
+            key: 'resources/file.txt',
+            method: 'PUT',
             contentType: 'text/plain',
         });
+        const deleteUrl = await service.getPresignedUrl('objects', {
+            key: 'resources/file.txt',
+            method: 'DELETE',
+            queryParams: { versionId: 'version-1' },
+        });
+
+        expect([getUrl, putUrl, deleteUrl]).toEqual([
+            'https://storage.example/presigned',
+            'https://storage.example/presigned',
+            'https://storage.example/presigned',
+        ]);
+        expect(mockGetSignedUrl.mock.calls.map(([, command]) => command)).toEqual([
+            expect.objectContaining({
+                commandName: 'GetObjectCommand',
+                input: {
+                    Bucket: 'objects',
+                    Key: 'resources/file.txt',
+                    VersionId: 'version-1',
+                    ResponseContentDisposition: 'attachment; filename="file.txt"',
+                },
+            }),
+            expect.objectContaining({
+                commandName: 'PutObjectCommand',
+                input: {
+                    Bucket: 'objects',
+                    Key: 'resources/file.txt',
+                    ContentType: 'text/plain',
+                },
+            }),
+            expect.objectContaining({
+                commandName: 'DeleteObjectCommand',
+                input: {
+                    Bucket: 'objects',
+                    Key: 'resources/file.txt',
+                    VersionId: 'version-1',
+                },
+            }),
+        ]);
+        expect(mockGetSignedUrl.mock.calls.map(([, , options]) => options)).toEqual([
+            { expiresIn: 900 },
+            { expiresIn: 3600 },
+            { expiresIn: 3600 },
+        ]);
+
+        await expect(
+            service.getPresignedUrl('objects', {
+                key: 'resources/file.txt',
+                contentType: 'text/plain',
+            }),
+        ).rejects.toMatchObject({ code: 'INVALID_PRESIGNED_URL_OPTIONS', statusCode: 400 });
+        await expect(
+            service.getPresignedUrl('objects', {
+                key: 'resources/file.txt',
+                expiresIn: 0,
+            }),
+        ).rejects.toMatchObject({ code: 'INVALID_PRESIGNED_URL_OPTIONS', statusCode: 400 });
+        await expect(
+            service.getPresignedUrl('objects', {
+                key: 'resources/file.txt',
+                queryParams: { unsupported: 'value' },
+            }),
+        ).rejects.toMatchObject({ code: 'INVALID_PRESIGNED_URL_OPTIONS', statusCode: 400 });
+    });
+
+    it('creates policy-backed presigned POST forms', async () => {
+        const service = new RustFSServiceImpl({
+            endpoint: 'http://storage:9000',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+        });
+
+        const result = await service.getPresignedPostUrl('objects', {
+            key: 'resources/file.txt',
+            expiresIn: 600,
+            conditions: {
+                contentLengthRange: { min: 1, max: 10_000 },
+                contentType: 'text/plain',
+                acl: 'private',
+            },
+        });
+
+        expect(result).toEqual({
+            url: 'https://storage.example/upload',
+            fields: { key: 'resources/file.txt', policy: 'signed-policy' },
+        });
+        expect(mockCreatePresignedPost).toHaveBeenCalledWith(expect.objectContaining({ send: mockSend }), {
+            Bucket: 'objects',
+            Key: 'resources/file.txt',
+            Expires: 600,
+            Fields: { 'Content-Type': 'text/plain', acl: 'private' },
+            Conditions: [['content-length-range', 1, 10_000], { 'Content-Type': 'text/plain' }, { acl: 'private' }],
+        });
+        await expect(
+            service.getPresignedPostUrl('objects', {
+                key: 'resources/file.txt',
+                conditions: { contentLengthRange: { min: 10, max: 1 } },
+            }),
+        ).rejects.toMatchObject({ code: 'INVALID_PRESIGNED_URL_OPTIONS', statusCode: 400 });
+    });
+
+    it('handles multipart uploads', async () => {
+        const service = new RustFSServiceImpl({
+            endpoint: 'http://storage:9000',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+        });
+
         const uploadId = await service.createMultipartUpload('objects', {
             key: 'resources/file.txt',
             contentType: 'text/plain',
@@ -288,19 +420,6 @@ describe('rustfs package', () => {
             partNumberMarker: 1,
         });
 
-        expect(url).toBe('https://storage.example/presigned');
-        expect(mockGetSignedUrl).toHaveBeenCalledWith(
-            expect.objectContaining({ send: mockSend }),
-            expect.objectContaining({
-                commandName: 'GetObjectCommand',
-                input: expect.objectContaining({
-                    Bucket: 'objects',
-                    Key: 'resources/file.txt',
-                    ContentType: 'text/plain',
-                }),
-            }),
-            { expiresIn: 900 },
-        );
         expect(findCommand('CreateMultipartUploadCommand').input).toMatchObject({
             Bucket: 'objects',
             Key: 'resources/file.txt',
@@ -321,5 +440,58 @@ describe('rustfs package', () => {
             nextPartNumberMarker: 2,
             maxParts: 100,
         });
+    });
+
+    it('waits for active response streams before closing and rejects new work', async () => {
+        let markStreamStarted: (() => void) | undefined;
+        let releaseStream: (() => void) | undefined;
+        const streamStarted = new Promise<void>(resolve => {
+            markStreamStarted = resolve;
+        });
+        const streamReleased = new Promise<void>(resolve => {
+            releaseStream = resolve;
+        });
+        async function* delayedBody() {
+            markStreamStarted?.();
+            await streamReleased;
+            yield Buffer.from('complete');
+        }
+        mockSend.mockResolvedValueOnce({ Body: delayedBody() });
+        const service = new RustFSServiceImpl({
+            endpoint: 'http://storage:9000',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+        });
+
+        const request = service.getObject('objects', { key: 'resources/file.txt' });
+        await streamStarted;
+        const shutdown = service.onModuleDestroy();
+
+        expect(mockDestroy).not.toHaveBeenCalled();
+        releaseStream?.();
+        await expect(request).resolves.toEqual(Buffer.from('complete'));
+        await shutdown;
+        await service.onModuleDestroy();
+
+        expect(mockDestroy).toHaveBeenCalledTimes(1);
+        await expect(service.listBuckets()).rejects.toMatchObject({ code: 'CLIENT_CLOSED', statusCode: 503 });
+    });
+
+    it('rejects contradictory endpoint and timeout configuration', () => {
+        const baseOptions = {
+            endpoint: 'http://storage:9000',
+            accessKeyId: 'access-key',
+            secretAccessKey: 'secret-key',
+        };
+
+        expect(() => new RustFSServiceImpl({ ...baseOptions, sslEnabled: true })).toThrow(
+            'sslEnabled must match the endpoint URL protocol',
+        );
+        expect(() => new RustFSServiceImpl({ ...baseOptions, requestTimeout: 0 })).toThrow(
+            'requestTimeout must be a positive integer',
+        );
+        expect(() => new RustFSServiceImpl({ ...baseOptions, endpoint: 'storage:9000' })).toThrow(
+            'endpoint must use the HTTP or HTTPS protocol',
+        );
     });
 });

--- a/packages/rustfs/src/rustfs.service.ts
+++ b/packages/rustfs/src/rustfs.service.ts
@@ -1,57 +1,141 @@
-import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import {
-    S3Client,
-    CreateBucketCommand,
-    ListBucketsCommand,
-    DeleteBucketCommand,
-    HeadBucketCommand,
-    GetObjectCommand,
-    PutObjectCommand,
-    CopyObjectCommand,
-    DeleteObjectCommand,
-    DeleteObjectsCommand,
-    ListObjectsV2Command,
-    HeadObjectCommand,
-    GetBucketAclCommand,
-    PutBucketAclCommand,
-    CreateMultipartUploadCommand,
-    UploadPartCommand,
-    CompleteMultipartUploadCommand,
     AbortMultipartUploadCommand,
-    ListPartsCommand,
     type AccessControlPolicy,
     type BucketCannedACL as AwsBucketCannedACL,
+    type Type as AwsGranteeType,
     type ObjectCannedACL as AwsObjectCannedACL,
     type Permission as AwsPermission,
-    type S3ClientConfig,
     type StorageClass as AwsStorageClass,
-    type Type as AwsGranteeType,
+    CompleteMultipartUploadCommand,
+    CopyObjectCommand,
+    CreateBucketCommand,
+    CreateMultipartUploadCommand,
+    DeleteBucketCommand,
+    DeleteObjectCommand,
+    DeleteObjectsCommand,
+    GetBucketAclCommand,
+    GetObjectCommand,
+    type GetObjectCommandInput,
+    HeadBucketCommand,
+    HeadObjectCommand,
+    ListBucketsCommand,
+    ListObjectsV2Command,
+    ListPartsCommand,
+    PutBucketAclCommand,
+    PutObjectCommand,
+    S3Client,
+    type S3ClientConfig,
+    UploadPartCommand,
 } from '@aws-sdk/client-s3';
+import { type PresignedPostOptions as AwsPresignedPostOptions, createPresignedPost } from '@aws-sdk/s3-presigned-post';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import { MODULE_OPTIONS_TOKEN } from './rustfs.module-definition';
 import type {
-    RustFSPackageOptions,
     Bucket,
-    CreateBucketOptions,
-    BucketCannedAcl,
     BucketAcl,
-    StorageObject,
-    PutObjectOptions,
-    ObjectCannedAcl,
-    GetObjectOptions,
+    BucketCannedAcl,
+    CompleteMultipartUploadOptions,
     CopyObjectOptions,
+    CreateBucketOptions,
+    CreateMultipartUploadOptions,
+    GetObjectOptions,
     ListObjectsOptions,
     ListObjectsResult,
-    PresignedUrlOptions,
-    PresignedPostOptions,
-    CreateMultipartUploadOptions,
-    UploadPartOptions,
-    CompleteMultipartUploadOptions,
     ListPartsOptions,
     ListPartsResult,
+    ObjectCannedAcl,
+    PresignedPostOptions,
+    PresignedUrlOptions,
+    PutObjectOptions,
+    RustFSPackageOptions,
     StorageClass,
+    StorageObject,
+    UploadPartOptions,
 } from './rustfs.types';
-import { RustFSError, ObjectNotFoundError, BucketAlreadyExistsError } from './rustfs.types';
+import { BucketAlreadyExistsError, ObjectNotFoundError, RustFSError } from './rustfs.types';
+
+const DEFAULT_PRESIGNED_URL_EXPIRATION_SECONDS = 3600;
+const MAX_PRESIGNED_URL_EXPIRATION_SECONDS = 7 * 24 * 60 * 60;
+
+function invalidConfiguration(message: string): RustFSError {
+    return new RustFSError(message, 'INVALID_CONFIGURATION', 500);
+}
+
+function invalidPresignedOptions(message: string): RustFSError {
+    return new RustFSError(message, 'INVALID_PRESIGNED_URL_OPTIONS', 400);
+}
+
+function assertPositiveInteger(name: string, value?: number): void {
+    if (value !== undefined && (!Number.isInteger(value) || value <= 0)) {
+        throw invalidConfiguration(`${name} must be a positive integer`);
+    }
+}
+
+function resolvePresignedExpiration(expiresIn?: number): number {
+    const expiration = expiresIn ?? DEFAULT_PRESIGNED_URL_EXPIRATION_SECONDS;
+
+    if (!Number.isInteger(expiration) || expiration <= 0 || expiration > MAX_PRESIGNED_URL_EXPIRATION_SECONDS) {
+        throw invalidPresignedOptions(
+            `expiresIn must be an integer between 1 and ${MAX_PRESIGNED_URL_EXPIRATION_SECONDS} seconds`,
+        );
+    }
+
+    return expiration;
+}
+
+function getBodySize(body?: Buffer | Uint8Array | string): number {
+    if (body === undefined) {
+        return 0;
+    }
+
+    return typeof body === 'string' ? Buffer.byteLength(body) : body.byteLength;
+}
+
+function applyGetObjectQueryParams(input: GetObjectCommandInput, queryParams?: Record<string, string>): void {
+    for (const [name, value] of Object.entries(queryParams ?? {})) {
+        switch (name) {
+            case 'versionId':
+                input.VersionId = value;
+                break;
+            case 'response-cache-control':
+                input.ResponseCacheControl = value;
+                break;
+            case 'response-content-disposition':
+                input.ResponseContentDisposition = value;
+                break;
+            case 'response-content-encoding':
+                input.ResponseContentEncoding = value;
+                break;
+            case 'response-content-language':
+                input.ResponseContentLanguage = value;
+                break;
+            case 'response-content-type':
+                input.ResponseContentType = value;
+                break;
+            case 'response-expires': {
+                const expires = new Date(value);
+                if (Number.isNaN(expires.getTime())) {
+                    throw invalidPresignedOptions('response-expires must be a valid date');
+                }
+                input.ResponseExpires = expires;
+                break;
+            }
+            default:
+                throw invalidPresignedOptions(`Unsupported signed query parameter: ${name}`);
+        }
+    }
+}
+
+function getDeleteObjectVersionId(queryParams?: Record<string, string>): string | undefined {
+    const entries = Object.entries(queryParams ?? {});
+    const unsupported = entries.find(([name]) => name !== 'versionId');
+    if (unsupported) {
+        throw invalidPresignedOptions(`Unsupported DELETE query parameter: ${unsupported[0]}`);
+    }
+
+    return queryParams?.versionId;
+}
 
 function toBucketAcl(acl?: BucketCannedAcl): AwsBucketCannedACL | undefined {
     return acl as AwsBucketCannedACL | undefined;
@@ -136,9 +220,12 @@ function toPartNumberMarker(marker?: string): number | undefined {
 }
 
 @Injectable()
-export class RustFSServiceImpl implements OnModuleInit {
-    private client: S3Client;
-    private defaultBucket: string;
+export class RustFSServiceImpl implements OnModuleInit, OnModuleDestroy {
+    private readonly client: S3Client;
+    private readonly defaultBucket: string;
+    private readonly inFlightRequests = new Set<Promise<unknown>>();
+    private shuttingDown = false;
+    private shutdownPromise?: Promise<void>;
     private readonly logger = new Logger(RustFSServiceImpl.name);
 
     constructor(@Inject(MODULE_OPTIONS_TOKEN) private readonly options: RustFSPackageOptions) {
@@ -156,8 +243,55 @@ export class RustFSServiceImpl implements OnModuleInit {
         this.logger.log(`RustFS client initialized for endpoint: ${this.options.endpoint}`);
     }
 
+    async onModuleDestroy(): Promise<void> {
+        if (!this.shutdownPromise) {
+            this.shuttingDown = true;
+            this.shutdownPromise = this.destroyClient();
+        }
+
+        await this.shutdownPromise;
+    }
+
+    private async destroyClient(): Promise<void> {
+        await Promise.allSettled([...this.inFlightRequests]);
+        this.client.destroy();
+    }
+
+    private run<T>(operation: () => Promise<T>): Promise<T> {
+        if (this.shuttingDown) {
+            return Promise.reject(new RustFSError('RustFS client is shutting down', 'CLIENT_CLOSED', 503));
+        }
+
+        const request = Promise.resolve().then(operation);
+        this.inFlightRequests.add(request);
+
+        return request.finally(() => {
+            this.inFlightRequests.delete(request);
+        });
+    }
+
     private createClient(): S3Client {
-        const config: Record<string, unknown> = {
+        let endpoint: URL;
+        try {
+            endpoint = new URL(this.options.endpoint);
+        } catch {
+            throw invalidConfiguration('endpoint must be an absolute HTTP or HTTPS URL');
+        }
+
+        if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
+            throw invalidConfiguration('endpoint must use the HTTP or HTTPS protocol');
+        }
+
+        if (this.options.sslEnabled !== undefined && this.options.sslEnabled !== (endpoint.protocol === 'https:')) {
+            throw invalidConfiguration('sslEnabled must match the endpoint URL protocol');
+        }
+
+        assertPositiveInteger('timeout', this.options.timeout);
+        assertPositiveInteger('connectionTimeout', this.options.connectionTimeout);
+        assertPositiveInteger('requestTimeout', this.options.requestTimeout);
+        assertPositiveInteger('maxAttempts', this.options.maxAttempts);
+
+        const config: S3ClientConfig = {
             endpoint: this.options.endpoint,
             region: this.options.region || 'us-east-1',
             credentials: {
@@ -167,19 +301,21 @@ export class RustFSServiceImpl implements OnModuleInit {
             forcePathStyle: this.options.forcePathStyle ?? true,
         };
 
-        if (this.options.sslEnabled !== false) {
-            config.tls = true;
+        const connectionTimeout = this.options.connectionTimeout ?? this.options.timeout;
+        const requestTimeout = this.options.requestTimeout ?? this.options.timeout;
+        if (connectionTimeout !== undefined || requestTimeout !== undefined) {
+            config.requestHandler = {
+                connectionTimeout,
+                requestTimeout,
+                throwOnRequestTimeout: true,
+            };
         }
 
-        if (this.options.timeout) {
-            config.requestTimeout = this.options.timeout;
-        }
-
-        if (this.options.maxAttempts) {
+        if (this.options.maxAttempts !== undefined) {
             config.maxAttempts = this.options.maxAttempts;
         }
 
-        return new S3Client(config as S3ClientConfig);
+        return new S3Client(config);
     }
 
     // =========================================================================
@@ -193,7 +329,7 @@ export class RustFSServiceImpl implements OnModuleInit {
                 ACL: toBucketAcl(options.acl),
             });
 
-            await this.client.send(command);
+            await this.run(() => this.client.send(command));
 
             this.logger.log(`Bucket created: ${options.name}`);
 
@@ -202,6 +338,10 @@ export class RustFSServiceImpl implements OnModuleInit {
                 creationDate: new Date(),
             };
         } catch (error) {
+            if (error instanceof RustFSError) {
+                throw error;
+            }
+
             const err = error as { name?: string; message?: string };
             if (err.name === 'BucketAlreadyOwnedByYou' || err.name === 'BucketAlreadyExists') {
                 throw new BucketAlreadyExistsError(options.name);
@@ -212,7 +352,7 @@ export class RustFSServiceImpl implements OnModuleInit {
 
     async listBuckets(): Promise<Bucket[]> {
         const command = new ListBucketsCommand({});
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return (response.Buckets || []).map(b => ({
             name: b.Name || '',
@@ -222,7 +362,7 @@ export class RustFSServiceImpl implements OnModuleInit {
 
     async getBucketAcl(bucketName: string): Promise<BucketAcl> {
         const command = new GetBucketAclCommand({ Bucket: bucketName });
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return {
             owner: response.Owner?.ID || '',
@@ -244,21 +384,24 @@ export class RustFSServiceImpl implements OnModuleInit {
             AccessControlPolicy: toAccessControlPolicy(acl),
         });
 
-        await this.client.send(command);
+        await this.run(() => this.client.send(command));
     }
 
     async deleteBucket(bucketName: string): Promise<void> {
         const command = new DeleteBucketCommand({ Bucket: bucketName });
-        await this.client.send(command);
+        await this.run(() => this.client.send(command));
         this.logger.log(`Bucket deleted: ${bucketName}`);
     }
 
     async bucketExists(bucketName: string): Promise<boolean> {
         try {
             const command = new HeadBucketCommand({ Bucket: bucketName });
-            await this.client.send(command);
+            await this.run(() => this.client.send(command));
             return true;
-        } catch {
+        } catch (error) {
+            if (error instanceof RustFSError && error.code === 'CLIENT_CLOSED') {
+                throw error;
+            }
             return false;
         }
     }
@@ -283,13 +426,13 @@ export class RustFSServiceImpl implements OnModuleInit {
             CacheControl: options.cacheControl,
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return {
             key: options.key,
             bucket: bucketName,
             etag: response.ETag || '',
-            size: response.$metadata?.httpStatusCode || 0,
+            size: getBodySize(options.body),
             lastModified: new Date(),
             contentType: options.contentType,
             metadata: options.metadata,
@@ -310,16 +453,18 @@ export class RustFSServiceImpl implements OnModuleInit {
         });
 
         try {
-            const response = await this.client.send(command);
-            const chunks: Uint8Array[] = [];
+            return await this.run(async () => {
+                const response = await this.client.send(command);
+                const chunks: Uint8Array[] = [];
 
-            if (response.Body) {
-                for await (const chunk of response.Body as AsyncIterable<Uint8Array>) {
-                    chunks.push(chunk);
+                if (response.Body) {
+                    for await (const chunk of response.Body as AsyncIterable<Uint8Array>) {
+                        chunks.push(chunk);
+                    }
                 }
-            }
 
-            return Buffer.concat(chunks);
+                return Buffer.concat(chunks);
+            });
         } catch (error) {
             const err = error as { name?: string };
             if (err.name === 'NoSuchKey' || err.name === '404') {
@@ -336,7 +481,7 @@ export class RustFSServiceImpl implements OnModuleInit {
         });
 
         try {
-            const response = await this.client.send(command);
+            const response = await this.run(() => this.client.send(command));
 
             return {
                 key,
@@ -371,7 +516,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             StorageClass: toStorageClass(options.storageClass),
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return {
             key: options.destinationKey,
@@ -390,7 +535,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             Key: key,
         });
 
-        await this.client.send(command);
+        await this.run(() => this.client.send(command));
         this.logger.debug(`Object deleted: ${key} from ${bucketName}`);
     }
 
@@ -402,7 +547,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             },
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         if (response.Errors && response.Errors.length > 0) {
             this.logger.warn(`Failed to delete some objects: ${response.Errors.length}`);
@@ -419,7 +564,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             StartAfter: options?.startAfter,
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return {
             objects: (response.Contents || []).map(obj => ({
@@ -443,38 +588,91 @@ export class RustFSServiceImpl implements OnModuleInit {
     // =========================================================================
 
     async getPresignedUrl(bucketName: string, options: PresignedUrlOptions): Promise<string> {
-        const command = new GetObjectCommand({
-            Bucket: bucketName,
-            Key: options.key,
-            ...(options.contentType && { ContentType: options.contentType }),
-        });
+        const method = options.method ?? 'GET';
+        let command: GetObjectCommand | PutObjectCommand | DeleteObjectCommand;
 
-        const url = await getSignedUrl(this.client, command, {
-            expiresIn: options.expiresIn || 3600,
-        });
+        switch (method) {
+            case 'GET': {
+                if (options.contentType) {
+                    throw invalidPresignedOptions(
+                        'contentType is only supported for PUT URLs; use response-content-type for GET URLs',
+                    );
+                }
 
-        return url;
+                const input: GetObjectCommandInput = {
+                    Bucket: bucketName,
+                    Key: options.key,
+                };
+                applyGetObjectQueryParams(input, options.queryParams);
+                command = new GetObjectCommand(input);
+                break;
+            }
+            case 'PUT':
+                if (options.queryParams && Object.keys(options.queryParams).length > 0) {
+                    throw invalidPresignedOptions('queryParams are not supported for PUT URLs');
+                }
+                command = new PutObjectCommand({
+                    Bucket: bucketName,
+                    Key: options.key,
+                    ContentType: options.contentType,
+                });
+                break;
+            case 'DELETE':
+                if (options.contentType) {
+                    throw invalidPresignedOptions('contentType is not supported for DELETE URLs');
+                }
+                command = new DeleteObjectCommand({
+                    Bucket: bucketName,
+                    Key: options.key,
+                    VersionId: getDeleteObjectVersionId(options.queryParams),
+                });
+                break;
+            default:
+                throw invalidPresignedOptions(`Unsupported HTTP method: ${String(method)}`);
+        }
+
+        return this.run(() =>
+            getSignedUrl(this.client, command, {
+                expiresIn: resolvePresignedExpiration(options.expiresIn),
+            }),
+        );
     }
 
     async getPresignedPostUrl(
         bucketName: string,
         options: PresignedPostOptions,
     ): Promise<{ url: string; fields: Record<string, string> }> {
-        // Note: Presigned POST requires additional implementation
-        // For now, return a simple presigned PUT URL as alternative
-        const url = await this.getPresignedUrl(bucketName, {
-            key: options.key,
-            expiresIn: options.expiresIn || 3600,
-            method: 'PUT',
-            contentType: options.conditions?.contentType,
-        });
+        const fields: Record<string, string> = {};
+        const conditions: NonNullable<AwsPresignedPostOptions['Conditions']> = [];
+        const contentLengthRange = options.conditions?.contentLengthRange;
 
-        return {
-            url,
-            fields: {
-                'Content-Type': options.conditions?.contentType || 'application/octet-stream',
-            },
-        };
+        if (contentLengthRange) {
+            const { min, max } = contentLengthRange;
+            if (!Number.isInteger(min) || !Number.isInteger(max) || min < 0 || max < min) {
+                throw invalidPresignedOptions('contentLengthRange must use integers where 0 <= min <= max');
+            }
+            conditions.push(['content-length-range', min, max]);
+        }
+
+        if (options.conditions?.contentType) {
+            fields['Content-Type'] = options.conditions.contentType;
+            conditions.push({ 'Content-Type': options.conditions.contentType });
+        }
+
+        if (options.conditions?.acl) {
+            fields.acl = options.conditions.acl;
+            conditions.push({ acl: options.conditions.acl });
+        }
+
+        return this.run(() =>
+            createPresignedPost(this.client, {
+                Bucket: bucketName,
+                Key: options.key,
+                Expires: resolvePresignedExpiration(options.expiresIn),
+                Fields: fields,
+                Conditions: conditions,
+            }),
+        );
     }
 
     // =========================================================================
@@ -491,7 +689,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             StorageClass: toStorageClass(options.storageClass),
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         if (!response.UploadId) {
             throw new RustFSError('Failed to create multipart upload', 'MULTIPART_UPLOAD_ERROR');
@@ -510,7 +708,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             ContentLength: options.contentLength,
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return response.ETag || '';
     }
@@ -528,7 +726,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             },
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return {
             key: options.key,
@@ -546,7 +744,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             UploadId: uploadId,
         });
 
-        await this.client.send(command);
+        await this.run(() => this.client.send(command));
     }
 
     async listParts(bucketName: string, options: ListPartsOptions): Promise<ListPartsResult> {
@@ -558,7 +756,7 @@ export class RustFSServiceImpl implements OnModuleInit {
             PartNumberMarker: options.partNumberMarker?.toString(),
         });
 
-        const response = await this.client.send(command);
+        const response = await this.run(() => this.client.send(command));
 
         return {
             key: options.key,
@@ -581,7 +779,7 @@ export class RustFSServiceImpl implements OnModuleInit {
     async isHealthy(): Promise<boolean> {
         try {
             const command = new ListBucketsCommand({});
-            await this.client.send(command);
+            await this.run(() => this.client.send(command));
             return true;
         } catch {
             return false;

--- a/packages/rustfs/src/rustfs.types.ts
+++ b/packages/rustfs/src/rustfs.types.ts
@@ -9,8 +9,12 @@ export interface RustFSPackageOptions {
     secretAccessKey: string;
     bucket?: string;
     forcePathStyle?: boolean;
+    /** @deprecated The endpoint URL protocol now controls TLS. */
     sslEnabled?: boolean;
+    /** @deprecated Use connectionTimeout and requestTimeout instead. */
     timeout?: number;
+    connectionTimeout?: number;
+    requestTimeout?: number;
     maxAttempts?: number;
 }
 
@@ -152,8 +156,13 @@ export interface ListObjectsResult {
 export interface PresignedUrlOptions {
     key: string;
     expiresIn?: number;
-    method?: 'GET' | 'PUT' | 'DELETE' | 'POST';
+    method?: 'GET' | 'PUT' | 'DELETE';
     contentType?: string;
+    /**
+     * Supported S3 query parameters are versionId and the response-* overrides
+     * accepted by GetObject. Unknown parameters are rejected instead of being
+     * silently omitted from the signature.
+     */
     queryParams?: Record<string, string>;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.4(typescript@5.9.3)(webpack@5.106.2(@swc/core@1.15.11))
@@ -179,7 +179,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -210,7 +210,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -241,7 +241,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -272,7 +272,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -290,7 +290,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -321,7 +321,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -360,7 +360,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -412,7 +412,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -461,7 +461,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -510,7 +510,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -544,7 +544,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -575,7 +575,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -627,7 +627,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -667,7 +667,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -707,7 +707,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -715,11 +715,14 @@ importers:
   packages/rustfs:
     dependencies:
       '@aws-sdk/client-s3':
-        specifier: ^3.600.0
-        version: 3.1075.0
+        specifier: ^3.1091.0
+        version: 3.1091.0
+      '@aws-sdk/s3-presigned-post':
+        specifier: ^3.1091.0
+        version: 3.1091.0
       '@aws-sdk/s3-request-presigner':
-        specifier: ^3.600.0
-        version: 3.1075.0
+        specifier: ^3.1091.0
+        version: 3.1091.0
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.28
@@ -741,7 +744,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -772,7 +775,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -827,7 +830,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -907,111 +910,84 @@ packages:
     resolution: {integrity: sha512-/PZmyAlb2NGWPikRRuiWLdfHQd8Wrx6lX4HqvTcaDhlU43M3T0ud4PH2T3QDp7BzHYY92xtD8iPxX2asg67G1A==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@aws-crypto/crc32@5.2.0':
-    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/crc32c@5.2.0':
-    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
-
-  '@aws-crypto/sha1-browser@5.2.0':
-    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
-
-  '@aws-crypto/sha256-js@5.2.0':
-    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
-    engines: {node: '>=16.0.0'}
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
-
-  '@aws-crypto/util@5.2.0':
-    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
-
-  '@aws-sdk/checksums@3.1000.8':
-    resolution: {integrity: sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==}
+  '@aws-sdk/checksums@3.1000.18':
+    resolution: {integrity: sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/client-s3@3.1075.0':
-    resolution: {integrity: sha512-h1A6nIl1YX6Y45enGsTK7ef3ZrOnBiQJ1qF5R2K/nMWfsu6A9mc2Y5T66nxerABzyjjyyvign3MrzafnFoQKmA==}
+  '@aws-sdk/client-s3@3.1091.0':
+    resolution: {integrity: sha512-jvXBCWZdPEXACF7TEbLdwLgmrcWvAqSnIJeRbnnFTxLuPRAZtEbujVUU48i7PGnrOoO6Jc6HCw9hRqBECoKSww==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.23':
-    resolution: {integrity: sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==}
+  '@aws-sdk/core@3.975.3':
+    resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.49':
-    resolution: {integrity: sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==}
+  '@aws-sdk/credential-provider-env@3.972.59':
+    resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.51':
-    resolution: {integrity: sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==}
+  '@aws-sdk/credential-provider-http@3.972.61':
+    resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.56':
-    resolution: {integrity: sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==}
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.55':
-    resolution: {integrity: sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==}
+  '@aws-sdk/credential-provider-login@3.972.66':
+    resolution: {integrity: sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.58':
-    resolution: {integrity: sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==}
+  '@aws-sdk/credential-provider-node@3.972.70':
+    resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.49':
-    resolution: {integrity: sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==}
+  '@aws-sdk/credential-provider-process@3.972.59':
+    resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.55':
-    resolution: {integrity: sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==}
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.55':
-    resolution: {integrity: sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==}
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.33':
-    resolution: {integrity: sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==}
+  '@aws-sdk/middleware-sdk-s3@3.972.64':
+    resolution: {integrity: sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-sdk-s3@3.972.54':
-    resolution: {integrity: sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==}
+  '@aws-sdk/nested-clients@3.997.33':
+    resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.997.23':
-    resolution: {integrity: sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==}
+  '@aws-sdk/s3-presigned-post@3.1091.0':
+    resolution: {integrity: sha512-ugK0CYqeCJhI5iQKtBfNC8JcCX9Xt4gHLR4x7ivdBtFgnvY96OisC88D+rONYJ5KHCO8AymnqhaB2dl6i2Ns5g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/s3-request-presigner@3.1075.0':
-    resolution: {integrity: sha512-++ftTvAGZSTuzFVHEPk8lLi7mybBD8PzJ9USWBvwnE4kSrXOyqYVJ5Ixd06xUEWS/xsrhpkI07mzCLGIxrRymA==}
+  '@aws-sdk/s3-request-presigner@3.1091.0':
+    resolution: {integrity: sha512-BdF1FNOhYyif/tAN0uvTnjo/IC/JkgKfBbQ8PwtM2uDy2Mq95aK8khS+kF8ZK64wxU3M0f0wLlAXTrGxOHtrUQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/signature-v4-multi-region@3.996.35':
-    resolution: {integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==}
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1074.0':
-    resolution: {integrity: sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==}
+  '@aws-sdk/token-providers@3.1088.0':
+    resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/types@3.973.13':
-    resolution: {integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==}
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-locate-window@3.965.8':
-    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+  '@aws-sdk/xml-builder@3.972.36':
+    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/xml-builder@3.972.31':
-    resolution: {integrity: sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.4':
-    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
@@ -1987,41 +1963,29 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
-  '@smithy/core@3.26.0':
-    resolution: {integrity: sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==}
+  '@smithy/core@3.29.6':
+    resolution: {integrity: sha512-TO3w25cdGWBeYqKNDaqH3v4O3jjMPpKwf39YlG5X5xhqWfpOWJbi5gQi1lrllukuwohdhY0TPB8jBEv6UC50Vg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/credential-provider-imds@4.4.2':
-    resolution: {integrity: sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==}
+  '@smithy/credential-provider-imds@4.4.11':
+    resolution: {integrity: sha512-6CUvZwS0tCcVCrcvh2TpwTXxmAkuY6JGNPeKODYRLjHtUUhFLGS3dNkNdRvT/ttJyqimqnhFMTS2nqp4pDZ7oQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/fetch-http-handler@5.5.2':
-    resolution: {integrity: sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==}
+  '@smithy/fetch-http-handler@5.6.8':
+    resolution: {integrity: sha512-AFuLou893FesRZeQcKMh87P9x4PF2/ksPOYLLI1ctW7WJxm55SWInFSHAhaNRBPBmbgZyUcCCDKepBX+1jZBBw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/is-array-buffer@2.2.0':
-    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/node-http-handler@4.8.2':
-    resolution: {integrity: sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==}
+  '@smithy/node-http-handler@4.9.8':
+    resolution: {integrity: sha512-ArSSIN4t1wLutcIkHzaL6N11J7xpZK7W3T0pFz9cep9zIpEr9x5+lhJRcVUgObGI3OIMbnROq7w8bwzx+Nkf8A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/signature-v4@5.5.2':
-    resolution: {integrity: sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==}
+  '@smithy/signature-v4@5.6.7':
+    resolution: {integrity: sha512-32PmEsuZV9lz7SZk3gJcm+EfIAoIVu83AJyEzgALpwmSqLvuacdAu0fvCVNMbDbegyk1S0lHUDrMWIfR47Micw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.15.0':
-    resolution: {integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==}
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
-
-  '@smithy/util-buffer-from@2.2.0':
-    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
-    engines: {node: '>=14.0.0'}
-
-  '@smithy/util-utf8@2.3.0':
-    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
-    engines: {node: '>=14.0.0'}
 
   '@swc/cli@0.7.10':
     resolution: {integrity: sha512-QQ36Q1VwGTT2YzvMeNe/j1x4DKS277DscNhWc57dIwQn//C+zAgvuSupMB/XkmYqPKQX+8hjn5/cHRJrMvWy0Q==}
@@ -4941,243 +4905,189 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@aws-crypto/crc32@5.2.0':
+  '@aws-sdk/checksums@3.1000.18':
     dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-crypto/crc32c@5.2.0':
+  '@aws-sdk/client-s3@3.1091.0':
     dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
+      '@aws-sdk/checksums': 3.1000.18
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/middleware-sdk-s3': 3.972.64
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-crypto/sha1-browser@5.2.0':
+  '@aws-sdk/core@3.975.3':
     dependencies:
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/util-locate-window': 3.965.8
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-browser@5.2.0':
-    dependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-crypto/supports-web-crypto': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/util-locate-window': 3.965.8
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-crypto/sha256-js@5.2.0':
-    dependencies:
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.13
-      tslib: 2.8.1
-
-  '@aws-crypto/supports-web-crypto@5.2.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@aws-crypto/util@5.2.0':
-    dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@smithy/util-utf8': 2.3.0
-      tslib: 2.8.1
-
-  '@aws-sdk/checksums@3.1000.8':
-    dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@aws-crypto/crc32c': 5.2.0
-      '@aws-crypto/util': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/client-s3@3.1075.0':
-    dependencies:
-      '@aws-crypto/sha1-browser': 5.2.0
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-node': 3.972.58
-      '@aws-sdk/middleware-flexible-checksums': 3.974.33
-      '@aws-sdk/middleware-sdk-s3': 3.972.54
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.8.2
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws-sdk/core@3.974.23':
-    dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@aws-sdk/xml-builder': 3.972.31
-      '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/core': 3.26.0
-      '@smithy/signature-v4': 5.5.2
-      '@smithy/types': 4.15.0
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.36
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.6
+      '@smithy/signature-v4': 5.6.7
+      '@smithy/types': 4.16.1
       bowser: 2.14.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.49':
+  '@aws-sdk/credential-provider-env@3.972.59':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.51':
+  '@aws-sdk/credential-provider-http@3.972.61':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.8.2
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.972.56':
+  '@aws-sdk/credential-provider-ini@3.973.4':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/credential-provider-env': 3.972.49
-      '@aws-sdk/credential-provider-http': 3.972.51
-      '@aws-sdk/credential-provider-login': 3.972.55
-      '@aws-sdk/credential-provider-process': 3.972.49
-      '@aws-sdk/credential-provider-sso': 3.972.55
-      '@aws-sdk/credential-provider-web-identity': 3.972.55
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/credential-provider-imds': 4.4.2
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/credential-provider-imds': 4.4.11
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-login@3.972.55':
+  '@aws-sdk/credential-provider-login@3.972.66':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-node@3.972.58':
+  '@aws-sdk/credential-provider-node@3.972.70':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.49
-      '@aws-sdk/credential-provider-http': 3.972.51
-      '@aws-sdk/credential-provider-ini': 3.972.56
-      '@aws-sdk/credential-provider-process': 3.972.49
-      '@aws-sdk/credential-provider-sso': 3.972.55
-      '@aws-sdk/credential-provider-web-identity': 3.972.55
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/credential-provider-imds': 4.4.2
-      '@smithy/types': 4.15.0
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.4
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/credential-provider-imds': 4.4.11
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.49':
+  '@aws-sdk/credential-provider-process@3.972.59':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.972.55':
+  '@aws-sdk/credential-provider-sso@3.973.3':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/token-providers': 3.1074.0
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/token-providers': 3.1088.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-web-identity@3.972.55':
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-flexible-checksums@3.974.33':
+  '@aws-sdk/middleware-sdk-s3@3.972.64':
     dependencies:
-      '@aws-sdk/checksums': 3.1000.8
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-sdk-s3@3.972.54':
+  '@aws-sdk/nested-clients@3.997.33':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/fetch-http-handler': 5.6.8
+      '@smithy/node-http-handler': 4.9.8
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.997.23':
+  '@aws-sdk/s3-presigned-post@3.1091.0':
     dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/fetch-http-handler': 5.5.2
-      '@smithy/node-http-handler': 4.8.2
-      '@smithy/types': 4.15.0
+      '@aws-sdk/client-s3': 3.1091.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/signature-v4': 5.6.7
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/s3-request-presigner@3.1075.0':
+  '@aws-sdk/s3-request-presigner@3.1091.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/signature-v4-multi-region': 3.996.35
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/signature-v4-multi-region@3.996.35':
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
     dependencies:
-      '@aws-sdk/types': 3.973.13
-      '@smithy/signature-v4': 5.5.2
-      '@smithy/types': 4.15.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.7
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/token-providers@3.1074.0':
+  '@aws-sdk/token-providers@3.1088.0':
     dependencies:
-      '@aws-sdk/core': 3.974.23
-      '@aws-sdk/nested-clients': 3.997.23
-      '@aws-sdk/types': 3.973.13
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/types@3.973.13':
+  '@aws-sdk/types@3.974.2':
     dependencies:
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-locate-window@3.965.8':
+  '@aws-sdk/xml-builder@3.972.36':
     dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.31':
-    dependencies:
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.4': {}
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -6262,52 +6172,37 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@smithy/core@3.26.0':
+  '@smithy/core@3.29.6':
     dependencies:
-      '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.15.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.4.2':
+  '@smithy/credential-provider-imds@4.4.11':
     dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.5.2':
+  '@smithy/fetch-http-handler@5.6.8':
     dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/is-array-buffer@2.2.0':
+  '@smithy/node-http-handler@4.9.8':
     dependencies:
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.8.2':
+  '@smithy/signature-v4@5.6.7':
     dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
+      '@smithy/core': 3.29.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
-  '@smithy/signature-v4@5.5.2':
+  '@smithy/types@4.16.1':
     dependencies:
-      '@smithy/core': 3.26.0
-      '@smithy/types': 4.15.0
-      tslib: 2.8.1
-
-  '@smithy/types@4.15.0':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/util-buffer-from@2.2.0':
-    dependencies:
-      '@smithy/is-array-buffer': 2.2.0
-      tslib: 2.8.1
-
-  '@smithy/util-utf8@2.3.0':
-    dependencies:
-      '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
   '@swc/cli@0.7.10(@swc/core@1.15.11)(chokidar@4.0.3)':
@@ -9140,7 +9035,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
## What changed

- generate presigned URLs with the matching S3 GET, PUT, or DELETE command
- replace the fake POST fallback with a policy-backed presigned POST form
- validate expiration, signed query parameters, endpoint protocols, and timeout options
- map connection/request timeouts through the AWS SDK request handler
- report uploaded byte sizes instead of HTTP status codes
- drain active requests and response streams before destroying the client during Nest shutdown
- document the signing and lifecycle contracts and add a minor changeset

## Why

The previous implementation always signed a GetObject command, returned a PUT URL from the POST API, passed unsupported client configuration fields, and never closed the owned S3 client. This made method semantics misleading and could leak sockets or interrupt active streams during shutdown.

## Validation

- `pnpm release:check`
- `pnpm smoke:core-install`
- `pnpm audit:prod`
- RustFS package: 9 tests passed
