### PR TITLE
feat: harden etcd lifecycle and cache

### DIFF
--- a/.changeset/calm-etcd-watchers.md
+++ b/.changeset/calm-etcd-watchers.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/etcd": minor
+---
+
+Harden watcher, lease, retry, cache-coherency, subscription, and shutdown lifecycles; add bounded typed caching and document the runtime guarantees.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/bullmq` | NestJS BullMQ module, queue service helpers, worker lifecycle, queue metrics, and cleanup helpers. |
 | `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
-| `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
+| `@a3s-lab/etcd` | NestJS etcd module with key-value operations, coherent bounded config caching, shared watches, leases, compare-and-set, retries, health checks, and failure-isolated cleanup. |
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run NestJS module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |

--- a/packages/etcd/README.md
+++ b/packages/etcd/README.md
@@ -17,7 +17,15 @@ import { EtcdModule } from '@a3s-lab/etcd';
     imports: [
         EtcdModule.register({
             endpoints: ['http://localhost:2379'],
-            requestOptions: { timeout: 5000 },
+            requestOptions: {
+                timeout: 5000,
+                retry: 3,
+            },
+            configCache: {
+                ttl: 5000,
+                maxEntries: 1000,
+                cacheMissing: true,
+            },
         }),
     ],
 })
@@ -46,10 +54,9 @@ export class SettingsStore {
     }
 
     watchSettings() {
-        return this.etcd.watch('settings/api', event => {
-            if (event.value !== null) {
-                applySettings(event.value);
-            }
+        return this.config.subscribe<string>('settings/api', value => {
+            // Deletions are delivered as null so consumers can remove stale state.
+            applySettings(value === null ? null : JSON.parse(value));
         });
     }
 
@@ -60,6 +67,31 @@ export class SettingsStore {
 }
 ```
 
+Keep the function returned by `watch`, `watchPrefix`, `subscribe`, or `subscribePrefix` and call it when the consumer no longer needs updates. Watch values are the raw UTF-8 strings stored by etcd; parse JSON in the subscriber when needed. Multiple configuration subscribers for the same key or prefix share one underlying etcd watcher. Subscriber failures are logged and isolated, so one synchronous or asynchronous callback cannot prevent the remaining subscribers from running.
+
+## Configuration
+
+| Option | Default | Behavior |
+| --- | --- | --- |
+| `endpoints` | required | One or more non-empty etcd URLs. |
+| `auth` | none | Username and password must be supplied together. |
+| `tls` | none | Client certificate and key must be supplied together; `ca` is optional. |
+| `requestOptions.timeout` | etcd3 default | Deadline in milliseconds for non-streaming RPCs. Watch streams are not given a finite request deadline. |
+| `requestOptions.retry` | etcd3 default | Number of retries for recoverable RPC failures. Set to `0` to disable global retries. |
+| `configCache.ttl` | `5000` | Local cache lifetime in milliseconds. Set to `0` to disable caching. |
+| `configCache.maxEntries` | `1000` | Maximum typed cache entries per service instance. Set to `0` to disable caching. |
+| `configCache.cacheMissing` | `true` | Cache missing keys for the configured TTL to coalesce repeated misses. |
+
+Raw and JSON reads use separate cache entries. Concurrent cache misses for the same typed key share one request, write/watch/delete events invalidate stale entries, and late reads cannot overwrite newer watch updates. TTL writes never outlive the shorter of the etcd lease TTL and local cache TTL.
+
+## Lifecycle guarantees
+
+- Duplicate `EtcdService.watch()` calls for the same key remain independently cancellable.
+- Watch creation, cancellation, and callback failures are logged without leaking unhandled promises.
+- Shutdown attempts every watcher and lease cleanup even when one cleanup fails, then closes the client exactly once.
+- Anonymous TTL writes and compare-and-set leases release local keepalive resources after the operation.
+- Lease TTLs must be positive integers; `ttl` and an existing `lease` cannot be combined on one write.
+
 ## Exports
 
 - `EtcdModule`
@@ -69,4 +101,4 @@ export class SettingsStore {
 
 ## Notes
 
-The package owns generic etcd client creation, key-value operations, prefix reads, JSON helpers, local config caching, watches, leases, compare-and-set, cluster health, and lifecycle cleanup. Applications still own key naming, value schemas, cache TTL policy, and change-handling behavior.
+The package owns generic etcd client creation, key-value operations, prefix reads, JSON helpers, bounded local config caching, shared watches, leases, compare-and-set, cluster health, and lifecycle cleanup. Applications still own key naming, value schemas, cache policy overrides, and change-handling behavior.

--- a/packages/etcd/package.json
+++ b/packages/etcd/package.json
@@ -49,6 +49,7 @@
         "prepublishOnly": "pnpm run build"
     },
     "dependencies": {
+        "cockatiel": "^3.2.1",
         "etcd3": "^1.1.2"
     },
     "peerDependencies": {

--- a/packages/etcd/src/__tests__/index.spec.ts
+++ b/packages/etcd/src/__tests__/index.spec.ts
@@ -1,11 +1,12 @@
 import { EtcdConfigService } from '../config.service';
-import { ETCD_MODULE_OPTIONS } from '../etcd.types';
 import { EtcdModule } from '../etcd.module';
 import { EtcdService } from '../etcd.service';
+import { ETCD_MODULE_OPTIONS } from '../etcd.types';
 
 const mockEtcd3 = jest.fn();
 let mockClient: any;
 let mockWatcher: any;
+let mockWatchers: any[];
 
 jest.mock('etcd3', () => ({
     Etcd3: jest.fn().mockImplementation((options: Record<string, unknown>) => {
@@ -25,13 +26,17 @@ function kv(key: string, value: string, version = 1) {
 }
 
 function createLease(id: string, store: Map<string, string>) {
-    const lease = {
+    const lease: any = {
         grant: jest.fn(async () => id),
         keepaliveOnce: jest.fn(async () => undefined),
         revoke: jest.fn(async () => undefined),
         release: jest.fn(),
         put: jest.fn((key: string) => createPutBuilder(key, store)),
     };
+    lease.once = jest.fn((_event: string, handler: () => void) => {
+        lease.lostHandler = handler;
+        return lease;
+    });
     return lease;
 }
 
@@ -66,13 +71,23 @@ function createWatcher() {
     };
 }
 
+function flushAsyncWork(): Promise<void> {
+    return new Promise(resolve => setImmediate(resolve));
+}
+
 function createClient() {
     const store = new Map<string, string>([
         ['settings/api', JSON.stringify({ enabled: true })],
         ['settings/name', 'api'],
     ]);
     const lease = createLease('lease-1', store);
-    mockWatcher = createWatcher();
+    mockWatchers = [];
+
+    const nextWatcher = () => {
+        mockWatcher = createWatcher();
+        mockWatchers.push(mockWatcher);
+        return mockWatcher;
+    };
 
     return {
         get: jest.fn((key: string) => ({
@@ -110,10 +125,10 @@ function createClient() {
         },
         watch: jest.fn(() => ({
             key: jest.fn(() => ({
-                create: jest.fn(async () => mockWatcher),
+                create: jest.fn(async () => nextWatcher()),
             })),
             prefix: jest.fn(() => ({
-                create: jest.fn(async () => mockWatcher),
+                create: jest.fn(async () => nextWatcher()),
             })),
         })),
         maintenance: {
@@ -171,7 +186,7 @@ describe('etcd package', () => {
             endpoints: ['http://etcd:2379'],
             auth: { username: 'user', password: 'pass' },
             tls: { ca: 'ca', cert: 'cert', key: 'key' },
-            requestOptions: { timeout: 5000 },
+            requestOptions: { timeout: 5000, retry: 2 },
         });
 
         await service.onModuleInit();
@@ -189,8 +204,12 @@ describe('etcd package', () => {
                     certChain: Buffer.from('cert'),
                 }),
                 defaultCallOptions: expect.any(Function),
+                faultHandling: { global: expect.any(Object) },
             }),
         );
+        const clientOptions = mockEtcd3.mock.calls[0][0];
+        expect(clientOptions.defaultCallOptions({ isStream: true })).toEqual({});
+        expect(clientOptions.defaultCallOptions({ isStream: false }).deadline).toBeGreaterThan(Date.now());
         expect(health).toEqual({ healthy: true, leader: 'node-1', etcdVersion: '3.5.0' });
         expect(members).toEqual(['node-1']);
         expect(leader).toBe('node-1');
@@ -229,7 +248,7 @@ describe('etcd package', () => {
 
         const handleChange = jest.fn();
         const unsubscribe = service.watch('settings/api', handleChange);
-        await Promise.resolve();
+        await flushAsyncWork();
         mockWatcher.handlers.get('put')?.(kv('settings/api', 'changed', 2));
         mockWatcher.handlers.get('delete')?.(kv('settings/api', '', 3));
 
@@ -249,7 +268,7 @@ describe('etcd package', () => {
         });
 
         unsubscribe();
-        await Promise.resolve();
+        await flushAsyncWork();
         await service.revokeLease(lease.id);
         await service.onModuleDestroy();
 
@@ -257,8 +276,51 @@ describe('etcd package', () => {
         expect(mockClient.close).toHaveBeenCalled();
     });
 
+    it('tracks duplicate watchers independently and always completes shutdown cleanup', async () => {
+        const service = new EtcdService({ endpoints: ['http://etcd:2379'] });
+        await service.createLease(30);
+        const failedSubscriber = jest.fn(() => {
+            throw new Error('subscriber failed');
+        });
+        const firstStop = service.watch('settings/api', failedSubscriber);
+        service.watch('settings/api', jest.fn());
+        await flushAsyncWork();
+
+        expect(mockWatchers).toHaveLength(2);
+        expect(() => mockWatchers[0].handlers.get('put')?.(kv('settings/api', 'changed'))).not.toThrow();
+        mockWatchers[0].cancel.mockRejectedValueOnce(new Error('cancel failed'));
+        firstStop();
+        mockWatchers[0].handlers.get('put')?.(kv('settings/api', 'ignored'));
+        await flushAsyncWork();
+        await service.onModuleDestroy();
+        await service.onModuleDestroy();
+
+        expect(mockWatchers[0].cancel).toHaveBeenCalledTimes(1);
+        expect(mockWatchers[1].cancel).toHaveBeenCalledTimes(1);
+        expect(failedSubscriber).toHaveBeenCalledTimes(1);
+        expect(mockClient.lease.mock.results[0].value.release).toHaveBeenCalled();
+        expect(mockClient.close).toHaveBeenCalledTimes(1);
+        expect(() => service.watch('settings/api', jest.fn())).toThrow('shutdown has started');
+    });
+
+    it('validates connection and lease options', async () => {
+        expect(() => new EtcdService({ endpoints: [] })).toThrow('At least one etcd endpoint');
+        expect(() => new EtcdService({ endpoints: ['http://etcd:2379'], auth: { username: 'user' } })).toThrow(
+            'both username and password',
+        );
+        expect(() => new EtcdService({ endpoints: ['http://etcd:2379'], requestOptions: { retry: -1 } })).toThrow(
+            'non-negative integer',
+        );
+
+        const service = new EtcdService({ endpoints: ['http://etcd:2379'] });
+        await expect(service.createLease(0)).rejects.toThrow('positive integer');
+        await expect(service.set('key', 'value', { ttl: 10, lease: 'lease-1' })).rejects.toThrow(
+            'cannot be used together',
+        );
+    });
+
     it('caches configuration values and forwards subscriptions', async () => {
-        let watchCallback: ((event: { value: unknown }) => void) | undefined;
+        let watchCallback: ((event: { key: string; value: unknown | null }) => void) | undefined;
         const unsubscribe = jest.fn();
         const etcd = {
             get: jest.fn(async () => 'cached-value'),
@@ -268,7 +330,7 @@ describe('etcd package', () => {
             delete: jest.fn(async () => true),
             deleteByPrefix: jest.fn(async () => 1),
             exists: jest.fn(async () => true),
-            watch: jest.fn((_key: string, callback: (event: { value: unknown }) => void) => {
+            watch: jest.fn((_key: string, callback: (event: { key: string; value: unknown | null }) => void) => {
                 watchCallback = callback;
                 return unsubscribe;
             }),
@@ -283,12 +345,170 @@ describe('etcd package', () => {
 
         const subscriber = jest.fn();
         const stop = config.subscribe('settings/api', subscriber);
-        watchCallback?.({ value: 'changed' });
+        watchCallback?.({ key: 'settings/api', value: 'changed' });
+        watchCallback?.({ key: 'settings/api', value: null });
         stop();
 
         expect(etcd.get).toHaveBeenCalledTimes(1);
         expect(etcd.set).toHaveBeenCalledWith('settings/api', { enabled: false }, undefined);
         expect(subscriber).toHaveBeenCalledWith('changed');
+        expect(subscriber).toHaveBeenCalledWith(null);
         expect(unsubscribe).toHaveBeenCalled();
+    });
+
+    it('separates raw and JSON caches, coalesces reads, and prevents stale cache races', async () => {
+        let resolveRead: ((value: string | null) => void) | undefined;
+        let watchCallback: ((event: { key: string; value: string | null }) => void) | undefined;
+        const get = jest.fn(
+            () =>
+                new Promise<string | null>(resolve => {
+                    resolveRead = resolve;
+                }),
+        );
+        const etcd = {
+            get,
+            getJSON: jest.fn(async () => ({ enabled: true })),
+            watch: jest.fn((_key: string, callback: (event: { key: string; value: string | null }) => void) => {
+                watchCallback = callback;
+                return jest.fn();
+            }),
+        } as unknown as EtcdService;
+        const config = new EtcdConfigService(etcd);
+        config.subscribe('settings/api', jest.fn());
+
+        const first = config.get('settings/api');
+        const second = config.get('settings/api');
+        expect(get).toHaveBeenCalledTimes(1);
+        watchCallback?.({ key: 'settings/api', value: '{"enabled":false}' });
+        resolveRead?.('{"enabled":true}');
+
+        await expect(first).resolves.toBe('{"enabled":true}');
+        await expect(second).resolves.toBe('{"enabled":true}');
+        await expect(config.get('settings/api')).resolves.toBe('{"enabled":false}');
+        await expect(config.getJSON<{ enabled: boolean }>('settings/api')).resolves.toEqual({ enabled: false });
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(etcd.getJSON as jest.Mock).not.toHaveBeenCalled();
+    });
+
+    it('keeps write, delete, and prefix-watch cache entries coherent', async () => {
+        const values = new Map<string, string>([
+            ['settings/api', 'old'],
+            ['other/value', 'stable'],
+        ]);
+        let prefixCallback: ((event: { key: string; value: string | null }) => void) | undefined;
+        const prefixUnsubscribe = jest.fn();
+        const etcd = {
+            get: jest.fn(async (key: string) => values.get(key) ?? null),
+            getJSON: jest.fn(async (key: string) => {
+                const value = values.get(key);
+                return value === undefined ? null : JSON.parse(value);
+            }),
+            set: jest.fn(async (key: string, value: unknown) => {
+                values.set(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+            }),
+            delete: jest.fn(async (key: string) => values.delete(key)),
+            deleteByPrefix: jest.fn(async (prefix: string) => {
+                const keys = [...values.keys()].filter(key => key.startsWith(prefix));
+                for (const key of keys) values.delete(key);
+                return keys.length;
+            }),
+            watchPrefix: jest.fn(
+                (_prefix: string, callback: (event: { key: string; value: string | null }) => void) => {
+                    prefixCallback = callback;
+                    return prefixUnsubscribe;
+                },
+            ),
+        } as unknown as EtcdService;
+        const config = new EtcdConfigService(etcd);
+        const prefixSubscriber = jest.fn();
+        const stop = config.subscribePrefix('settings/', prefixSubscriber);
+
+        await expect(config.get('settings/api')).resolves.toBe('old');
+        await expect(config.get('other/value')).resolves.toBe('stable');
+        values.set('settings/api', 'new');
+        prefixCallback?.({ key: 'settings/api', value: 'new' });
+        await expect(config.get('settings/api')).resolves.toBe('new');
+        expect(etcd.get).toHaveBeenCalledTimes(2);
+
+        values.delete('settings/api');
+        prefixCallback?.({ key: 'settings/api', value: null });
+        await expect(config.get('settings/api')).resolves.toBeNull();
+        await expect(config.get('settings/api')).resolves.toBeNull();
+        expect(prefixSubscriber).toHaveBeenLastCalledWith({ key: 'settings/api', value: null });
+        expect(etcd.get).toHaveBeenCalledTimes(3);
+
+        await config.setJSON('settings/json', { enabled: true });
+        await expect(config.get('settings/json')).resolves.toBe('{"enabled":true}');
+        await expect(config.getJSON('settings/json')).resolves.toEqual({ enabled: true });
+        await config.deleteByPrefix('settings/');
+        await expect(config.get('settings/json')).resolves.toBeNull();
+        await expect(config.get('other/value')).resolves.toBe('stable');
+
+        stop();
+        expect(prefixUnsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports cache controls and validates cache configuration', async () => {
+        const etcd = {
+            get: jest.fn(async () => null),
+        } as unknown as EtcdService;
+        const config = new EtcdConfigService(etcd);
+
+        await config.get('missing');
+        await config.get('missing');
+        expect(etcd.get).toHaveBeenCalledTimes(1);
+
+        config.setCacheMissing(false);
+        await config.get('missing');
+        await config.get('missing');
+        expect(etcd.get).toHaveBeenCalledTimes(3);
+
+        config.setCacheTtl(0);
+        await config.get('missing');
+        await config.get('missing');
+        expect(etcd.get).toHaveBeenCalledTimes(5);
+        expect(() => config.setCacheTtl(-1)).toThrow('non-negative number');
+        expect(() => config.setCacheMaxEntries(-1)).toThrow('non-negative integer');
+        expect(
+            () =>
+                new EtcdConfigService(etcd, {
+                    endpoints: ['http://etcd:2379'],
+                    configCache: { maxEntries: 1.5 },
+                }),
+        ).toThrow('non-negative integer');
+    });
+
+    it('shares prefix watches, bounds the cache, and releases subscriptions on shutdown', async () => {
+        const exactUnsubscribe = jest.fn();
+        const prefixUnsubscribe = jest.fn();
+        const etcd = {
+            get: jest.fn(async (key: string) => key),
+            watch: jest.fn(() => exactUnsubscribe),
+            watchPrefix: jest.fn(() => prefixUnsubscribe),
+        } as unknown as EtcdService;
+        const config = new EtcdConfigService(etcd, {
+            endpoints: ['http://etcd:2379'],
+            configCache: { maxEntries: 1 },
+        });
+
+        await config.get('first');
+        await config.get('second');
+        await config.get('first');
+        expect(etcd.get).toHaveBeenCalledTimes(3);
+
+        const stopExactOne = config.subscribe('settings/api', jest.fn());
+        config.subscribe('settings/api', jest.fn());
+        config.subscribePrefix('settings/', jest.fn());
+        config.subscribePrefix('settings/', jest.fn());
+        expect(etcd.watch).toHaveBeenCalledTimes(1);
+        expect(etcd.watchPrefix).toHaveBeenCalledTimes(1);
+
+        stopExactOne();
+        expect(exactUnsubscribe).not.toHaveBeenCalled();
+        config.onModuleDestroy();
+        config.onModuleDestroy();
+        expect(exactUnsubscribe).toHaveBeenCalledTimes(1);
+        expect(prefixUnsubscribe).toHaveBeenCalledTimes(1);
+        expect(() => config.subscribe('settings/api', jest.fn())).toThrow('shutdown has started');
     });
 });

--- a/packages/etcd/src/config.service.ts
+++ b/packages/etcd/src/config.service.ts
@@ -1,66 +1,96 @@
-import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit, Optional } from '@nestjs/common';
 import { EtcdService } from './etcd.service';
+import { ETCD_MODULE_OPTIONS, type EtcdModuleOptions } from './etcd.types';
 
-export type ConfigSubscriber = (value: unknown) => void;
+export type ConfigSubscriber<T = unknown> = (value: T | null) => void | Promise<void>;
+
+export interface ConfigPrefixEvent<T = unknown> {
+    key: string;
+    value: T | null;
+}
+
+export type ConfigPrefixSubscriber<T = unknown> = (event: ConfigPrefixEvent<T>) => void | Promise<void>;
+
+type CacheKind = 'json' | 'raw';
+
+interface CacheEntry {
+    key: string;
+    value: unknown;
+    expiresAt: number;
+}
 
 /**
- * Distributed configuration service with hot-reload support
+ * Distributed configuration service with bounded, coherent caching and shared hot-reload watches.
  */
 @Injectable()
-export class EtcdConfigService implements OnModuleInit {
+export class EtcdConfigService implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(EtcdConfigService.name);
-    private subscribers: Map<string, Set<ConfigSubscriber>> = new Map();
-    private unsubscribers: Map<string, () => void> = new Map();
-    private cache: Map<string, { value: unknown; timestamp: number }> = new Map();
-    private cacheTtl = 5000;
+    private readonly subscribers = new Map<string, Set<ConfigSubscriber>>();
+    private readonly unsubscribers = new Map<string, () => void>();
+    private readonly prefixSubscribers = new Map<string, Set<ConfigPrefixSubscriber>>();
+    private readonly prefixUnsubscribers = new Map<string, () => void>();
+    private readonly cache = new Map<string, CacheEntry>();
+    private readonly inFlight = new Map<string, Promise<unknown | null>>();
+    private cacheTtl: number;
+    private cacheMaxEntries: number;
+    private cacheMissing: boolean;
+    private cacheEpoch = 0;
+    private destroyed = false;
 
-    constructor(private readonly etcd: EtcdService) {}
+    constructor(
+        private readonly etcd: EtcdService,
+        @Optional() @Inject(ETCD_MODULE_OPTIONS) options?: EtcdModuleOptions,
+    ) {
+        this.cacheTtl = options?.configCache?.ttl ?? 5000;
+        this.cacheMaxEntries = options?.configCache?.maxEntries ?? 1000;
+        this.cacheMissing = options?.configCache?.cacheMissing ?? true;
+        validateCacheTtl(this.cacheTtl);
+        validateCacheMaxEntries(this.cacheMaxEntries);
+    }
 
-    async onModuleInit() {
+    onModuleInit(): void {
         this.logger.log('EtcdConfigService initialized');
+    }
+
+    onModuleDestroy(): void {
+        if (this.destroyed) return;
+        this.destroyed = true;
+
+        for (const [key, unsubscribe] of this.unsubscribers) {
+            this.unsubscribeSafely(`key ${key}`, unsubscribe);
+        }
+        for (const [prefix, unsubscribe] of this.prefixUnsubscribers) {
+            this.unsubscribeSafely(`prefix ${prefix}`, unsubscribe);
+        }
+
+        this.subscribers.clear();
+        this.unsubscribers.clear();
+        this.prefixSubscribers.clear();
+        this.prefixUnsubscribers.clear();
+        this.clearCache();
+        this.inFlight.clear();
     }
 
     // ==================== Get Configuration ====================
 
     async get<T = string>(key: string, useCache = true): Promise<T | null> {
-        if (useCache) {
-            const cached = this.cache.get(key);
-            if (cached && Date.now() - cached.timestamp < this.cacheTtl) {
-                return cached.value as T;
-            }
-        }
-
-        const value = await this.etcd.get<T>(key);
-        if (value !== null) {
-            this.cache.set(key, { value, timestamp: Date.now() });
-        }
-        return value;
+        return this.readThrough('raw', key, useCache, () => this.etcd.get<T>(key));
     }
 
     async getJSON<T = unknown>(key: string, useCache = true): Promise<T | null> {
-        if (useCache) {
-            const cached = this.cache.get(key);
-            if (cached && Date.now() - cached.timestamp < this.cacheTtl) {
-                return cached.value as T;
-            }
-        }
-
-        const value = await this.etcd.getJSON<T>(key);
-        if (value !== null) {
-            this.cache.set(key, { value, timestamp: Date.now() });
-        }
-        return value;
+        return this.readThrough('json', key, useCache, () => this.etcd.getJSON<T>(key));
     }
 
     async getByPrefix<T = unknown>(prefix: string): Promise<Map<string, T>> {
-        return await this.etcd.getEntriesAsJSON<T>(prefix);
+        return this.etcd.getEntriesAsJSON<T>(prefix);
     }
 
     // ==================== Set Configuration ====================
 
     async set(key: string, value: string | number | boolean | object, options?: { ttl?: number }): Promise<void> {
         await this.etcd.set(key, value, options);
-        this.cache.set(key, { value, timestamp: Date.now() });
+        this.invalidateKey(key);
+        this.cacheWrittenValue(key, value, options?.ttl);
     }
 
     async setJSON<T extends object>(key: string, value: T, options?: { ttl?: number }): Promise<void> {
@@ -71,81 +101,273 @@ export class EtcdConfigService implements OnModuleInit {
 
     async delete(key: string): Promise<boolean> {
         const result = await this.etcd.delete(key);
-        this.cache.delete(key);
+        this.invalidateKey(key);
         return result;
     }
 
     async deleteByPrefix(prefix: string): Promise<number> {
         const count = await this.etcd.deleteByPrefix(prefix);
-        for (const key of this.cache.keys()) {
-            if (key.startsWith(prefix)) {
-                this.cache.delete(key);
-            }
-        }
+        this.invalidatePrefix(prefix);
         return count;
     }
 
     // ==================== Hot Reload ====================
 
-    subscribe<T = string>(key: string, callback: (value: T) => void): () => void {
+    subscribe<T = string>(key: string, callback: ConfigSubscriber<T>): () => void {
+        this.assertActive();
         if (!this.subscribers.has(key)) {
             this.subscribers.set(key, new Set());
-
             const unsubscribe = this.etcd.watch<T>(key, event => {
-                const subs = this.subscribers.get(key);
-                if (subs) {
-                    if (event.value !== null) {
-                        this.cache.set(key, { value: event.value, timestamp: Date.now() });
-                        subs.forEach(cb => {
-                            cb(event.value as T);
-                        });
-                    }
+                this.invalidateKey(event.key);
+                if (event.value !== null) {
+                    this.cacheWatchedValue(event.key, event.value);
+                }
+                const subscribers = this.subscribers.get(key);
+                if (!subscribers) return;
+
+                for (const subscriber of [...subscribers]) {
+                    this.notifySubscriber(`key ${key}`, subscriber, event.value);
                 }
             });
-
             this.unsubscribers.set(key, unsubscribe);
         }
 
-        this.subscribers.get(key)!.add(callback as ConfigSubscriber);
+        const subscriber = callback as ConfigSubscriber;
+        this.subscribers.get(key)!.add(subscriber);
 
+        let unsubscribed = false;
         return () => {
-            const subs = this.subscribers.get(key);
-            if (subs) {
-                subs.delete(callback as ConfigSubscriber);
-                if (subs.size === 0) {
-                    const unsub = this.unsubscribers.get(key);
-                    if (unsub) {
-                        unsub();
-                        this.unsubscribers.delete(key);
-                    }
-                    this.subscribers.delete(key);
-                }
+            if (unsubscribed) return;
+            unsubscribed = true;
+            const subscribers = this.subscribers.get(key);
+            if (!subscribers) return;
+
+            subscribers.delete(subscriber);
+            if (subscribers.size > 0) return;
+
+            const unsubscribe = this.unsubscribers.get(key);
+            if (unsubscribe) {
+                this.unsubscribeSafely(`key ${key}`, unsubscribe);
             }
+            this.unsubscribers.delete(key);
+            this.subscribers.delete(key);
         };
     }
 
-    subscribePrefix<T = string>(
-        prefix: string,
-        callback: (event: { key: string; value: T | null }) => void,
-    ): () => void {
-        const unsubscribe = this.etcd.watchPrefix<T>(prefix, event => {
-            callback({ key: event.key, value: event.value });
-        });
+    subscribePrefix<T = string>(prefix: string, callback: ConfigPrefixSubscriber<T>): () => void {
+        this.assertActive();
+        if (!this.prefixSubscribers.has(prefix)) {
+            this.prefixSubscribers.set(prefix, new Set());
+            const unsubscribe = this.etcd.watchPrefix<T>(prefix, event => {
+                this.invalidateKey(event.key);
+                if (event.value !== null) {
+                    this.cacheWatchedValue(event.key, event.value);
+                }
+                const subscribers = this.prefixSubscribers.get(prefix);
+                if (!subscribers) return;
 
-        return unsubscribe;
+                const change = { key: event.key, value: event.value };
+                for (const subscriber of [...subscribers]) {
+                    this.notifySubscriber(`prefix ${prefix}`, subscriber, change);
+                }
+            });
+            this.prefixUnsubscribers.set(prefix, unsubscribe);
+        }
+
+        const subscriber = callback as ConfigPrefixSubscriber;
+        this.prefixSubscribers.get(prefix)!.add(subscriber);
+
+        let unsubscribed = false;
+        return () => {
+            if (unsubscribed) return;
+            unsubscribed = true;
+            const subscribers = this.prefixSubscribers.get(prefix);
+            if (!subscribers) return;
+
+            subscribers.delete(subscriber);
+            if (subscribers.size > 0) return;
+
+            const unsubscribe = this.prefixUnsubscribers.get(prefix);
+            if (unsubscribe) {
+                this.unsubscribeSafely(`prefix ${prefix}`, unsubscribe);
+            }
+            this.prefixUnsubscribers.delete(prefix);
+            this.prefixSubscribers.delete(prefix);
+        };
     }
 
     // ==================== Utility ====================
 
     async exists(key: string): Promise<boolean> {
-        return await this.etcd.exists(key);
+        return this.etcd.exists(key);
     }
 
     clearCache(): void {
+        this.cacheEpoch += 1;
         this.cache.clear();
     }
 
     setCacheTtl(ttl: number): void {
+        validateCacheTtl(ttl);
         this.cacheTtl = ttl;
+        this.clearCache();
+    }
+
+    setCacheMaxEntries(maxEntries: number): void {
+        validateCacheMaxEntries(maxEntries);
+        this.cacheMaxEntries = maxEntries;
+        while (this.cache.size > maxEntries) {
+            const oldest = this.cache.keys().next().value;
+            if (oldest === undefined) break;
+            this.cache.delete(oldest);
+        }
+    }
+
+    setCacheMissing(cacheMissing: boolean): void {
+        this.cacheMissing = cacheMissing;
+        this.clearCache();
+    }
+
+    private async readThrough<T>(
+        kind: CacheKind,
+        key: string,
+        useCache: boolean,
+        load: () => Promise<T | null>,
+    ): Promise<T | null> {
+        if (!useCache || this.cacheTtl === 0 || this.cacheMaxEntries === 0) {
+            return load();
+        }
+
+        const cacheKey = createCacheKey(kind, key);
+        const cached = this.readCache(cacheKey);
+        if (cached.hit) {
+            return cached.value as T | null;
+        }
+
+        const pending = this.inFlight.get(cacheKey);
+        if (pending) {
+            return pending as Promise<T | null>;
+        }
+
+        const epoch = this.cacheEpoch;
+        let request: Promise<T | null>;
+        request = load()
+            .then(value => {
+                if (epoch === this.cacheEpoch && (value !== null || this.cacheMissing)) {
+                    this.writeCache(kind, key, value);
+                }
+                return value;
+            })
+            .finally(() => {
+                if (this.inFlight.get(cacheKey) === request) {
+                    this.inFlight.delete(cacheKey);
+                }
+            });
+        this.inFlight.set(cacheKey, request);
+        return request;
+    }
+
+    private readCache(cacheKey: string): { hit: boolean; value?: unknown } {
+        const entry = this.cache.get(cacheKey);
+        if (!entry) return { hit: false };
+        if (entry.expiresAt <= Date.now()) {
+            this.cache.delete(cacheKey);
+            return { hit: false };
+        }
+
+        this.cache.delete(cacheKey);
+        this.cache.set(cacheKey, entry);
+        return { hit: true, value: entry.value };
+    }
+
+    private writeCache(kind: CacheKind, key: string, value: unknown, ttlSeconds?: number): void {
+        if (this.cacheTtl === 0 || this.cacheMaxEntries === 0) return;
+        const lifetime = ttlSeconds === undefined ? this.cacheTtl : Math.min(this.cacheTtl, ttlSeconds * 1000);
+        if (lifetime <= 0) return;
+
+        const cacheKey = createCacheKey(kind, key);
+        this.cache.delete(cacheKey);
+        this.cache.set(cacheKey, { key, value, expiresAt: Date.now() + lifetime });
+        while (this.cache.size > this.cacheMaxEntries) {
+            const oldest = this.cache.keys().next().value;
+            if (oldest === undefined) break;
+            this.cache.delete(oldest);
+        }
+    }
+
+    private invalidateKey(key: string): void {
+        this.cacheEpoch += 1;
+        this.cache.delete(createCacheKey('raw', key));
+        this.cache.delete(createCacheKey('json', key));
+    }
+
+    private invalidatePrefix(prefix: string): void {
+        this.cacheEpoch += 1;
+        for (const [cacheKey, entry] of this.cache) {
+            if (entry.key.startsWith(prefix)) {
+                this.cache.delete(cacheKey);
+            }
+        }
+    }
+
+    private cacheWrittenValue(key: string, value: string | number | boolean | object, ttl?: number): void {
+        const serialized = typeof value === 'object' ? JSON.stringify(value) : String(value);
+        this.writeCache('raw', key, serialized, ttl);
+        this.cacheJsonValue(key, serialized, ttl);
+    }
+
+    private cacheWatchedValue(key: string, value: unknown): void {
+        this.writeCache('raw', key, value);
+        if (typeof value === 'string') {
+            this.cacheJsonValue(key, value);
+        }
+    }
+
+    private cacheJsonValue(key: string, serialized: string, ttl?: number): void {
+        try {
+            this.writeCache('json', key, JSON.parse(serialized), ttl);
+        } catch {
+            this.cache.delete(createCacheKey('json', key));
+        }
+    }
+
+    private notifySubscriber<T>(label: string, callback: (value: T) => void | Promise<void>, value: T): void {
+        try {
+            void Promise.resolve(callback(value)).catch(error => {
+                this.logger.error(`Configuration subscriber failed for ${label}`, error);
+            });
+        } catch (error) {
+            this.logger.error(`Configuration subscriber failed for ${label}`, error);
+        }
+    }
+
+    private unsubscribeSafely(label: string, unsubscribe: () => void): void {
+        try {
+            unsubscribe();
+        } catch (error) {
+            this.logger.error(`Failed to unsubscribe configuration watcher for ${label}`, error);
+        }
+    }
+
+    private assertActive(): void {
+        if (this.destroyed) {
+            throw new Error('Cannot subscribe after EtcdConfigService shutdown has started');
+        }
+    }
+}
+
+function createCacheKey(kind: CacheKind, key: string): string {
+    return `${kind}:${key}`;
+}
+
+function validateCacheTtl(ttl: number): void {
+    if (!Number.isFinite(ttl) || ttl < 0) {
+        throw new Error('Etcd configuration cache TTL must be a non-negative number');
+    }
+}
+
+function validateCacheMaxEntries(maxEntries: number): void {
+    if (!Number.isInteger(maxEntries) || maxEntries < 0) {
+        throw new Error('Etcd configuration cache maxEntries must be a non-negative integer');
     }
 }

--- a/packages/etcd/src/etcd.module.ts
+++ b/packages/etcd/src/etcd.module.ts
@@ -1,14 +1,10 @@
-import {
-    Global,
-    Module,
-    type DynamicModule,
-    type FactoryProvider,
-    type ModuleMetadata,
-    type Provider,
-} from '@nestjs/common';
-import { ETCD_MODULE_OPTIONS, type EtcdModuleOptions } from './etcd.types';
-import { EtcdService } from './etcd.service';
+import { type DynamicModule, type FactoryProvider, Global, Module, type ModuleMetadata } from '@nestjs/common';
 import { EtcdConfigService } from './config.service';
+import { EtcdService } from './etcd.service';
+import { ETCD_MODULE_OPTIONS, type EtcdModuleOptions } from './etcd.types';
+
+export type EtcdModuleAsyncOptions = Pick<ModuleMetadata, 'imports'> &
+    Pick<FactoryProvider<EtcdModuleOptions>, 'inject' | 'useFactory'>;
 
 @Global()
 @Module({})
@@ -28,25 +24,19 @@ export class EtcdModule {
         };
     }
 
-    static registerAsync(options: {
-        imports?: ModuleMetadata['imports'];
-        useFactory?: (...args: unknown[]) => Promise<EtcdModuleOptions> | EtcdModuleOptions;
-        inject?: FactoryProvider['inject'];
-    }): DynamicModule {
-        const asyncProviders: Provider[] = [];
-
-        if (options.useFactory) {
-            asyncProviders.push({
-                provide: ETCD_MODULE_OPTIONS,
-                useFactory: options.useFactory,
-                inject: options.inject ?? [],
-            });
-        }
-
+    static registerAsync(options: EtcdModuleAsyncOptions): DynamicModule {
         return {
             module: EtcdModule,
             imports: options.imports,
-            providers: [...asyncProviders, EtcdService, EtcdConfigService],
+            providers: [
+                {
+                    provide: ETCD_MODULE_OPTIONS,
+                    useFactory: options.useFactory,
+                    inject: options.inject ?? [],
+                },
+                EtcdService,
+                EtcdConfigService,
+            ],
             exports: [EtcdService, EtcdConfigService],
         };
     }

--- a/packages/etcd/src/etcd.service.ts
+++ b/packages/etcd/src/etcd.service.ts
@@ -1,8 +1,17 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
-import { Etcd3, type IKeyValue, type IOptions, type IStatusResponse, type Lease, type Watcher } from 'etcd3';
+import { retry as createRetryPolicy, handleWhen } from 'cockatiel';
 import {
-    ETCD_MODULE_OPTIONS,
+    Etcd3,
+    type IKeyValue,
+    type IOptions,
+    type IStatusResponse,
+    isRecoverableError,
+    type Lease,
+    type Watcher,
+} from 'etcd3';
+import {
     type ConfigEntry,
+    ETCD_MODULE_OPTIONS,
     type EtcdModuleOptions,
     type HealthResult,
     type LeaseInfo,
@@ -13,10 +22,16 @@ import {
 export class EtcdService implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(EtcdService.name);
     private readonly client: Etcd3;
-    private readonly watchers = new Map<string, Promise<Watcher>>();
+    private readonly watchers = new Map<number, WatchRegistration>();
     private readonly leases = new Map<string, Lease>();
+    private nextWatcherId = 0;
+    private destroyPromise?: Promise<void>;
 
     constructor(@Inject(ETCD_MODULE_OPTIONS) private readonly options: EtcdModuleOptions) {
+        validateOptions(this.options);
+
+        const timeout = this.options.requestOptions?.timeout;
+        const retry = this.options.requestOptions?.retry;
         const etcdOptions: IOptions = {
             hosts: this.options.endpoints,
             credentials: this.options.tls
@@ -33,9 +48,15 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
                           password: this.options.auth.password,
                       }
                     : undefined,
-            defaultCallOptions: this.options.requestOptions?.timeout
-                ? () => ({ deadline: Date.now() + this.options.requestOptions!.timeout! })
+            defaultCallOptions: timeout
+                ? context => (context.isStream ? {} : { deadline: Date.now() + timeout })
                 : undefined,
+            faultHandling:
+                retry === undefined
+                    ? undefined
+                    : {
+                          global: createRetryPolicy(handleWhen(isRecoverableError), { maxAttempts: retry }),
+                      },
         };
 
         this.client = new Etcd3(etcdOptions);
@@ -55,23 +76,8 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
     }
 
     async onModuleDestroy(): Promise<void> {
-        try {
-            for (const [key, watcher] of this.watchers) {
-                this.logger.debug(`Canceling watcher: ${key}`);
-                await (await watcher).cancel();
-            }
-            this.watchers.clear();
-
-            for (const lease of this.leases.values()) {
-                lease.release();
-            }
-            this.leases.clear();
-
-            this.client.close();
-            this.logger.log('Etcd connection closed');
-        } catch (error) {
-            this.logger.error('Error closing etcd connection', error);
-        }
+        this.destroyPromise ??= this.destroyResources();
+        await this.destroyPromise;
     }
 
     async get<T = string>(key: string): Promise<T | null> {
@@ -96,11 +102,21 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
     ): Promise<void> {
         const serialized = serializeValue(value);
 
-        if (options?.ttl && !options.lease) {
+        if (options?.ttl !== undefined) {
+            validateTtl(options.ttl);
+        }
+        if (options?.ttl !== undefined && options.lease) {
+            throw new Error('ttl and lease cannot be used together');
+        }
+
+        if (options?.ttl !== undefined) {
             const lease = this.client.lease(options.ttl, { autoKeepAlive: false });
-            const leaseId = await lease.grant();
-            this.leases.set(String(leaseId), lease);
-            await lease.put(key).value(serialized).exec();
+            try {
+                await lease.grant();
+                await lease.put(key).value(serialized).exec();
+            } finally {
+                lease.release();
+            }
             return;
         }
 
@@ -136,7 +152,7 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
             value: decodeBuffer(kv.value) as T,
             version: Number(kv.version),
             revision: Number(kv.mod_revision),
-            created: kv.create_revision === kv.mod_revision,
+            created: Number(kv.create_revision) === Number(kv.mod_revision),
         }));
     }
 
@@ -156,10 +172,17 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
     }
 
     async createLease(ttl: number): Promise<LeaseInfo> {
+        validateTtl(ttl);
         const lease = this.client.lease(ttl);
         const id = await lease.grant();
-        this.leases.set(String(id), lease);
-        return { id: String(id), ttl, remainingTTL: ttl };
+        const leaseId = String(id);
+        this.leases.set(leaseId, lease);
+        lease.once('lost', () => {
+            if (this.leases.get(leaseId) === lease) {
+                this.leases.delete(leaseId);
+            }
+        });
+        return { id: leaseId, ttl, remainingTTL: ttl };
     }
 
     async grantLease(ttl: number): Promise<string> {
@@ -185,41 +208,11 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
     }
 
     watch<T = string>(key: string, callback: WatchCallback<T>): () => void {
-        const watcher = this.client
-            .watch()
-            .key(key)
-            .create()
-            .then(watcher => {
-                this.attachWatcherHandlers(watcher, key, callback);
-                return watcher;
-            });
-        this.watchers.set(key, watcher);
-
-        return () => {
-            void watcher
-                .then(w => w.cancel())
-                .catch(error => this.logger.error(`Cancel watcher failed: ${key}`, error));
-            this.watchers.delete(key);
-        };
+        return this.registerWatcher(key, () => this.client.watch().key(key).create(), callback);
     }
 
     watchPrefix<T = string>(prefix: string, callback: WatchCallback<T>): () => void {
-        const watcher = this.client
-            .watch()
-            .prefix(prefix)
-            .create()
-            .then(watcher => {
-                this.attachWatcherHandlers(watcher, prefix, callback);
-                return watcher;
-            });
-        this.watchers.set(prefix, watcher);
-
-        return () => {
-            void watcher
-                .then(w => w.cancel())
-                .catch(error => this.logger.error(`Cancel watcher failed: ${prefix}`, error));
-            this.watchers.delete(prefix);
-        };
+        return this.registerWatcher(prefix, () => this.client.watch().prefix(prefix).create(), callback);
     }
 
     async healthCheck(): Promise<HealthResult> {
@@ -255,15 +248,22 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
         newValue: string,
         options?: { ttl?: number },
     ): Promise<boolean> {
+        if (options?.ttl !== undefined) {
+            validateTtl(options.ttl);
+        }
         const comparison =
             expectedValue === null
                 ? this.client.if(key, 'Create', '==', 0)
                 : this.client.if(key, 'Value', '==', expectedValue);
-        const put = options?.ttl
-            ? this.client.lease(options.ttl, { autoKeepAlive: false }).put(key).value(newValue)
-            : this.client.put(key).value(newValue);
-        const result = await comparison.then(put).commit();
-        return result.succeeded;
+        const lease = options?.ttl === undefined ? undefined : this.client.lease(options.ttl, { autoKeepAlive: false });
+        const put = lease ? lease.put(key).value(newValue) : this.client.put(key).value(newValue);
+
+        try {
+            const result = await comparison.then(put).commit();
+            return result.succeeded;
+        } finally {
+            lease?.release();
+        }
     }
 
     getClient(): Etcd3 {
@@ -274,9 +274,55 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
         return this.client.maintenance.status();
     }
 
+    private registerWatcher<T>(label: string, create: () => Promise<Watcher>, callback: WatchCallback<T>): () => void {
+        if (this.destroyPromise) {
+            throw new Error('Cannot create an etcd watcher after shutdown has started');
+        }
+
+        const id = ++this.nextWatcherId;
+        let active = true;
+        let cancellation: Promise<void> | undefined;
+        const watcher = Promise.resolve()
+            .then(create)
+            .then(created => {
+                this.attachWatcherHandlers<T>(created, label, event => {
+                    if (active) {
+                        return callback(event);
+                    }
+                });
+                return created;
+            })
+            .catch(error => {
+                this.watchers.delete(id);
+                this.logger.error(`Create watcher failed: ${label}`, error);
+                return undefined;
+            });
+        const registration: WatchRegistration = {
+            label,
+            cancel: () => {
+                active = false;
+                cancellation ??= watcher
+                    .then(created => created?.cancel())
+                    .then(() => undefined)
+                    .finally(() => {
+                        this.watchers.delete(id);
+                    });
+                return cancellation;
+            },
+        };
+        this.watchers.set(id, registration);
+
+        let unsubscribed = false;
+        return () => {
+            if (unsubscribed) return;
+            unsubscribed = true;
+            void registration.cancel().catch(error => this.logger.error(`Cancel watcher failed: ${label}`, error));
+        };
+    }
+
     private attachWatcherHandlers<T>(watcher: Watcher, label: string, callback: WatchCallback<T>): void {
         watcher.on('put', kv => {
-            callback({
+            this.invokeWatchCallback(label, callback, {
                 type: 'put',
                 key: decodeBuffer(kv.key),
                 value: decodeBuffer(kv.value) as T,
@@ -286,7 +332,7 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
         });
 
         watcher.on('delete', kv => {
-            callback({
+            this.invokeWatchCallback(label, callback, {
                 type: 'delete',
                 key: decodeBuffer(kv.key),
                 value: null,
@@ -299,6 +345,56 @@ export class EtcdService implements OnModuleInit, OnModuleDestroy {
             this.logger.error(`Watch error for ${label}:`, error);
         });
     }
+
+    private invokeWatchCallback<T>(
+        label: string,
+        callback: WatchCallback<T>,
+        event: Parameters<WatchCallback<T>>[0],
+    ): void {
+        try {
+            void Promise.resolve(callback(event)).catch(error => {
+                this.logger.error(`Watch callback failed: ${label}`, error);
+            });
+        } catch (error) {
+            this.logger.error(`Watch callback failed: ${label}`, error);
+        }
+    }
+
+    private async destroyResources(): Promise<void> {
+        const watcherResults = await Promise.allSettled(
+            [...this.watchers.values()].map(async registration => {
+                this.logger.debug(`Canceling watcher: ${registration.label}`);
+                await registration.cancel();
+            }),
+        );
+        this.watchers.clear();
+        for (const result of watcherResults) {
+            if (result.status === 'rejected') {
+                this.logger.error('Error canceling etcd watcher', result.reason);
+            }
+        }
+
+        for (const lease of this.leases.values()) {
+            try {
+                lease.release();
+            } catch (error) {
+                this.logger.error('Error releasing etcd lease', error);
+            }
+        }
+        this.leases.clear();
+
+        try {
+            this.client.close();
+            this.logger.log('Etcd connection closed');
+        } catch (error) {
+            this.logger.error('Error closing etcd connection', error);
+        }
+    }
+}
+
+interface WatchRegistration {
+    label: string;
+    cancel: () => Promise<void>;
 }
 
 function serializeValue(value: string | number | boolean | object): string | number {
@@ -313,4 +409,34 @@ function serializeValue(value: string | number | boolean | object): string | num
 
 function decodeBuffer(value: IKeyValue['key']): string {
     return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function validateOptions(options: EtcdModuleOptions): void {
+    if (!Array.isArray(options.endpoints) || options.endpoints.length === 0) {
+        throw new Error('At least one etcd endpoint is required');
+    }
+    if (options.endpoints.some(endpoint => typeof endpoint !== 'string' || endpoint.trim().length === 0)) {
+        throw new Error('Etcd endpoints must be non-empty strings');
+    }
+    if (Boolean(options.auth?.username) !== Boolean(options.auth?.password)) {
+        throw new Error('Etcd auth requires both username and password');
+    }
+    if (Boolean(options.tls?.cert) !== Boolean(options.tls?.key)) {
+        throw new Error('Etcd TLS client authentication requires both cert and key');
+    }
+
+    const timeout = options.requestOptions?.timeout;
+    if (timeout !== undefined && (!Number.isFinite(timeout) || timeout <= 0)) {
+        throw new Error('Etcd request timeout must be a positive number');
+    }
+    const retry = options.requestOptions?.retry;
+    if (retry !== undefined && (!Number.isInteger(retry) || retry < 0)) {
+        throw new Error('Etcd retry count must be a non-negative integer');
+    }
+}
+
+function validateTtl(ttl: number): void {
+    if (!Number.isInteger(ttl) || ttl <= 0) {
+        throw new Error('Etcd lease TTL must be a positive integer');
+    }
 }

--- a/packages/etcd/src/etcd.types.ts
+++ b/packages/etcd/src/etcd.types.ts
@@ -22,6 +22,15 @@ export interface EtcdModuleOptions {
         timeout?: number;
         retry?: number;
     };
+    /** Local configuration cache options */
+    configCache?: {
+        /** Cache lifetime in milliseconds. Set to 0 to disable caching. */
+        ttl?: number;
+        /** Maximum number of typed cache entries. Set to 0 to disable caching. */
+        maxEntries?: number;
+        /** Cache missing keys for the configured TTL. Defaults to true. */
+        cacheMissing?: boolean;
+    };
 }
 
 /**
@@ -43,7 +52,7 @@ export interface WatchEvent<T = unknown> {
 /**
  * Watch callback function
  */
-export type WatchCallback<T = unknown> = (event: WatchEvent<T>) => void;
+export type WatchCallback<T = unknown> = (event: WatchEvent<T>) => void | Promise<void>;
 
 /**
  * Configuration entry

--- a/packages/etcd/src/index.ts
+++ b/packages/etcd/src/index.ts
@@ -1,4 +1,4 @@
+export * from './config.service';
 export * from './etcd.module';
 export * from './etcd.service';
-export * from './config.service';
 export * from './etcd.types';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
 
   packages/etcd:
     dependencies:
+      cockatiel:
+        specifier: ^3.2.1
+        version: 3.2.1
       etcd3:
         specifier: ^1.1.2
         version: 1.1.2


### PR DESCRIPTION
## Summary
- track duplicate etcd watchers independently, isolate callback failures, and make shutdown cleanup exhaustive and idempotent
- add bounded typed config caching with request coalescing, negative-cache controls, delete coherency, shared subscriptions, and stale-read protection
- honor retry configuration, validate connection and lease options, release anonymous lease resources, and require a valid async options factory
- update root/package READMEs and add a minor Changeset

## Verification
- pnpm release:check
- pnpm smoke:core-install
- pnpm audit:prod
- @a3s-lab/etcd Jest coverage: 11 tests, 84.42% statements