### PR TITLE
feat: make file uploads failure-safe

### DIFF
--- a/.changeset/safe-files-compensate.md
+++ b/.changeset/safe-files-compensate.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/files": minor
+---
+
+Make upload workflows failure-safe with prevalidation, bounded concurrency, duplicate and unsafe key rejection, compensating cleanup, downstream handler rollback, functional route metadata and parameter decorators, async module registration, and structured batch and cleanup errors.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run NestJS module integration, and concurrent-safe non-transactional migration support. |
-| `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
+| `@a3s-lab/files` | Safe object-key validation, bounded and compensating batch uploads, route policies, request parameter decorators, and NestJS upload interceptors. |
 | `@a3s-lab/ai` | NestJS integration for the A3S coding-agent runtime through `@a3s-lab/code`, with injectable configuration and lifecycle-safe agent access. |
 | `@a3s-lab/sandbox` | NestJS integration for A3S Box sandbox and code-interpreter workflows through the lazily loaded first-party `@a3s-lab/box` TypeScript SDK. |
 

--- a/packages/files/README.md
+++ b/packages/files/README.md
@@ -1,47 +1,123 @@
 # @a3s-lab/files
 
-Generic file upload validation, storage contracts, and NestJS interceptors for backend APIs.
+Storage-neutral file validation and failure-safe NestJS upload workflows.
 
 ## Install
 
 ```bash
-pnpm add @a3s-lab/files
-pnpm add @nestjs/common @nestjs/core express rxjs
+pnpm add @a3s-lab/files @nestjs/common @nestjs/core express rxjs
 ```
 
 ## Use
 
+### Module configuration
+
+Provide an adapter that implements `FileStorageClient`, then register the module:
+
 ```ts
-import { FILE_STORAGE_CLIENT, FileUploadModule, FileUploadService } from '@a3s-lab/files';
+import { Module } from '@nestjs/common';
+import { FileUploadModule, type FileStorageClient } from '@a3s-lab/files';
 
-FileUploadModule.register({
-    keyPrefix: 'uploads',
-    signedUrlExpiresInSeconds: 900,
+const storage: FileStorageClient = {
+    upload: (key, body, options) => objectStore.put(key, body, options),
+    getSignedUrl: (key, expiresIn) => objectStore.signGet(key, expiresIn),
+    delete: key => objectStore.delete(key),
+    exists: key => objectStore.exists(key),
+};
+
+@Module({
+    imports: [
+        FileUploadModule.register({
+            storageClient: storage,
+            keyPrefix: 'uploads',
+            signedUrlExpiresInSeconds: 900,
+            maxFiles: 10,
+            maxConcurrentUploads: 4,
+            validation: {
+                maxSize: 10 * 1024 * 1024,
+                allowedTypes: ['image/png', 'image/jpeg', 'application/pdf'],
+            },
+        }),
+    ],
+})
+export class AppModule {}
+```
+
+`registerAsync` supports clients and policies created from injected configuration:
+
+```ts
+FileUploadModule.registerAsync({
+    imports: [ConfigModule],
+    inject: [ConfigService],
+    useFactory: async (config: ConfigService) => ({
+        storageClient: await createStorageClient(config),
+        keyPrefix: config.getOrThrow('FILE_PREFIX'),
+    }),
 });
+```
 
-class FileHandler {
-    constructor(private readonly files: FileUploadService) {}
+## Route policies and uploaded parameters
 
-    async save(buffer: Buffer) {
-        return this.files.uploadFile(buffer, 'document.pdf', 'application/pdf');
+The interceptors consume `@FileUpload()` metadata. `@UploadedFile()` and `@UploadedFiles()` read the stored results from the request as real Nest parameter decorators:
+
+```ts
+import { Controller, Post, UseInterceptors } from '@nestjs/common';
+import {
+    FileUpload,
+    SingleFileUploadInterceptor,
+    UploadedFile,
+    type StoredUploadedFile,
+} from '@a3s-lab/files';
+
+@Controller('documents')
+export class DocumentsController {
+    @Post()
+    @FileUpload({
+        fieldName: 'document',
+        maxSize: 5 * 1024 * 1024,
+        allowedTypes: ['application/pdf'],
+        allowedExtensions: ['pdf'],
+    })
+    @UseInterceptors(SingleFileUploadInterceptor)
+    create(@UploadedFile() file: StoredUploadedFile) {
+        return { key: file.key };
     }
 }
 ```
 
-Provide `FILE_STORAGE_CLIENT` with an adapter that implements `upload`, `getSignedUrl`, `delete`, and `exists`.
+Use `FileUploadInterceptor` with `@UploadedFiles()` for multiple files. The multipart adapter must populate `request.file` or `request.files` before these interceptors run.
 
-## Exports
+## Failure and concurrency semantics
 
-- File storage client contract and injection token
-- File validation options and default validation policy
-- Upload service with key generation and signed URL helpers
-- Multipart file extraction helpers
-- Single and multi-file upload interceptors
-- Upload decorators and metadata keys
-- `FileUploadModule`
+The safe defaults are:
+
+| Option | Default | Behavior |
+| --- | ---: | --- |
+| `maxFiles` | `10` | Reject larger batches before any remote write. |
+| `maxConcurrentUploads` | `4` | Bound storage pressure while preserving input order. |
+| `rollbackOnFailure` | `true` | Delete completed objects when signing or another batch operation fails. |
+| `rollbackOnHandlerError` | `true` | Delete uploaded objects if the downstream route handler fails. |
+
+Every file in a batch is validated and assigned a unique key before the first storage call. After the first remote failure, no new work is scheduled; already completed uploads are compensated with deletes. `FileBatchUploadError` exposes operation errors and cleanup failures, while `FileCleanupError` retains the original error as `cause` if compensation itself fails.
+
+Set `rollbackOnHandlerError: false` only when a handler deliberately persists the file reference before emitting an error. Compensation is best-effort rather than a distributed transaction, so custom `storedNameFactory` implementations should generate keys that do not overwrite existing objects.
+
+## Object-key safety
+
+`keyPrefix`, generated names, URL lookup names, and delete names are validated as relative logical object paths. Empty segments, dot traversal, encoded traversal, absolute paths, backslashes, and control characters are rejected. Cleanup helpers also refuse keys outside the configured prefix.
+
+The default policy validates the declared MIME type and a 10 MiB size limit. MIME declarations are not content sniffing; applications handling untrusted formats should add magic-byte or malware inspection before upload.
 
 ## Notes
 
-This package does not choose object storage, bucket names, credentials, or route-level upload policy. Those decisions belong in the consuming API.
+This package does not parse multipart bodies or choose an object store, bucket, credentials, retention policy, or malware scanner. The consuming application owns those integrations. Compensating deletes improve failure consistency but cannot provide a distributed transaction across the handler's database and object storage.
+
+## Exports
+
+- `FileUploadModule`, including `register` and `registerAsync`
+- `FileUploadService` and the `FileStorageClient` contract
+- `FileUploadInterceptor` and `SingleFileUploadInterceptor`
+- `FileUpload`, `UploadedFile`, and `UploadedFiles`
+- Validation, upload result, cleanup, batch error, and module option types
 
 See the [framework core guide](../../docs/framework-core.md) for package boundaries.

--- a/packages/files/package.json
+++ b/packages/files/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@a3s-lab/files",
     "version": "0.1.0",
-    "description": "Generic file upload validation, storage contracts, and NestJS interceptors for APIs",
+    "description": "Failure-safe file validation, storage contracts, and NestJS upload workflows",
     "author": "A3S Lab",
     "license": "MIT",
     "homepage": "https://github.com/A3S-Lab/nestify/tree/main/packages/files#readme",
@@ -19,6 +19,7 @@
         "upload",
         "storage",
         "validation",
+        "rollback",
         "typescript"
     ],
     "source": "./src/index.ts",
@@ -44,6 +45,7 @@
     "scripts": {
         "build": "rimraf dist && tsc",
         "test": "jest --passWithNoTests",
+        "test:cov": "jest --coverage",
         "clean": "rimraf dist && rimraf node_modules",
         "prepublishOnly": "pnpm run build"
     },

--- a/packages/files/src/__tests__/index.spec.ts
+++ b/packages/files/src/__tests__/index.spec.ts
@@ -1,14 +1,23 @@
 import 'reflect-metadata';
-import { BadRequestException } from '@nestjs/common';
-import { lastValueFrom, of } from 'rxjs';
+import { BadRequestException, Module } from '@nestjs/common';
+import { ROUTE_ARGS_METADATA } from '@nestjs/common/constants';
+import { NestFactory, Reflector } from '@nestjs/core';
+import { lastValueFrom, of, throwError } from 'rxjs';
 import {
+    extractFiles,
     FILE_STORAGE_CLIENT,
     FILE_UPLOAD_OPTIONS,
+    FileBatchUploadError,
+    FileCleanupError,
+    type FileStorageClient,
+    FileUpload,
     FileUploadInterceptor,
+    type FileUploadMetadata,
     FileUploadModule,
     FileUploadService,
     SingleFileUploadInterceptor,
-    extractFiles,
+    UploadedFile,
+    UploadedFiles,
 } from '../index';
 
 describe('file upload package', () => {
@@ -20,8 +29,8 @@ describe('file upload package', () => {
             storedNameFactory: input => `${input.size}-${input.originalName}`,
         });
 
-        const result = await service.uploadFile(Buffer.from('hello'), 'note.txt', 'text/plain', {
-            allowedExtensions: ['.txt'],
+        const result = await service.uploadFile(Buffer.from('hello'), 'note.txt', 'Text/Plain; charset=utf-8', {
+            allowedExtensions: ['txt'],
         });
 
         expect(storage.upload).toHaveBeenCalledWith('incoming/5-note.txt', Buffer.from('hello'), {
@@ -38,9 +47,9 @@ describe('file upload package', () => {
         });
     });
 
-    it('validates size, type, and extension before upload', async () => {
+    it('validates size, type, extension, and batch count before upload', async () => {
         const storage = createStorageClient();
-        const service = new FileUploadService(storage);
+        const service = new FileUploadService(storage, { maxFiles: 3, validation: { maxCount: 2 } });
 
         await expect(service.uploadFile(Buffer.alloc(5), 'note.txt', 'text/plain', { maxSize: 4 })).rejects.toThrow(
             BadRequestException,
@@ -51,7 +60,31 @@ describe('file upload package', () => {
         await expect(
             service.uploadFile(Buffer.alloc(1), 'note.exe', 'text/plain', { allowedExtensions: ['.txt'] }),
         ).rejects.toThrow(BadRequestException);
+        await expect(
+            service.uploadFiles([uploadInput('one.txt'), uploadInput('two.txt'), uploadInput('three.txt')]),
+        ).rejects.toThrow('File count exceeds maximum allowed (2)');
+        await expect(service.uploadFiles([])).resolves.toEqual([]);
         expect(storage.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects unsafe logical object paths', async () => {
+        const storage = createStorageClient();
+        const service = new FileUploadService(storage, { keyPrefix: '/public/uploads/' });
+
+        expect(service.buildKey('tenant/file.txt')).toBe('public/uploads/tenant/file.txt');
+        expect(() => service.buildKey('../private.txt')).toThrow(BadRequestException);
+        expect(() => service.buildKey('%2e%2e/private.txt')).toThrow(BadRequestException);
+        expect(() => service.buildKey('%252e%252e/private.txt')).toThrow(BadRequestException);
+        expect(() => service.buildKey('tenant\\private.txt')).toThrow(BadRequestException);
+        expect(() => new FileUploadService(storage, { keyPrefix: '../private' })).toThrow(
+            'keyPrefix contains an unsafe path segment',
+        );
+        await expect(service.getFileUrl('/absolute.txt')).rejects.toThrow(BadRequestException);
+        await expect(service.cleanupUploadedFiles([{ key: 'private/file.txt' }])).rejects.toThrow(
+            'Uploaded file key is outside the configured keyPrefix',
+        );
+        expect(storage.getSignedUrl).not.toHaveBeenCalled();
+        expect(storage.delete).not.toHaveBeenCalled();
     });
 
     it('uses normalized storage keys for URL, existence, and delete helpers', async () => {
@@ -67,28 +100,40 @@ describe('file upload package', () => {
         expect(storage.delete).toHaveBeenCalledWith('public/uploads/file.txt');
     });
 
-    it('extracts multipart files from common request shapes', () => {
-        const first = multipartFile('first.txt');
-        const second = multipartFile('second.txt');
-        const third = multipartFile('third.txt');
+    it('extracts multipart files from common request shapes and filters fields', () => {
+        const first = multipartFile('first.txt', 'avatar');
+        const second = multipartFile('second.txt', 'documents');
+        const third = multipartFile('third.txt', 'documents');
 
         expect(extractFiles({ file: first })).toEqual([first]);
         expect(extractFiles({ files: [first, second] })).toEqual([first, second]);
         expect(extractFiles({ files: { avatar: first, documents: [second, third] } })).toEqual([first, second, third]);
+        expect(extractFiles({ files: [first, second] }, 'documents')).toEqual([second]);
         expect(extractFiles({})).toEqual([]);
     });
 
-    it('uploads multiple files and merges them into the response', async () => {
-        const service = new FileUploadService(createStorageClient(), {
-            storedNameFactory: input => input.originalName,
-        });
-        const interceptor = new FileUploadInterceptor(service);
-        const request = { files: [multipartFile('one.txt'), multipartFile('two.txt')] };
+    it('applies route metadata and merges uploaded files into the response', async () => {
+        const storage = createStorageClient();
+        const service = new FileUploadService(storage, { storedNameFactory: input => input.originalName });
+        const interceptor = new FileUploadInterceptor(service, new Reflector());
+        const route = createDecoratedRoute({ fieldName: 'documents', allowedExtensions: ['txt'], maxCount: 2 });
+        const request = {
+            files: {
+                avatar: multipartFile('avatar.png', 'avatar', 'image/png'),
+                documents: [multipartFile('one.txt', 'documents'), multipartFile('two.txt', 'documents')],
+            },
+        };
 
         const result = await lastValueFrom(
-            await interceptor.intercept(createHttpContext(request), { handle: () => of({ ok: true }) }),
+            await interceptor.intercept(createHttpContext(request, route), { handle: () => of({ ok: true }) }),
         );
 
+        expect(storage.upload).toHaveBeenCalledTimes(2);
+        expect(storage.upload).not.toHaveBeenCalledWith(
+            expect.stringContaining('avatar.png'),
+            expect.anything(),
+            expect.anything(),
+        );
         expect(request).toMatchObject({
             uploadedFiles: [
                 { originalName: 'one.txt', key: 'uploads/one.txt' },
@@ -104,27 +149,251 @@ describe('file upload package', () => {
         });
     });
 
-    it('uploads a single file and rejects missing files', async () => {
+    it('uploads a single selected file and rejects ambiguous or missing inputs', async () => {
         const service = new FileUploadService(createStorageClient(), {
             storedNameFactory: input => input.originalName,
         });
-        const interceptor = new SingleFileUploadInterceptor(service);
-        const request = { file: multipartFile('one.txt') };
+        const interceptor = new SingleFileUploadInterceptor(service, new Reflector());
+        const route = createDecoratedRoute({ fieldName: 'avatar' });
+        const request = {
+            files: [multipartFile('avatar.png', 'avatar', 'image/png'), multipartFile('note.txt', 'document')],
+        };
 
         const result = await lastValueFrom(
-            await interceptor.intercept(createHttpContext(request), { handle: () => of('ignored') }),
+            await interceptor.intercept(createHttpContext(request, route), { handle: () => of('ignored') }),
         );
 
         await expect(
-            new SingleFileUploadInterceptor(service).intercept(createHttpContext({}), { handle: () => of('never') }),
+            interceptor.intercept(createHttpContext({}, route), { handle: () => of('never') }),
         ).rejects.toThrow(BadRequestException);
-        expect(request).toMatchObject({ uploadedFile: { originalName: 'one.txt', key: 'uploads/one.txt' } });
-        expect(result).toMatchObject({ file: { originalName: 'one.txt', key: 'uploads/one.txt' } });
+        await expect(
+            interceptor.intercept(
+                createHttpContext(
+                    {
+                        files: [
+                            multipartFile('one.png', 'avatar', 'image/png'),
+                            multipartFile('two.png', 'avatar', 'image/png'),
+                        ],
+                    },
+                    route,
+                ),
+                { handle: () => of('never') },
+            ),
+        ).rejects.toThrow('Single-file upload received more than one file');
+        expect(request).toMatchObject({ uploadedFile: { originalName: 'avatar.png', key: 'uploads/avatar.png' } });
+        expect(result).toMatchObject({ file: { originalName: 'avatar.png', key: 'uploads/avatar.png' } });
     });
 
-    it('registers module providers with optional storage client', () => {
+    it('exposes uploaded request values through parameter decorators', () => {
+        class Controller {
+            handle(_file: unknown, _files: unknown) {}
+        }
+        UploadedFile()(Controller.prototype, 'handle', 0);
+        UploadedFiles()(Controller.prototype, 'handle', 1);
+        const uploadedFile = { key: 'uploads/one.txt' };
+        const uploadedFiles = [uploadedFile];
+        const context = createHttpContext({ uploadedFile, uploadedFiles });
+        const metadata = Reflect.getMetadata(ROUTE_ARGS_METADATA, Controller, 'handle') as Record<
+            string,
+            { index: number; factory: (data: unknown, context: unknown) => unknown }
+        >;
+        const entries = Object.values(metadata);
+
+        expect(entries.find(entry => entry.index === 0)?.factory(undefined, context)).toBe(uploadedFile);
+        expect(entries.find(entry => entry.index === 1)?.factory(undefined, context)).toBe(uploadedFiles);
+    });
+
+    it('removes an uploaded object when signed URL generation fails', async () => {
+        const storage = createStorageClient();
+        const signingError = new Error('signing unavailable');
+        storage.getSignedUrl.mockRejectedValueOnce(signingError);
+        const service = new FileUploadService(storage, { storedNameFactory: input => input.originalName });
+
+        await expect(service.uploadFile(Buffer.from('file'), 'one.txt', 'text/plain')).rejects.toBe(signingError);
+
+        expect(storage.delete).toHaveBeenCalledWith('uploads/one.txt');
+    });
+
+    it('preserves the original cause when compensating cleanup fails', async () => {
+        const storage = createStorageClient();
+        const signingError = new Error('signing unavailable');
+        const cleanupError = new Error('delete unavailable');
+        storage.getSignedUrl.mockRejectedValueOnce(signingError);
+        storage.delete.mockRejectedValueOnce(cleanupError);
+        const service = new FileUploadService(storage, { storedNameFactory: input => input.originalName });
+
+        const error = await service.uploadFile(Buffer.from('file'), 'one.txt', 'text/plain').catch(value => value);
+
+        expect(error).toBeInstanceOf(FileCleanupError);
+        expect(error).toMatchObject({
+            cause: signingError,
+            failures: [{ key: 'uploads/one.txt', error: cleanupError }],
+        });
+    });
+
+    it('reports cleanup failures alongside the batch operation error', async () => {
+        const storage = createStorageClient();
+        const operationError = new Error('second upload failed');
+        const cleanupError = new Error('first delete failed');
+        storage.upload.mockImplementation(async key => {
+            if (key.endsWith('two.txt')) throw operationError;
+        });
+        storage.delete.mockRejectedValueOnce(cleanupError);
+        const service = new FileUploadService(storage, {
+            storedNameFactory: input => input.originalName,
+            maxConcurrentUploads: 1,
+        });
+
+        const error = await service.uploadFiles([uploadInput('one.txt'), uploadInput('two.txt')]).catch(value => value);
+
+        expect(error).toBeInstanceOf(FileBatchUploadError);
+        expect(error).toMatchObject({
+            cause: operationError,
+            operationErrors: [operationError],
+            cleanupFailures: [{ key: 'uploads/one.txt', error: cleanupError }],
+        });
+    });
+
+    it('prevalidates batches and compensates successful writes after a remote failure', async () => {
+        const storage = createStorageClient();
+        const service = new FileUploadService(storage, {
+            storedNameFactory: input => input.originalName,
+            maxConcurrentUploads: 1,
+        });
+
+        await expect(
+            service.uploadFiles([uploadInput('valid.txt'), uploadInput('invalid.exe', 'application/x-msdownload')]),
+        ).rejects.toThrow(BadRequestException);
+        expect(storage.upload).not.toHaveBeenCalled();
+
+        const duplicateService = new FileUploadService(storage, {
+            storedNameFactory: () => 'duplicate.txt',
+        });
+        await expect(duplicateService.uploadFiles([uploadInput('one.txt'), uploadInput('two.txt')])).rejects.toThrow(
+            "Batch upload generated duplicate object key 'uploads/duplicate.txt'",
+        );
+        expect(storage.upload).not.toHaveBeenCalled();
+
+        const remoteError = new Error('storage unavailable');
+        storage.upload.mockImplementation(async key => {
+            if (key.endsWith('two.txt')) throw remoteError;
+        });
+        const error = await service
+            .uploadFiles([uploadInput('one.txt'), uploadInput('two.txt'), uploadInput('three.txt')])
+            .catch(value => value);
+
+        expect(error).toBeInstanceOf(FileBatchUploadError);
+        expect(error).toMatchObject({ operationErrors: [remoteError], cleanupFailures: [] });
+        expect(storage.delete).toHaveBeenCalledWith('uploads/one.txt');
+        expect(storage.upload).not.toHaveBeenCalledWith('uploads/three.txt', expect.anything(), expect.anything());
+    });
+
+    it('bounds batch upload concurrency', async () => {
+        const storage = createStorageClient();
+        let active = 0;
+        let peak = 0;
+        storage.upload.mockImplementation(async () => {
+            active += 1;
+            peak = Math.max(peak, active);
+            await new Promise(resolve => setTimeout(resolve, 5));
+            active -= 1;
+        });
+        const service = new FileUploadService(storage, {
+            storedNameFactory: input => input.originalName,
+            maxConcurrentUploads: 2,
+            maxFiles: 5,
+        });
+
+        await service.uploadFiles([
+            uploadInput('one.txt'),
+            uploadInput('two.txt'),
+            uploadInput('three.txt'),
+            uploadInput('four.txt'),
+            uploadInput('five.txt'),
+        ]);
+
+        expect(peak).toBe(2);
+    });
+
+    it('rolls back uploads when downstream handlers fail', async () => {
+        const storage = createStorageClient();
+        const service = new FileUploadService(storage, { storedNameFactory: input => input.originalName });
+        const interceptor = new SingleFileUploadInterceptor(service, new Reflector());
+        const handlerError = new Error('database transaction failed');
+
+        const observable = await interceptor.intercept(createHttpContext({ file: multipartFile('one.txt') }), {
+            handle: () => throwError(() => handlerError),
+        });
+        await expect(lastValueFrom(observable)).rejects.toBe(handlerError);
+        expect(storage.delete).toHaveBeenCalledWith('uploads/one.txt');
+
+        storage.delete.mockClear();
+        await expect(
+            interceptor.intercept(createHttpContext({ file: multipartFile('two.txt') }), {
+                handle: () => {
+                    throw handlerError;
+                },
+            }),
+        ).rejects.toBe(handlerError);
+        expect(storage.delete).toHaveBeenCalledWith('uploads/two.txt');
+    });
+
+    it('can retain successful uploads after a handler failure when explicitly configured', async () => {
+        const storage = createStorageClient();
+        const service = new FileUploadService(storage, {
+            storedNameFactory: input => input.originalName,
+            rollbackOnHandlerError: false,
+        });
+        const interceptor = new SingleFileUploadInterceptor(service, new Reflector());
+        const handlerError = new Error('handler failed after persisting the key');
+
+        const observable = await interceptor.intercept(createHttpContext({ file: multipartFile('one.txt') }), {
+            handle: () => throwError(() => handlerError),
+        });
+
+        await expect(lastValueFrom(observable)).rejects.toBe(handlerError);
+        expect(storage.delete).not.toHaveBeenCalled();
+    });
+
+    it('surfaces downstream cleanup failures without losing the handler cause', async () => {
+        const storage = createStorageClient();
+        const cleanupError = new Error('delete unavailable');
+        storage.delete.mockRejectedValueOnce(cleanupError);
+        const service = new FileUploadService(storage, { storedNameFactory: input => input.originalName });
+        const interceptor = new SingleFileUploadInterceptor(service, new Reflector());
+        const handlerError = new Error('handler failed');
+        const observable = await interceptor.intercept(createHttpContext({ file: multipartFile('one.txt') }), {
+            handle: () => throwError(() => handlerError),
+        });
+
+        const error = await lastValueFrom(observable).catch(value => value);
+
+        expect(error).toBeInstanceOf(FileCleanupError);
+        expect(error).toMatchObject({
+            cause: handlerError,
+            failures: [{ key: 'uploads/one.txt', error: cleanupError }],
+        });
+    });
+
+    it('fails fast for invalid service configuration and missing storage', async () => {
+        expect(() => new FileUploadService(undefined, { maxFiles: 0 })).toThrow('maxFiles must be a positive integer');
+        const service = new FileUploadService();
+
+        await expect(service.uploadFile(Buffer.from('file'), 'one.txt', 'text/plain')).rejects.toThrow(
+            'File storage client is not configured',
+        );
+        await expect(service.getFileUrl('one.txt', 0)).rejects.toThrow('expiresInSeconds must be a positive integer');
+    });
+
+    it('registers static and asynchronous module providers', async () => {
         const storage = createStorageClient();
         const module = FileUploadModule.register({ keyPrefix: 'files', storageClient: storage });
+        const useFactory = jest.fn(async () => ({ keyPrefix: 'async-files', storageClient: storage }));
+        const asyncModule = FileUploadModule.registerAsync({
+            imports: [class ConfigModule {}],
+            inject: ['CONFIG'],
+            useFactory,
+        });
 
         expect(module.providers).toEqual(
             expect.arrayContaining([
@@ -138,10 +407,58 @@ describe('file upload package', () => {
         expect(module.exports).toEqual(
             expect.arrayContaining([FileUploadService, FileUploadInterceptor, SingleFileUploadInterceptor]),
         );
+        expect(asyncModule.providers).toEqual(
+            expect.arrayContaining([
+                FileUploadService,
+                FileUploadInterceptor,
+                SingleFileUploadInterceptor,
+                expect.objectContaining({ provide: FILE_UPLOAD_OPTIONS, inject: ['CONFIG'], useFactory }),
+                expect.objectContaining({ provide: FILE_STORAGE_CLIENT, inject: [FILE_UPLOAD_OPTIONS] }),
+            ]),
+        );
+
+        const storageProvider = asyncModule.providers?.find(
+            provider =>
+                typeof provider === 'object' &&
+                provider !== null &&
+                'provide' in provider &&
+                provider.provide === FILE_STORAGE_CLIENT,
+        ) as { useFactory: (options: { storageClient: FileStorageClient }) => FileStorageClient };
+        expect(storageProvider.useFactory(await useFactory())).toBe(storage);
+    });
+
+    it('resolves asynchronous options and storage through the Nest container', async () => {
+        const storage = createStorageClient();
+        @Module({
+            providers: [{ provide: 'FILE_PREFIX', useValue: 'async-files' }],
+            exports: ['FILE_PREFIX'],
+        })
+        class ConfigModule {}
+
+        const application = await NestFactory.createApplicationContext(
+            FileUploadModule.registerAsync({
+                imports: [ConfigModule],
+                inject: ['FILE_PREFIX'],
+                useFactory: (keyPrefix: string) => ({
+                    keyPrefix,
+                    storageClient: storage,
+                    storedNameFactory: input => input.originalName,
+                }),
+            }),
+            { logger: false },
+        );
+
+        const service = application.get(FileUploadService);
+        await service.uploadFile(Buffer.from('file'), 'one.txt', 'text/plain');
+        await application.close();
+
+        expect(storage.upload).toHaveBeenCalledWith('async-files/one.txt', Buffer.from('file'), {
+            contentType: 'text/plain',
+        });
     });
 });
 
-function createStorageClient() {
+function createStorageClient(): jest.Mocked<FileStorageClient> {
     return {
         upload: jest.fn().mockResolvedValue(undefined),
         getSignedUrl: jest.fn().mockResolvedValue('signed-url'),
@@ -150,21 +467,42 @@ function createStorageClient() {
     };
 }
 
-function multipartFile(originalname: string) {
+function uploadInput(filename: string, mimeType = 'text/plain') {
+    return { buffer: Buffer.from('file'), filename, mimeType };
+}
+
+function multipartFile(originalname: string, fieldname = 'file', mimetype = 'text/plain') {
     return {
-        fieldname: 'file',
+        fieldname,
         originalname,
         encoding: '7bit',
-        mimetype: 'text/plain',
+        mimetype,
         size: 4,
         buffer: Buffer.from('file'),
     };
 }
 
-function createHttpContext(request: Record<string, unknown>) {
+function createDecoratedRoute(options: FileUploadMetadata) {
+    class Controller {
+        handler() {}
+    }
+    const descriptor = Object.getOwnPropertyDescriptor(Controller.prototype, 'handler');
+    FileUpload(options)(Controller.prototype, 'handler', descriptor!);
+    return { controller: Controller, handler: Controller.prototype.handler };
+}
+
+function createHttpContext(
+    request: Record<string, unknown>,
+    route: { controller: new (...args: never[]) => unknown; handler: (...args: never[]) => unknown } = {
+        controller: class Controller {},
+        handler: () => undefined,
+    },
+) {
     return {
         switchToHttp: () => ({
             getRequest: () => request,
         }),
+        getHandler: () => route.handler,
+        getClass: () => route.controller,
     } as never;
 }

--- a/packages/files/src/file-upload.decorator.ts
+++ b/packages/files/src/file-upload.decorator.ts
@@ -1,17 +1,26 @@
-import { SetMetadata } from '@nestjs/common';
+import { createParamDecorator, type ExecutionContext, SetMetadata } from '@nestjs/common';
+import type { FileUploadRequest } from './file-upload.interceptor';
+import type { FileValidationOptions } from './file-upload.service';
 
 export const FILE_UPLOAD_KEY = 'file_upload';
+/** @deprecated UploadedFile is now a request parameter decorator. */
 export const SINGLE_FILE_UPLOAD_KEY = 'file_upload:single';
+/** @deprecated UploadedFiles is now a request parameter decorator. */
 export const MULTIPLE_FILE_UPLOAD_KEY = 'file_upload:multiple';
 
-export interface FileUploadMetadata {
+export interface FileUploadMetadata extends FileValidationOptions {
     fieldName?: string;
-    maxSize?: number;
-    allowedTypes?: string[];
-    allowedExtensions?: string[];
-    maxCount?: number;
 }
 
+/** Configure validation and field selection for a file upload interceptor. */
 export const FileUpload = (options: FileUploadMetadata = {}) => SetMetadata(FILE_UPLOAD_KEY, options);
-export const UploadedFile = () => SetMetadata(SINGLE_FILE_UPLOAD_KEY, true);
-export const UploadedFiles = () => SetMetadata(MULTIPLE_FILE_UPLOAD_KEY, true);
+
+/** Read the file stored on the request by SingleFileUploadInterceptor. */
+export const UploadedFile = createParamDecorator(
+    (_data: unknown, context: ExecutionContext) => context.switchToHttp().getRequest<FileUploadRequest>().uploadedFile,
+);
+
+/** Read the files stored on the request by FileUploadInterceptor. */
+export const UploadedFiles = createParamDecorator(
+    (_data: unknown, context: ExecutionContext) => context.switchToHttp().getRequest<FileUploadRequest>().uploadedFiles,
+);

--- a/packages/files/src/file-upload.interceptor.ts
+++ b/packages/files/src/file-upload.interceptor.ts
@@ -1,8 +1,15 @@
-import { BadRequestException, CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import {
+    BadRequestException,
+    type CallHandler,
+    type ExecutionContext,
+    Injectable,
+    type NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import type { Request } from 'express';
-import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { FileUploadService, StoredUploadedFile } from './file-upload.service';
+import { catchError, from, map, type Observable } from 'rxjs';
+import { FILE_UPLOAD_KEY, type FileUploadMetadata } from './file-upload.decorator';
+import { FileUploadService, type StoredUploadedFile } from './file-upload.service';
 
 export interface MultipartFile {
     fieldname: string;
@@ -22,74 +29,127 @@ export interface FileUploadRequest extends Request {
 
 @Injectable()
 export class FileUploadInterceptor implements NestInterceptor {
-    constructor(private readonly fileUploadService: FileUploadService) {}
+    constructor(
+        private readonly fileUploadService: FileUploadService,
+        private readonly reflector: Reflector,
+    ) {}
 
     async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<unknown>> {
         const request = context.switchToHttp().getRequest<FileUploadRequest>();
-        const files = extractFiles(request);
+        const metadata = getUploadMetadata(this.reflector, context);
+        const files = extractFiles(request, metadata.fieldName);
 
         if (files.length === 0) {
-            throw new BadRequestException('No file uploaded');
+            throw new BadRequestException(
+                metadata.fieldName ? `No file uploaded for field '${metadata.fieldName}'` : 'No file uploaded',
+            );
         }
 
-        const uploadedFiles = await Promise.all(
-            files.map(file => this.fileUploadService.uploadFile(file.buffer, file.originalname, file.mimetype)),
+        const uploadedFiles = await this.fileUploadService.uploadFiles(
+            files.map(file => ({ buffer: file.buffer, filename: file.originalname, mimeType: file.mimetype })),
+            metadata,
         );
         request.uploadedFiles = uploadedFiles;
 
-        return next.handle().pipe(
+        return (await this.callNext(next, uploadedFiles)).pipe(
             map(response => {
                 if (response && typeof response === 'object' && !Array.isArray(response)) {
                     return { ...response, files: uploadedFiles };
                 }
                 return { files: uploadedFiles };
             }),
+            catchError(error => from(rollbackAndRethrow(this.fileUploadService, uploadedFiles, error))),
         );
+    }
+
+    private async callNext(next: CallHandler, uploadedFiles: StoredUploadedFile[]): Promise<Observable<unknown>> {
+        try {
+            return next.handle();
+        } catch (error) {
+            return rollbackAndRethrow(this.fileUploadService, uploadedFiles, error);
+        }
     }
 }
 
 @Injectable()
 export class SingleFileUploadInterceptor implements NestInterceptor {
-    constructor(private readonly fileUploadService: FileUploadService) {}
+    constructor(
+        private readonly fileUploadService: FileUploadService,
+        private readonly reflector: Reflector,
+    ) {}
 
     async intercept(context: ExecutionContext, next: CallHandler): Promise<Observable<unknown>> {
         const request = context.switchToHttp().getRequest<FileUploadRequest>();
-        const file = request.file ?? firstFileFromFiles(request.files);
+        const metadata = getUploadMetadata(this.reflector, context);
+        const files = extractFiles(request, metadata.fieldName);
 
-        if (!file) {
-            throw new BadRequestException('No file uploaded');
+        if (files.length === 0) {
+            throw new BadRequestException(
+                metadata.fieldName ? `No file uploaded for field '${metadata.fieldName}'` : 'No file uploaded',
+            );
+        }
+        if (files.length > 1) {
+            throw new BadRequestException('Single-file upload received more than one file');
         }
 
-        const uploadedFile = await this.fileUploadService.uploadFile(file.buffer, file.originalname, file.mimetype);
+        const file = files[0];
+        const uploadedFile = await this.fileUploadService.uploadFile(
+            file.buffer,
+            file.originalname,
+            file.mimetype,
+            metadata,
+        );
         request.uploadedFile = uploadedFile;
 
-        return next.handle().pipe(
+        return (await this.callNext(next, uploadedFile)).pipe(
             map(response => {
                 if (response && typeof response === 'object' && !Array.isArray(response)) {
                     return { ...response, file: uploadedFile };
                 }
                 return { file: uploadedFile };
             }),
+            catchError(error => from(rollbackAndRethrow(this.fileUploadService, [uploadedFile], error))),
         );
     }
+
+    private async callNext(next: CallHandler, uploadedFile: StoredUploadedFile): Promise<Observable<unknown>> {
+        try {
+            return next.handle();
+        } catch (error) {
+            return rollbackAndRethrow(this.fileUploadService, [uploadedFile], error);
+        }
+    }
 }
 
-export function extractFiles(request: Pick<FileUploadRequest, 'file' | 'files'>): MultipartFile[] {
+export function extractFiles(request: Pick<FileUploadRequest, 'file' | 'files'>, fieldName?: string): MultipartFile[] {
+    let files: MultipartFile[];
     if (request.file) {
-        return [request.file];
+        files = [request.file];
+    } else if (Array.isArray(request.files)) {
+        files = request.files;
+    } else if (request.files && typeof request.files === 'object') {
+        files = Object.values(request.files).flatMap(file => (Array.isArray(file) ? file : [file]));
+    } else {
+        files = [];
     }
 
-    if (Array.isArray(request.files)) {
-        return request.files;
-    }
-
-    if (!request.files || typeof request.files !== 'object') {
-        return [];
-    }
-
-    return Object.values(request.files).flatMap(file => (Array.isArray(file) ? file : [file]));
+    return fieldName ? files.filter(file => file.fieldname === fieldName) : files;
 }
 
-function firstFileFromFiles(files: FileUploadRequest['files']): MultipartFile | undefined {
-    return extractFiles({ files })[0];
+function getUploadMetadata(reflector: Reflector, context: ExecutionContext): FileUploadMetadata {
+    return (
+        reflector.getAllAndOverride<FileUploadMetadata>(FILE_UPLOAD_KEY, [context.getHandler(), context.getClass()]) ??
+        {}
+    );
+}
+
+async function rollbackAndRethrow(
+    service: FileUploadService,
+    uploadedFiles: StoredUploadedFile[],
+    error: unknown,
+): Promise<never> {
+    if (service.shouldRollbackOnHandlerError()) {
+        await service.cleanupUploadedFiles(uploadedFiles, error);
+    }
+    throw error;
 }

--- a/packages/files/src/file-upload.module.ts
+++ b/packages/files/src/file-upload.module.ts
@@ -1,10 +1,20 @@
-import { DynamicModule, Module, Provider } from '@nestjs/common';
-import { FILE_STORAGE_CLIENT, FILE_UPLOAD_OPTIONS, FileStorageClient, FileUploadOptions } from './file-upload.service';
+import { type DynamicModule, type FactoryProvider, Module, type ModuleMetadata, type Provider } from '@nestjs/common';
 import { FileUploadInterceptor, SingleFileUploadInterceptor } from './file-upload.interceptor';
-import { FileUploadService } from './file-upload.service';
+import {
+    FILE_STORAGE_CLIENT,
+    FILE_UPLOAD_OPTIONS,
+    FileStorageClient,
+    FileUploadOptions,
+    FileUploadService,
+} from './file-upload.service';
 
 export interface FileUploadModuleOptions extends FileUploadOptions {
     storageClient?: FileStorageClient;
+}
+
+export interface FileUploadModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+    inject?: FactoryProvider['inject'];
+    useFactory: (...args: any[]) => FileUploadModuleOptions | Promise<FileUploadModuleOptions>;
 }
 
 @Module({
@@ -41,6 +51,29 @@ export class FileUploadModule {
         return {
             module: FileUploadModule,
             providers,
+            exports: [FileUploadService, FileUploadInterceptor, SingleFileUploadInterceptor],
+        };
+    }
+
+    static registerAsync(options: FileUploadModuleAsyncOptions): DynamicModule {
+        return {
+            module: FileUploadModule,
+            imports: options.imports,
+            providers: [
+                FileUploadService,
+                FileUploadInterceptor,
+                SingleFileUploadInterceptor,
+                {
+                    provide: FILE_UPLOAD_OPTIONS,
+                    inject: options.inject ?? [],
+                    useFactory: options.useFactory,
+                },
+                {
+                    provide: FILE_STORAGE_CLIENT,
+                    inject: [FILE_UPLOAD_OPTIONS],
+                    useFactory: (resolved: FileUploadModuleOptions) => resolved.storageClient,
+                },
+            ],
             exports: [FileUploadService, FileUploadInterceptor, SingleFileUploadInterceptor],
         };
     }

--- a/packages/files/src/file-upload.service.ts
+++ b/packages/files/src/file-upload.service.ts
@@ -22,10 +22,17 @@ export interface StoredUploadedFile {
     uploadedAt: Date;
 }
 
+export interface FileUploadInput {
+    buffer: Buffer;
+    filename: string;
+    mimeType: string;
+}
+
 export interface FileValidationOptions {
     maxSize?: number;
-    allowedTypes?: string[];
-    allowedExtensions?: string[];
+    allowedTypes?: readonly string[];
+    allowedExtensions?: readonly string[];
+    maxCount?: number;
 }
 
 export interface StoredNameInput {
@@ -38,6 +45,39 @@ export interface FileUploadOptions {
     keyPrefix?: string;
     signedUrlExpiresInSeconds?: number;
     storedNameFactory?: (input: StoredNameInput) => string;
+    validation?: FileValidationOptions;
+    maxFiles?: number;
+    maxConcurrentUploads?: number;
+    rollbackOnFailure?: boolean;
+    rollbackOnHandlerError?: boolean;
+}
+
+export interface FileCleanupFailure {
+    key: string;
+    error: unknown;
+}
+
+export class FileCleanupError extends Error {
+    constructor(
+        public readonly failures: ReadonlyArray<FileCleanupFailure>,
+        cause?: unknown,
+    ) {
+        super(`Failed to clean up ${failures.length} uploaded file${failures.length === 1 ? '' : 's'}`, { cause });
+        this.name = 'FileCleanupError';
+    }
+}
+
+export class FileBatchUploadError extends Error {
+    constructor(
+        public readonly operationErrors: readonly unknown[],
+        public readonly cleanupFailures: ReadonlyArray<FileCleanupFailure> = [],
+    ) {
+        super(
+            `Batch upload failed with ${operationErrors.length} operation error${operationErrors.length === 1 ? '' : 's'}`,
+            { cause: operationErrors[0] },
+        );
+        this.name = 'FileBatchUploadError';
+    }
 }
 
 export const DEFAULT_FILE_VALIDATION: FileValidationOptions = {
@@ -53,21 +93,57 @@ export const DEFAULT_FILE_VALIDATION: FileValidationOptions = {
     ],
 };
 
-export const DEFAULT_FILE_UPLOAD_OPTIONS: Required<Omit<FileUploadOptions, 'storedNameFactory'>> = {
+export const DEFAULT_FILE_UPLOAD_OPTIONS: Required<Omit<FileUploadOptions, 'storedNameFactory' | 'validation'>> = {
     keyPrefix: 'uploads',
     signedUrlExpiresInSeconds: 3600,
+    maxFiles: 10,
+    maxConcurrentUploads: 4,
+    rollbackOnFailure: true,
+    rollbackOnHandlerError: true,
 };
+
+type ResolvedFileUploadOptions = typeof DEFAULT_FILE_UPLOAD_OPTIONS & Pick<FileUploadOptions, 'storedNameFactory'>;
+
+interface PreparedUpload extends FileUploadInput {
+    storedName: string;
+    key: string;
+}
 
 @Injectable()
 export class FileUploadService {
     private readonly logger = new Logger(FileUploadService.name);
-    private readonly options: FileUploadOptions;
+    private readonly options: ResolvedFileUploadOptions;
+    private readonly defaultValidation: FileValidationOptions;
 
     constructor(
         @Optional() @Inject(FILE_STORAGE_CLIENT) private readonly storageClient?: FileStorageClient,
         @Optional() @Inject(FILE_UPLOAD_OPTIONS) options?: FileUploadOptions,
     ) {
-        this.options = { ...DEFAULT_FILE_UPLOAD_OPTIONS, ...options };
+        this.options = {
+            keyPrefix: normalizePrefix(options?.keyPrefix ?? DEFAULT_FILE_UPLOAD_OPTIONS.keyPrefix),
+            signedUrlExpiresInSeconds: requirePositiveInteger(
+                options?.signedUrlExpiresInSeconds ?? DEFAULT_FILE_UPLOAD_OPTIONS.signedUrlExpiresInSeconds,
+                'signedUrlExpiresInSeconds',
+            ),
+            maxFiles: requirePositiveInteger(options?.maxFiles ?? DEFAULT_FILE_UPLOAD_OPTIONS.maxFiles, 'maxFiles'),
+            maxConcurrentUploads: requirePositiveInteger(
+                options?.maxConcurrentUploads ?? DEFAULT_FILE_UPLOAD_OPTIONS.maxConcurrentUploads,
+                'maxConcurrentUploads',
+            ),
+            rollbackOnFailure: options?.rollbackOnFailure ?? DEFAULT_FILE_UPLOAD_OPTIONS.rollbackOnFailure,
+            rollbackOnHandlerError:
+                options?.rollbackOnHandlerError ?? DEFAULT_FILE_UPLOAD_OPTIONS.rollbackOnHandlerError,
+            storedNameFactory: options?.storedNameFactory,
+        };
+        this.defaultValidation = {
+            ...DEFAULT_FILE_VALIDATION,
+            ...options?.validation,
+            allowedTypes: [...(options?.validation?.allowedTypes ?? DEFAULT_FILE_VALIDATION.allowedTypes ?? [])],
+            allowedExtensions: options?.validation?.allowedExtensions
+                ? [...options.validation.allowedExtensions]
+                : undefined,
+        };
+        validateValidationConfiguration(this.defaultValidation);
     }
 
     async uploadFile(
@@ -76,32 +152,61 @@ export class FileUploadService {
         mimeType: string,
         options?: FileValidationOptions,
     ): Promise<StoredUploadedFile> {
-        const validation = { ...DEFAULT_FILE_VALIDATION, ...options };
-        this.validateFile(buffer, filename, mimeType, validation);
-
-        const storedName = this.generateStoredName({ originalName: filename, mimeType, size: buffer.length });
-        const key = this.buildKey(storedName);
-        const storage = this.getStorageClient();
-
-        await storage.upload(key, buffer, { contentType: mimeType });
-        this.logger.log(`File uploaded: ${filename} -> ${storedName}`);
-
-        return {
-            originalName: filename,
-            storedName,
-            mimeType,
-            size: buffer.length,
-            key,
-            url: await storage.getSignedUrl(key, this.options.signedUrlExpiresInSeconds),
-            uploadedAt: new Date(),
-        };
+        return this.uploadPrepared(this.prepareUpload({ buffer, filename, mimeType }, options));
     }
 
     async uploadFiles(
-        files: Array<{ buffer: Buffer; filename: string; mimeType: string }>,
+        files: readonly FileUploadInput[],
         options?: FileValidationOptions,
     ): Promise<StoredUploadedFile[]> {
-        return Promise.all(files.map(file => this.uploadFile(file.buffer, file.filename, file.mimeType, options)));
+        const maxCount = options?.maxCount ?? this.defaultValidation.maxCount ?? this.options.maxFiles;
+        assertValidMaxCount(maxCount);
+        if (files.length > maxCount) {
+            throw new BadRequestException(`File count exceeds maximum allowed (${maxCount})`);
+        }
+
+        // Validate and allocate every key before starting any remote write.
+        const prepared = files.map(file => this.prepareUpload(file, options));
+        const duplicateKey = findDuplicate(prepared.map(file => file.key));
+        if (duplicateKey) {
+            throw new BadRequestException(`Batch upload generated duplicate object key '${duplicateKey}'`);
+        }
+        if (prepared.length === 0) {
+            return [];
+        }
+
+        const settled = await this.uploadPreparedBatch(prepared);
+        const operationErrors = settled.flatMap(result => (result?.status === 'rejected' ? [result.reason] : []));
+        const successfulFiles = settled.flatMap(result => (result?.status === 'fulfilled' ? [result.value] : []));
+
+        if (operationErrors.length > 0) {
+            const cleanupFailures = operationErrors.flatMap(error =>
+                error instanceof FileCleanupError ? error.failures : [],
+            );
+
+            if (this.options.rollbackOnFailure && successfulFiles.length > 0) {
+                try {
+                    await this.cleanupUploadedFiles(successfulFiles, operationErrors[0]);
+                } catch (error) {
+                    if (error instanceof FileCleanupError) {
+                        cleanupFailures.push(...error.failures);
+                    } else {
+                        cleanupFailures.push({ key: '<unknown>', error });
+                    }
+                }
+            }
+
+            throw new FileBatchUploadError(operationErrors, cleanupFailures);
+        }
+
+        return settled.map(result => (result as PromiseFulfilledResult<StoredUploadedFile>).value);
+    }
+
+    async cleanupUploadedFiles(files: ReadonlyArray<Pick<StoredUploadedFile, 'key'>>, cause?: unknown): Promise<void> {
+        await this.cleanupKeys(
+            files.map(file => this.validateOwnedKey(file.key)),
+            cause,
+        );
     }
 
     async deleteFile(storedName: string): Promise<void> {
@@ -111,6 +216,9 @@ export class FileUploadService {
     }
 
     async getFileUrl(storedName: string, expiresInSeconds = this.options.signedUrlExpiresInSeconds): Promise<string> {
+        if (!Number.isInteger(expiresInSeconds) || expiresInSeconds <= 0) {
+            throw new BadRequestException('expiresInSeconds must be a positive integer');
+        }
         return this.getStorageClient().getSignedUrl(this.buildKey(storedName), expiresInSeconds);
     }
 
@@ -118,32 +226,152 @@ export class FileUploadService {
         return this.getStorageClient().exists(this.buildKey(storedName));
     }
 
+    shouldRollbackOnHandlerError(): boolean {
+        return this.options.rollbackOnHandlerError;
+    }
+
     validateFile(buffer: Buffer, filename: string, mimeType: string, options: FileValidationOptions): void {
-        if (options.maxSize && buffer.length > options.maxSize) {
+        validateValidationConfiguration(options, true);
+        const normalizedFilename = filename.trim();
+        const normalizedMimeType = normalizeMimeType(mimeType);
+
+        if (!normalizedFilename || CONTROL_CHARACTERS.test(normalizedFilename)) {
+            throw new BadRequestException('File name must be non-empty and contain no control characters');
+        }
+        if (!normalizedMimeType) {
+            throw new BadRequestException('File MIME type must be non-empty');
+        }
+
+        if (options.maxSize !== undefined && buffer.length > options.maxSize) {
             const maxMB = options.maxSize / (1024 * 1024);
             throw new BadRequestException(`File size exceeds maximum allowed (${maxMB}MB)`);
         }
 
-        if (options.allowedTypes && !options.allowedTypes.includes(mimeType)) {
-            throw new BadRequestException(
-                `File type '${mimeType}' is not allowed. Allowed types: ${options.allowedTypes.join(', ')}`,
-            );
+        if (options.allowedTypes) {
+            const allowedTypes = options.allowedTypes.map(normalizeMimeType);
+            if (!allowedTypes.includes(normalizedMimeType)) {
+                throw new BadRequestException(
+                    `File type '${normalizedMimeType}' is not allowed. Allowed types: ${allowedTypes.join(', ')}`,
+                );
+            }
         }
 
         if (options.allowedExtensions) {
-            const ext = getExtension(filename).toLowerCase();
-            const allowedExts = options.allowedExtensions.map(extension => extension.toLowerCase());
-            if (!allowedExts.includes(ext)) {
+            const extension = getExtension(normalizedFilename).toLowerCase();
+            const allowedExtensions = options.allowedExtensions.map(normalizeExtension);
+            if (!allowedExtensions.includes(extension)) {
                 throw new BadRequestException(
-                    `File extension '${ext}' is not allowed. Allowed extensions: ${allowedExts.join(', ')}`,
+                    `File extension '${extension}' is not allowed. Allowed extensions: ${allowedExtensions.join(', ')}`,
                 );
             }
         }
     }
 
     buildKey(storedName: string): string {
-        const prefix = normalizePrefix(this.options.keyPrefix ?? DEFAULT_FILE_UPLOAD_OPTIONS.keyPrefix);
-        return prefix ? `${prefix}/${storedName}` : storedName;
+        const normalizedStoredName = normalizeStoredName(storedName);
+        return this.options.keyPrefix ? `${this.options.keyPrefix}/${normalizedStoredName}` : normalizedStoredName;
+    }
+
+    private prepareUpload(input: FileUploadInput, options?: FileValidationOptions): PreparedUpload {
+        const validation = {
+            ...this.defaultValidation,
+            ...options,
+            allowedTypes: options?.allowedTypes ?? this.defaultValidation.allowedTypes,
+            allowedExtensions: options?.allowedExtensions ?? this.defaultValidation.allowedExtensions,
+        };
+        const mimeType = normalizeMimeType(input.mimeType);
+        this.validateFile(input.buffer, input.filename, mimeType, validation);
+
+        const storedName = normalizeStoredName(
+            this.generateStoredName({
+                originalName: input.filename,
+                mimeType,
+                size: input.buffer.length,
+            }),
+        );
+
+        return {
+            ...input,
+            mimeType,
+            storedName,
+            key: this.buildKey(storedName),
+        };
+    }
+
+    private async uploadPrepared(prepared: PreparedUpload): Promise<StoredUploadedFile> {
+        const storage = this.getStorageClient();
+        await storage.upload(prepared.key, prepared.buffer, { contentType: prepared.mimeType });
+
+        let url: string;
+        try {
+            url = await storage.getSignedUrl(prepared.key, this.options.signedUrlExpiresInSeconds);
+            if (!url) {
+                throw new Error('Storage client returned an empty signed URL');
+            }
+        } catch (error) {
+            if (this.options.rollbackOnFailure) {
+                await this.cleanupKeys([prepared.key], error);
+            }
+            throw error;
+        }
+
+        this.logger.log(`File uploaded: ${prepared.filename} -> ${prepared.storedName}`);
+
+        return {
+            originalName: prepared.filename,
+            storedName: prepared.storedName,
+            mimeType: prepared.mimeType,
+            size: prepared.buffer.length,
+            key: prepared.key,
+            url,
+            uploadedAt: new Date(),
+        };
+    }
+
+    private async uploadPreparedBatch(
+        prepared: PreparedUpload[],
+    ): Promise<Array<PromiseSettledResult<StoredUploadedFile> | undefined>> {
+        const results: Array<PromiseSettledResult<StoredUploadedFile> | undefined> = new Array(prepared.length);
+        let nextIndex = 0;
+        let stopScheduling = false;
+
+        const worker = async () => {
+            while (!stopScheduling) {
+                const index = nextIndex;
+                nextIndex += 1;
+                if (index >= prepared.length) {
+                    return;
+                }
+
+                try {
+                    results[index] = { status: 'fulfilled', value: await this.uploadPrepared(prepared[index]) };
+                } catch (reason) {
+                    results[index] = { status: 'rejected', reason };
+                    stopScheduling = true;
+                }
+            }
+        };
+
+        const workerCount = Math.min(this.options.maxConcurrentUploads, prepared.length);
+        await Promise.all(Array.from({ length: workerCount }, () => worker()));
+        return results;
+    }
+
+    private async cleanupKeys(keys: string[], cause?: unknown): Promise<void> {
+        const uniqueKeys = [...new Set(keys)];
+        if (uniqueKeys.length === 0) {
+            return;
+        }
+        const storage = this.getStorageClient();
+        const results = await Promise.allSettled(uniqueKeys.map(key => storage.delete(key)));
+        const failures = results.flatMap((result, index) =>
+            result.status === 'rejected' ? [{ key: uniqueKeys[index], error: result.reason }] : [],
+        );
+
+        if (failures.length > 0) {
+            this.logger.error(`Failed to clean up ${failures.length} uploaded file(s)`);
+            throw new FileCleanupError(failures, cause);
+        }
     }
 
     private getStorageClient(): FileStorageClient {
@@ -151,6 +379,20 @@ export class FileUploadService {
             throw new Error('File storage client is not configured');
         }
         return this.storageClient;
+    }
+
+    private validateOwnedKey(key: string): string {
+        let normalized: string;
+        try {
+            normalized = validateObjectPath(key.trim(), 'key');
+        } catch (error) {
+            throw new BadRequestException(error instanceof Error ? error.message : 'Invalid uploaded file key');
+        }
+
+        if (this.options.keyPrefix && !normalized.startsWith(`${this.options.keyPrefix}/`)) {
+            throw new BadRequestException('Uploaded file key is outside the configured keyPrefix');
+        }
+        return normalized;
     }
 
     private generateStoredName(input: StoredNameInput): string {
@@ -161,11 +403,106 @@ export class FileUploadService {
     }
 }
 
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
 export function getExtension(filename: string): string {
-    const lastDot = filename.lastIndexOf('.');
-    return lastDot !== -1 ? filename.substring(lastDot) : '';
+    const basename = filename.replace(/\\/g, '/').split('/').pop() ?? '';
+    const lastDot = basename.lastIndexOf('.');
+    return lastDot > 0 ? basename.substring(lastDot) : '';
+}
+
+function normalizeMimeType(mimeType: string): string {
+    return mimeType.split(';', 1)[0].trim().toLowerCase();
+}
+
+function normalizeExtension(extension: string): string {
+    const normalized = extension.trim().toLowerCase();
+    return normalized && !normalized.startsWith('.') ? `.${normalized}` : normalized;
 }
 
 function normalizePrefix(prefix: string): string {
-    return prefix.trim().replace(/^\/+|\/+$/g, '');
+    const normalized = prefix.trim().replace(/^\/+|\/+$/g, '');
+    return normalized ? validateObjectPath(normalized, 'keyPrefix') : '';
+}
+
+function normalizeStoredName(storedName: string): string {
+    const normalized = storedName.trim();
+    try {
+        return validateObjectPath(normalized, 'storedName');
+    } catch (error) {
+        throw new BadRequestException(error instanceof Error ? error.message : 'Invalid stored file name');
+    }
+}
+
+function validateObjectPath(value: string, label: string): string {
+    if (
+        !value ||
+        value.startsWith('/') ||
+        value.endsWith('/') ||
+        value.includes('\\') ||
+        CONTROL_CHARACTERS.test(value)
+    ) {
+        throw new Error(`${label} must be a non-empty relative object path`);
+    }
+
+    const segments = value.split('/');
+    for (const segment of segments) {
+        let decoded = segment;
+        for (let depth = 0; depth < 3; depth += 1) {
+            try {
+                const next = decodeURIComponent(decoded);
+                if (next === decoded) break;
+                decoded = next;
+            } catch {
+                // A literal percent sign is valid in an object key and is left unchanged.
+                break;
+            }
+        }
+        if (!segment || decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\')) {
+            throw new Error(`${label} contains an unsafe path segment`);
+        }
+    }
+
+    return segments.join('/');
+}
+
+function requirePositiveInteger(value: number, label: string): number {
+    if (!Number.isInteger(value) || value <= 0) {
+        throw new Error(`${label} must be a positive integer`);
+    }
+    return value;
+}
+
+function assertValidMaxCount(maxCount: number): void {
+    if (!Number.isInteger(maxCount) || maxCount <= 0) {
+        throw new BadRequestException('maxCount must be a positive integer');
+    }
+}
+
+function validateValidationConfiguration(options: FileValidationOptions, requestError = false): void {
+    const invalid =
+        (options.maxSize !== undefined && (!Number.isInteger(options.maxSize) || options.maxSize < 0)) ||
+        (options.maxCount !== undefined && (!Number.isInteger(options.maxCount) || options.maxCount <= 0)) ||
+        options.allowedTypes?.some(type => !normalizeMimeType(type) || CONTROL_CHARACTERS.test(type)) ||
+        options.allowedExtensions?.some(
+            extension => !normalizeExtension(extension) || CONTROL_CHARACTERS.test(extension),
+        );
+    if (invalid) {
+        const message = 'File validation options contain invalid limits or empty values';
+        if (requestError) {
+            throw new BadRequestException(message);
+        }
+        throw new Error(message);
+    }
+}
+
+function findDuplicate(values: string[]): string | undefined {
+    const seen = new Set<string>();
+    for (const value of values) {
+        if (seen.has(value)) {
+            return value;
+        }
+        seen.add(value);
+    }
+    return undefined;
 }

--- a/packages/files/src/index.ts
+++ b/packages/files/src/index.ts
@@ -1,4 +1,4 @@
 export * from './file-upload.decorator';
-export * from './file-upload.service';
 export * from './file-upload.interceptor';
 export * from './file-upload.module';
+export * from './file-upload.service';


### PR DESCRIPTION
## What changed

- prevalidate every batch and reject unsafe or duplicate object keys before remote writes
- bound upload concurrency and stop scheduling new writes after the first failure
- compensate completed uploads when signing, another batch operation, or a downstream handler fails
- preserve operation causes and expose structured batch and cleanup failures
- make `FileUpload` route metadata effective and turn `UploadedFile(s)` into request parameter decorators
- add async module registration and validate module/request policy options
- document production semantics and add a minor changeset

## Why

The previous batch path used unbounded `Promise.all`, could leave successful objects behind when a sibling failed, and left objects orphaned when signed URL generation or the route handler failed. Public route metadata and uploaded-file decorators were exported but not connected to interceptor behavior, and custom names could escape the configured logical prefix.

## User impact

Uploads now use safe, bounded, best-effort atomic defaults. Existing applications that intentionally retain files after a handler error can set `rollbackOnHandlerError: false`. `UploadedFile` and `UploadedFiles` now behave as their names imply: Nest request parameter decorators.

## Validation

- `pnpm release:check`
- `pnpm smoke:core-install`
- `pnpm audit:prod`
- `@a3s-lab/files`: 19 tests passed, 93.92% statement coverage
- packaged declaration files and README inspected from the generated tarball
