### PR TITLE
feat: harden NATS messaging lifecycle

### DIFF
--- a/.changeset/reliable-nats-lifecycle.md
+++ b/.changeset/reliable-nats-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/nats": minor
+---
+
+Add validated first-party NATS connection options, nested authentication and complete TLS mapping, connection single-flight and recovery, bounded health/flush probes, multi-response requests, message response helpers, instance-owned subscription completion controls, strict JetStream acknowledgement handling, structured error causes, and one bounded drain-or-close lifecycle.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/redisson` | NestJS Redisson module, Redis service helpers, single-node Redis option builders, and public Redis/Redisson API re-exports. |
 | `@a3s-lab/resilience` | Retry, circuit breaker, cache, rate limiting, distributed lock decorators, services, guards, and interceptors. |
 | `@a3s-lab/bullmq` | NestJS BullMQ module, queue service helpers, worker lifecycle, queue metrics, and cleanup helpers. |
-| `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
+| `@a3s-lab/nats` | Lifecycle-safe NATS messaging with validated SDK options, connection single-flight, request-many helpers, owned subscriptions, JetStream acknowledgement policy, active health probes, and bounded shutdown. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |

--- a/docs/framework-core.md
+++ b/docs/framework-core.md
@@ -16,7 +16,7 @@ Nestify separates reusable backend API capabilities from the sample application.
 | `@a3s-lab/kysely` | NestJS Kysely module, query logging, and PostgreSQL option builders for API database wiring. |
 | `@a3s-lab/redisson` | NestJS Redisson module, Redis service helpers, and single-node Redis option builders. |
 | `@a3s-lab/bullmq` | NestJS BullMQ module, queue service helpers, worker lifecycle, and queue metrics for background tasks. |
-| `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
+| `@a3s-lab/nats` | Validated NATS SDK configuration, race-safe connection ownership, request-many and response helpers, owned subscriptions, JetStream acknowledgement policy, active health probes, and bounded drain/close. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
@@ -63,6 +63,8 @@ The NestJS integration packages accept NestJS 10 and 11 peers. Workspace builds,
   excess labels aggregate into a fixed overflow series, and HTTP paths come only from route templates or a fixed
   unmatched label.
 - Automatic migrations are fail-closed and require an explicit module or environment opt-in in production.
+- NATS connection attempts are coalesced, stale connection events cannot overwrite active state, subscription handles are
+  instance-owned, health checks perform bounded broker round trips, and shutdown has one total drain/close deadline.
 
 ## Sample API Wiring
 
@@ -134,7 +136,8 @@ The framework core is covered by package tests for:
 - Kysely PostgreSQL option builders and module registration
 - Redisson Redis option builders and module registration
 - BullMQ queue creation, worker lifecycle, metrics, and module registration
-- NATS module registration, publish/request encoding, subscriptions, JetStream publishing, and lifecycle cleanup
+- NATS option validation, connection races and recovery, publish/request-many encoding, response helpers, owned
+  subscriptions, JetStream acknowledgement behavior, active health probes, and bounded lifecycle cleanup
 - RustFS client registration, bucket/object commands, presigned URLs, multipart uploads, error mapping, and health checks
 - Etcd client registration, key-value operations, config cache, watches, leases, compare-and-set, health checks, and lifecycle cleanup
 - ClickHouse client routing and lifecycle

--- a/packages/nats/README.md
+++ b/packages/nats/README.md
@@ -1,6 +1,6 @@
 # @a3s-lab/nats
 
-NestJS module and service helpers for NATS publish/subscribe, request/reply, and JetStream messaging.
+Lifecycle-safe NestJS integration for core NATS publish/subscribe, request/reply, connection health, and JetStream messaging.
 
 ## Install
 
@@ -10,68 +10,179 @@ pnpm add @a3s-lab/nats @nestjs/common nats
 
 ## Use
 
+Register the module synchronously or asynchronously. The module connects during Nest initialization, coalesces concurrent connection attempts, and can reconnect lazily after an unexpected close.
+
 ```ts
+import { Module } from '@nestjs/common';
 import { NatsModule } from '@a3s-lab/nats';
 
 @Module({
     imports: [
         NatsModule.register({
-            servers: ['nats://localhost:4222'],
-            name: 'api-service',
-            timeout: 5000,
-            jetstream: { enabled: true },
+            servers: ['nats://nats-a:4222', 'nats://nats-b:4222'],
+            name: 'resource-api',
+            auth: {
+                user: process.env.NATS_USER,
+                pass: process.env.NATS_PASSWORD,
+            },
+            requestTimeoutMs: 5_000,
+            shutdownTimeoutMs: 10_000,
+            jetstream: { enabled: true, domain: 'A3S' },
         }),
     ],
 })
-export class AppModule {}
+export class MessagingModule {}
 ```
 
-Inject the service to publish events, send requests, and create subscriptions:
+`servers` accepts either one string or an array. Token authentication and username/password authentication are mutually exclusive. Top-level `user`, `pass`, and `token` remain supported; the nested `auth` object is useful for configuration factories. Invalid or conflicting options fail during provider construction with `NatsConfigurationError`.
+
+TLS accepts file paths or inline PEM values:
+
+```ts
+NatsModule.register({
+    servers: 'tls://nats.internal:4222',
+    tls: {
+        caFile: '/run/secrets/nats-ca.pem',
+        certFile: '/run/secrets/nats-client.pem',
+        keyFile: '/run/secrets/nats-client-key.pem',
+        rejectUnauthorized: true,
+    },
+});
+```
+
+`verify` is retained as an alias for `rejectUnauthorized`. Certificate verification defaults to `true`; disabling it should be limited to controlled development environments.
+
+The exported option builder returns the exact validated object passed to the first-party NATS client:
+
+```ts
+import { createNatsConnectionOptions } from '@a3s-lab/nats';
+
+const connection = createNatsConnectionOptions({
+    servers: 'nats://localhost:4222',
+    maxReconnectAttempts: 20,
+});
+```
+
+### Publish and request/reply
 
 ```ts
 import { Injectable } from '@nestjs/common';
 import { NatsService } from '@a3s-lab/nats';
 
 @Injectable()
-export class ResourceEvents {
+export class ResourceMessaging {
     constructor(private readonly nats: NatsService) {}
 
     async publishChanged(resourceId: string) {
         await this.nats.publish({
             subject: 'resources.changed',
             data: { resourceId },
+            headers: { 'x-schema-version': '1' },
         });
+
+        // Core NATS publish is buffered. Flush only when a server round trip is required.
+        await this.nats.flush();
     }
 
-    async lookup(resourceId: string) {
-        return this.nats.request$<{ status: string }>('resources.lookup', {
-            resourceId,
-        });
+    lookup(resourceId: string) {
+        return this.nats.request$<{ status: string }>('resources.lookup', { resourceId });
     }
 
-    async subscribe() {
-        return this.nats.subscribe$('resources.changed', async event => {
-            await handleResourceChanged(event);
-        });
-    }
-
-    async publishStreamEvent(resourceId: string) {
-        await this.nats.jsPublish({
-            stream: 'RESOURCE_EVENTS',
-            subject: 'resources.changed',
+    async discover(resourceId: string) {
+        return this.nats.requestMany({
+            subject: 'resources.discover',
             data: { resourceId },
+            strategy: 'count',
+            expectedResponseCount: 3,
+            maxWait: 2_000,
         });
     }
 }
 ```
 
+Alternatively, set `publish({ timeout: 1_000 })` to publish and perform the bounded flush in one operation.
+
+`requestMany()` also supports `timer`, `jitter`, and `sentinel` completion strategies. Transport and validation failures retain their original `cause` inside structured `NatsRequestError` or `NatsPublishError` instances.
+
+Request handlers can respond without manually publishing to the reply subject:
+
+```ts
+const subscription = await nats.subscribe({ subject: 'resources.lookup' }, async message => {
+    message.respond({ status: 'ready' }, { 'x-schema-version': '1' });
+});
+```
+
+### Subscriptions
+
+Every returned subscription belongs to the service instance that created it and exposes explicit completion controls:
+
+```ts
+const subscription = await nats.subscribe$<{ resourceId: string }>(
+    'resources.changed',
+    async event => processResource(event.resourceId),
+);
+
+await subscription.drain(); // Process messages already received by the client, then close.
+await subscription.closed;  // Resolves after the iterator and active handler finish.
+
+// Immediate alternative:
+subscription.cancel();
+```
+
+Core subscriptions accept `queue`, `maxMessages`, and first-message `timeout`. Passing a fabricated or foreign handle to `unsubscribe()` throws `NatsSubscriptionOwnershipError`; canceling an owned handle more than once is safe.
+
+### JetStream
+
+```ts
+await nats.jsPublish({
+    stream: 'RESOURCE_EVENTS',
+    subject: 'resources.changed',
+    data: { resourceId: 'resource-1' },
+});
+
+const consumer = await nats.jsSubscribe(
+    {
+        stream: 'RESOURCE_EVENTS',
+        subject: 'resources.changed',
+        durable: 'resource-workers',
+        queue: 'workers',
+        config: {
+            deliverPolicy: 'new',
+            ackPolicy: 'explicit',
+            ackWait: 30_000,
+            maxDeliver: 5,
+        },
+    },
+    async message => processEvent(message.data),
+);
+```
+
+Automatic acknowledgement occurs only after the handler succeeds. Handler failures are negatively acknowledged, `ackPolicy: 'none'` disables acknowledgements, and `manualAck: true` exposes `ack()`, `nak()`, `term()`, and `inProgress()` to the handler. Publish acknowledgements are checked against the requested stream so a subject routed to an unexpected stream fails explicitly.
+
+### Health and lifecycle
+
+```ts
+const health = await nats.healthCheck(1_000);
+const healthy = await nats.isHealthy();
+const state = nats.getState();
+const stats = await nats.getStats();
+```
+
+`healthCheck()` performs a bounded NATS `flush()` instead of trusting an in-memory flag. Status events update disconnect, error, reconnect count, and active server state; events from replaced connections cannot overwrite the active connection state.
+
+During shutdown the service rejects new operations, cleans up late subscription results, waits for active handlers and requests, drains buffered messages, and falls back to `close()` when draining fails. The entire sequence is bounded by `shutdownTimeoutMs`; `close()` and Nest lifecycle cleanup are idempotent. Set `drainOnShutdown: false` only when immediate connection close is intentional.
+
 ## Exports
 
 - `NatsModule`
-- `NatsService`
-- NATS message, headers, subscription, JetStream, health, and module option types
+- `NatsService` and `NatsServiceImpl`
+- `createNatsConnectionOptions`
+- `Subscription`, `NatsMessage`, `JetStreamMessage`, `NatsHealthResult`, and request/subscription option types
+- Structured connection, configuration, lifecycle, publish, request, and subscription errors
 - Configurable module definition helpers
 
 ## Notes
 
-The package owns generic NATS connection management, headers, serialization helpers, subscriptions, JetStream publish/subscribe helpers, health state, and lifecycle cleanup. Applications still own subject naming, stream naming, payload contracts, and message handling policy.
+The package owns generic NATS connection state, serialization, headers, request/reply, subscriptions, JetStream consumer mapping, acknowledgement policy, health probes, and bounded lifecycle cleanup. Applications still own subject and stream naming, payload schemas, idempotency, retry/dead-letter policy, and business message handling.
+
+`getConnection()` and `getJetStream()` are advanced escape hatches. Work performed directly on the returned native clients is not tracked by the service's operation drain and must not outlive application shutdown.

--- a/packages/nats/package.json
+++ b/packages/nats/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@a3s-lab/nats",
     "version": "0.0.1",
-    "description": "NestJS module for NATS message queue - publish/subscribe and request/reply patterns",
+    "description": "Lifecycle-safe NestJS NATS and JetStream integration with validated configuration",
     "author": "A3S Lab",
     "license": "MIT",
     "homepage": "https://github.com/A3S-Lab/nestify/tree/main/packages/nats#readme",
@@ -16,6 +16,7 @@
     "keywords": [
         "nestjs",
         "nats",
+        "jetstream",
         "message-queue",
         "messaging",
         "pubsub",

--- a/packages/nats/src/__tests__/index.spec.ts
+++ b/packages/nats/src/__tests__/index.spec.ts
@@ -15,6 +15,12 @@ jest.mock('nats', () => ({
         Error: 'error',
         Disconnect: 'disconnect',
     },
+    RequestStrategy: {
+        Timer: 'timer',
+        Count: 'count',
+        JitterTimer: 'jitterTimer',
+        SentinelMsg: 'sentinelMsg',
+    },
     headers: jest.fn(() => createHeaders()),
     StringCodec: jest.fn(() => ({
         encode: (value: string) => Buffer.from(value),
@@ -45,9 +51,13 @@ function createSubscription(id = 7, messages: unknown[] = [], iteratorError?: Er
         resolveClosed = resolve;
     });
 
-    return {
+    const subscription = {
         getID: jest.fn(() => id),
         unsubscribe: jest.fn(() => {
+            closed = true;
+            resolveClosed();
+        }),
+        drain: jest.fn(async () => {
             closed = true;
             resolveClosed();
         }),
@@ -64,6 +74,7 @@ function createSubscription(id = 7, messages: unknown[] = [], iteratorError?: Er
             }
         },
     };
+    return subscription;
 }
 
 function createJetStreamMessage() {
@@ -125,6 +136,16 @@ async function waitForCalls(mock: jest.Mock, expected = 1): Promise<void> {
     throw new Error(`Expected mock to be called ${expected} time(s), received ${mock.mock.calls.length}`);
 }
 
+async function waitForCondition(condition: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (condition()) {
+            return;
+        }
+        await new Promise<void>(resolve => setImmediate(resolve));
+    }
+    throw new Error('Expected condition to become true');
+}
+
 describe('nats package', () => {
     let mockConnection: any;
     let mockJetStream: any;
@@ -144,11 +165,36 @@ describe('nats package', () => {
             subscribe: jest.fn(async () => createSubscription(9)),
         };
 
+        let connectionClosed = false;
+        let connectionDraining = false;
+        let resolveConnectionClosed!: () => void;
+        const connectionClosedPromise = new Promise<void>(resolve => {
+            resolveConnectionClosed = resolve;
+        });
+        const finishConnectionClose = () => {
+            connectionClosed = true;
+            connectionDraining = false;
+            resolveConnectionClosed();
+        };
+
         mockConnection = {
             getServer: jest.fn(() => 'nats://broker:4222'),
-            closed: jest.fn(() => new Promise<never>(() => undefined)),
-            close: jest.fn(async () => undefined),
+            closed: jest.fn(() => connectionClosedPromise),
+            close: jest.fn(async () => finishConnectionClose()),
+            drain: jest.fn(async () => {
+                connectionDraining = true;
+                finishConnectionClose();
+            }),
+            isClosed: jest.fn(() => connectionClosed),
+            isDraining: jest.fn(() => connectionDraining),
             status: jest.fn(async function* () {}),
+            flush: jest.fn(async () => undefined),
+            stats: jest.fn(() => ({
+                inBytes: 1,
+                outBytes: 2,
+                inMsgs: 3,
+                outMsgs: 4,
+            })),
             jetstream: jest.fn(() => mockJetStream),
             publish: jest.fn(),
             request: jest.fn(async () => ({
@@ -157,7 +203,20 @@ describe('nats package', () => {
                 data: Buffer.from(JSON.stringify({ status: 'ready' })),
                 headers: createHeaders({ 'x-result': ['ok'] }),
                 reply: undefined,
+                respond: jest.fn(() => false),
             })),
+            requestMany: jest.fn(async () =>
+                (async function* () {
+                    yield {
+                        subject: 'resources.lookup.reply',
+                        sid: 4,
+                        data: Buffer.from(JSON.stringify({ status: 'ready' })),
+                        headers: createHeaders(),
+                        reply: undefined,
+                        respond: jest.fn(() => false),
+                    };
+                })(),
+            ),
             subscribe: jest.fn(() => createSubscription()),
         };
 
@@ -244,6 +303,7 @@ describe('nats package', () => {
             headers: { 'x-result': 'ok' },
             reply: undefined,
             timestamp: expect.any(Number),
+            respond: expect.any(Function),
         });
         expect(data).toEqual({ status: 'ready' });
         expect(mockConnection.request).toHaveBeenCalledWith(
@@ -280,8 +340,10 @@ describe('nats package', () => {
 
         await service.onModuleDestroy();
 
-        expect(subscription.unsubscribe).toHaveBeenCalled();
-        expect(mockConnection.close).toHaveBeenCalled();
+        expect(subscription.drain).toHaveBeenCalled();
+        expect(subscription.unsubscribe).not.toHaveBeenCalled();
+        expect(mockConnection.drain).toHaveBeenCalled();
+        expect(mockConnection.close).not.toHaveBeenCalled();
     });
 
     it('publishes to JetStream with encoded data and headers', async () => {
@@ -520,6 +582,7 @@ describe('nats package', () => {
 
         expect(logError).toHaveBeenCalledWith('Subscription on resources.changed stopped: consumer iterator failed');
         expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+        expect(subscription.drain).not.toHaveBeenCalled();
     });
 
     it('waits for an in-flight handler to acknowledge before closing the connection', async () => {
@@ -540,15 +603,16 @@ describe('nats package', () => {
 
         const shutdown = service.onModuleDestroy();
         await new Promise<void>(resolve => setImmediate(resolve));
-        expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
-        expect(mockConnection.close).not.toHaveBeenCalled();
+        expect(subscription.drain).toHaveBeenCalledTimes(1);
+        expect(subscription.unsubscribe).not.toHaveBeenCalled();
+        expect(mockConnection.drain).not.toHaveBeenCalled();
 
         releaseHandler();
         await shutdown;
 
         expect(message.ack).toHaveBeenCalledTimes(1);
-        expect(mockConnection.close).toHaveBeenCalledTimes(1);
-        expect(message.ack.mock.invocationCallOrder[0]).toBeLessThan(mockConnection.close.mock.invocationCallOrder[0]);
+        expect(mockConnection.drain).toHaveBeenCalledTimes(1);
+        expect(message.ack.mock.invocationCallOrder[0]).toBeLessThan(mockConnection.drain.mock.invocationCallOrder[0]);
     });
 
     it('waits for a pending JetStream subscription and cleans up its late result during shutdown', async () => {
@@ -569,13 +633,630 @@ describe('nats package', () => {
 
         const shutdown = service.onModuleDestroy();
         await new Promise<void>(resolve => setImmediate(resolve));
-        expect(mockConnection.close).not.toHaveBeenCalled();
+        expect(mockConnection.drain).not.toHaveBeenCalled();
 
         resolveSubscription(subscription);
-        await expect(pending).rejects.toMatchObject({ code: 'NATS_SUBSCRIBE_ERROR' });
+        await expect(pending).rejects.toMatchObject({ code: 'NATS_SERVICE_CLOSED' });
         await shutdown;
 
         expect(subscription.unsubscribe).toHaveBeenCalledTimes(1);
+        expect(subscription.drain).not.toHaveBeenCalled();
+        expect(mockConnection.drain).toHaveBeenCalledTimes(1);
+    });
+
+    it('normalizes string servers, nested authentication, and Node TLS verification options', async () => {
+        const service = new NatsServiceImpl({
+            servers: ' nats://secure-broker:4222 ',
+            auth: { user: 'service-user', pass: 'service-password' },
+            tls: {
+                cert: 'client-certificate',
+                key: 'client-key',
+                ca: 'root-certificate',
+                verify: false,
+                handshakeFirst: true,
+            },
+        });
+
+        await service.onModuleInit();
+
+        expect(mockConnect).toHaveBeenCalledWith(
+            expect.objectContaining({
+                servers: ['nats://secure-broker:4222'],
+                user: 'service-user',
+                pass: 'service-password',
+                token: undefined,
+                tls: {
+                    cert: 'client-certificate',
+                    key: 'client-key',
+                    ca: 'root-certificate',
+                    handshakeFirst: true,
+                    rejectUnauthorized: false,
+                },
+            }),
+        );
+
+        await service.close();
+    });
+
+    it.each([
+        [{ servers: [] }, 'servers must contain at least one server'],
+        [{ servers: ['nats://broker:4222'], token: 'token', user: 'user', pass: 'pass' }, 'mutually exclusive'],
+        [{ servers: ['nats://broker:4222'], auth: { user: 'user' } }, 'configured together'],
+        [{ servers: ['nats://broker:4222'], shutdownTimeoutMs: 0 }, 'positive integer'],
+        [
+            {
+                servers: ['nats://broker:4222'],
+                tls: { cert: 'certificate', key: 'key', verify: true, rejectUnauthorized: false },
+            },
+            'must agree',
+        ],
+    ])('rejects invalid module configuration %#', (options, message) => {
+        expect(() => new NatsServiceImpl(options as any)).toThrow(message as string);
+        try {
+            new NatsServiceImpl(options as any);
+        } catch (error) {
+            expect(error).toMatchObject({ code: 'NATS_CONFIGURATION_ERROR' });
+        }
+    });
+
+    it('coalesces concurrent connection attempts and reuses the same connection', async () => {
+        let resolveConnection!: (connection: typeof mockConnection) => void;
+        mockConnect.mockReturnValueOnce(
+            new Promise(resolve => {
+                resolveConnection = resolve;
+            }),
+        );
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        const first = service.getConnection();
+        const second = service.getConnection();
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+
+        resolveConnection(mockConnection);
+        await expect(first).resolves.toBe(mockConnection);
+        await expect(second).resolves.toBe(mockConnection);
+        await expect(service.getConnection()).resolves.toBe(mockConnection);
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+
+        await service.close();
+    });
+
+    it('rejects a connection that closes before callers can use it', async () => {
+        const closedConnection = {
+            ...mockConnection,
+            closed: jest.fn(async () => undefined),
+            isClosed: jest.fn(() => true),
+            status: jest.fn(async function* () {}),
+        };
+        mockConnect.mockResolvedValueOnce(closedConnection);
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await expect(service.getConnection()).rejects.toMatchObject({
+            code: 'NATS_CONNECTION_ERROR',
+            message: expect.stringContaining('closed before it became ready'),
+        });
+        expect(service.getState().connected).toBe(false);
+    });
+
+    it('recovers after an unusable connection instead of returning the stale client', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        const first = await service.getConnection();
+        first.isClosed = jest.fn(() => true);
+
+        const replacement = {
+            ...mockConnection,
+            getServer: jest.fn(() => 'nats://replacement:4222'),
+            isClosed: jest.fn(() => false),
+            isDraining: jest.fn(() => false),
+            closed: jest.fn(() => new Promise<never>(() => undefined)),
+            status: jest.fn(async function* () {}),
+        };
+        mockConnect.mockResolvedValueOnce(replacement);
+
+        await expect(service.getConnection()).resolves.toBe(replacement);
+        expect(mockConnect).toHaveBeenCalledTimes(2);
+        expect(service.getState().server).toBe('nats://replacement:4222');
+    });
+
+    it('preserves connection error causes and permits a later retry', async () => {
+        const rootCause = new Error('broker unavailable');
+        mockConnect.mockRejectedValueOnce(rootCause);
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await expect(service.onModuleInit()).rejects.toMatchObject({
+            code: 'NATS_CONNECTION_ERROR',
+            cause: rootCause,
+        });
+        await expect(service.getConnection()).resolves.toBe(mockConnection);
+        expect(mockConnect).toHaveBeenCalledTimes(2);
+
+        await service.close();
+    });
+
+    it('probes the connection, exposes native statistics, and reports health timeouts', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        await service.onModuleInit();
+
+        await expect(service.healthCheck(50)).resolves.toMatchObject({
+            healthy: true,
+            server: 'nats://broker:4222',
+            latencyMs: expect.any(Number),
+        });
+        await expect(service.getStats()).resolves.toEqual({ inBytes: 1, outBytes: 2, inMsgs: 3, outMsgs: 4 });
+
+        mockConnection.flush.mockReturnValueOnce(new Promise<never>(() => undefined));
+        await expect(service.healthCheck(5)).resolves.toMatchObject({
+            healthy: false,
+            error: 'NATS health check timed out after 5ms',
+        });
+
+        await service.close();
+    });
+
+    it('collects multiple request responses with an explicit count strategy', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'], requestTimeoutMs: 2500 });
+
+        await expect(
+            service.requestMany({
+                subject: 'resources.lookup',
+                data: { resourceId: 'resource-1' },
+                expectedResponseCount: 2,
+                headers: { 'x-request-id': 'request-1' },
+            }),
+        ).resolves.toEqual([
+            expect.objectContaining({
+                subject: 'resources.lookup.reply',
+                data: Buffer.from(JSON.stringify({ status: 'ready' })),
+                respond: expect.any(Function),
+            }),
+        ]);
+        expect(mockConnection.requestMany).toHaveBeenCalledWith(
+            'resources.lookup',
+            Buffer.from(JSON.stringify({ resourceId: 'resource-1' })),
+            expect.objectContaining({
+                strategy: 'count',
+                maxWait: 2500,
+                maxMessages: 2,
+                headers: expect.objectContaining({ values: { 'x-request-id': ['request-1'] } }),
+            }),
+        );
+    });
+
+    it('exposes encoded request/reply responses on converted messages', async () => {
+        const respond = jest.fn(() => true);
+        mockConnection.request.mockResolvedValueOnce({
+            subject: 'resources.lookup.reply',
+            sid: 30,
+            data: Buffer.from('request'),
+            headers: createHeaders(),
+            reply: 'resources.response',
+            respond,
+        });
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        const response = await service.request({ subject: 'resources.lookup' });
+        expect(response.respond({ accepted: true }, { 'x-result': 'ok' })).toBe(true);
+        expect(respond).toHaveBeenCalledWith(
+            Buffer.from(JSON.stringify({ accepted: true })),
+            expect.objectContaining({
+                headers: expect.objectContaining({ values: { 'x-result': ['ok'] } }),
+            }),
+        );
+    });
+
+    it('passes core subscription limits and enforces subscription handle ownership', async () => {
+        const nativeSubscription = createSubscription(31);
+        mockConnection.subscribe.mockReturnValueOnce(nativeSubscription);
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        const subscription = await service.subscribe(
+            { subject: 'resources.changed', queue: 'workers', maxMessages: 2, timeout: 500 },
+            async () => undefined,
+        );
+        expect(mockConnection.subscribe).toHaveBeenCalledWith('resources.changed', {
+            queue: 'workers',
+            max: 2,
+            timeout: 500,
+        });
+        expect(() =>
+            service.unsubscribe({
+                sid: 31,
+                subject: 'resources.changed',
+                closed: Promise.resolve(),
+                cancel: () => undefined,
+                drain: async () => undefined,
+                isCancelled: () => false,
+            }),
+        ).toThrow(expect.objectContaining({ code: 'NATS_SUBSCRIPTION_OWNERSHIP_ERROR' }));
+
+        subscription.cancel();
+        subscription.cancel();
+        await subscription.closed;
+        expect(nativeSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+        expect(() => service.unsubscribe(subscription)).not.toThrow();
+
+        await service.close();
+    });
+
+    it('drains a subscription and resolves its completion promise', async () => {
+        const nativeSubscription = createSubscription(32);
+        mockConnection.subscribe.mockReturnValueOnce(nativeSubscription);
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        const subscription = await service.subscribe({ subject: 'resources.changed' }, async () => undefined);
+        await subscription.drain();
+
+        expect(nativeSubscription.drain).toHaveBeenCalledTimes(1);
+        await expect(subscription.closed).resolves.toBeUndefined();
+        await service.close();
+    });
+
+    it('falls back to close when draining fails and keeps shutdown idempotent', async () => {
+        mockConnection.drain.mockRejectedValueOnce(new Error('drain failed'));
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        await service.onModuleInit();
+
+        const first = service.close();
+        const second = service.close();
+        expect(second).toBe(first);
+        await first;
+
+        expect(mockConnection.drain).toHaveBeenCalledTimes(1);
         expect(mockConnection.close).toHaveBeenCalledTimes(1);
+        await expect(service.publish({ subject: 'resources.changed' })).rejects.toMatchObject({
+            code: 'NATS_SERVICE_CLOSED',
+        });
+    });
+
+    it('supports an explicit immediate-close shutdown policy', async () => {
+        const nativeSubscription = createSubscription(34);
+        mockConnection.subscribe.mockReturnValueOnce(nativeSubscription);
+        const service = new NatsServiceImpl({
+            servers: ['nats://broker:4222'],
+            drainOnShutdown: false,
+        });
+        await service.subscribe({ subject: 'resources.changed' }, async () => undefined);
+
+        await service.close();
+
+        expect(nativeSubscription.drain).not.toHaveBeenCalled();
+        expect(nativeSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+        expect(mockConnection.drain).not.toHaveBeenCalled();
+        expect(mockConnection.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('bounds shutdown when a subscription handler never settles', async () => {
+        const subscription = createSubscription(33, [createJetStreamMessage()]);
+        mockJetStream.subscribe.mockResolvedValueOnce(subscription);
+        const handler = jest.fn(() => new Promise<never>(() => undefined));
+        const service = new NatsServiceImpl({
+            servers: ['nats://broker:4222'],
+            shutdownTimeoutMs: 15,
+        });
+
+        await service.jsSubscribe({ stream: 'RESOURCE_EVENTS', subject: 'resources.changed' }, handler);
+        await waitForCalls(handler);
+        const startedAt = Date.now();
+        await service.close();
+
+        expect(Date.now() - startedAt).toBeLessThan(250);
+        expect(subscription.drain).toHaveBeenCalledTimes(1);
+        expect(subscription.unsubscribe).not.toHaveBeenCalled();
+        expect(mockConnection.drain).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns from bounded shutdown and closes a connection that resolves late', async () => {
+        let resolveConnection!: (connection: typeof mockConnection) => void;
+        mockConnect.mockReturnValueOnce(
+            new Promise(resolve => {
+                resolveConnection = resolve;
+            }),
+        );
+        const service = new NatsServiceImpl({
+            servers: ['nats://broker:4222'],
+            shutdownTimeoutMs: 10,
+        });
+
+        const pendingConnection = service.getConnection();
+        await waitForCalls(mockConnect);
+        const startedAt = Date.now();
+        await service.close();
+        expect(Date.now() - startedAt).toBeLessThan(250);
+
+        resolveConnection(mockConnection);
+        await expect(pendingConnection).rejects.toMatchObject({ code: 'NATS_SERVICE_CLOSED' });
+        expect(mockConnection.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects invalid JetStream consumer values before opening a connection', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await expect(
+            service.jsSubscribe(
+                {
+                    stream: 'RESOURCE_EVENTS',
+                    subject: 'resources.changed',
+                    config: { samplingRate: 101 },
+                },
+                async () => undefined,
+            ),
+        ).rejects.toMatchObject({ code: 'NATS_SUBSCRIBE_ERROR' });
+        expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('rejects a JetStream acknowledgement from an unexpected stream', async () => {
+        mockJetStream.publish.mockResolvedValueOnce({ stream: 'OTHER_STREAM', seq: 1, duplicate: false });
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await expect(
+            service.jsPublish({ stream: 'RESOURCE_EVENTS', subject: 'resources.changed', data: 'changed' }),
+        ).rejects.toMatchObject({ code: 'NATS_PUBLISH_ERROR' });
+    });
+
+    it('tracks disconnect, error, and reconnect status events from the active connection', async () => {
+        mockConnection.getServer.mockReturnValue('nats://reconnected:4222');
+        mockConnection.status.mockImplementation(async function* () {
+            yield { type: 'disconnect', data: 'nats://broker:4222' };
+            yield { type: 'error', data: 'permissions violation' };
+            yield { type: 'reconnect', data: 'nats://reconnected:4222' };
+        });
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await service.onModuleInit();
+        await waitForCondition(() => service.getState().reconnectCount === 1);
+
+        expect(service.getState()).toEqual({
+            connected: true,
+            server: 'nats://reconnected:4222',
+            reconnectCount: 1,
+            lastError: 'permissions violation',
+        });
+        await service.close();
+    });
+
+    it('clears the active client and records an unexpected close error', async () => {
+        let resolveClosed!: (error: Error) => void;
+        mockConnection.closed.mockReturnValueOnce(
+            new Promise(resolve => {
+                resolveClosed = resolve;
+            }),
+        );
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        await service.onModuleInit();
+
+        resolveClosed(new Error('connection lost'));
+        await waitForCondition(() => service.getState().connected === false);
+
+        expect(service.getState().lastError).toBe('connection lost');
+        await expect(service.healthCheck()).resolves.toMatchObject({
+            healthy: false,
+            error: 'NATS connection is not active',
+        });
+        await service.close();
+    });
+
+    it('closes a partially initialized connection when JetStream construction fails', async () => {
+        mockConnection.jetstream.mockImplementationOnce(() => {
+            throw new Error('JetStream setup failed');
+        });
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await expect(service.onModuleInit()).rejects.toMatchObject({
+            code: 'NATS_CONNECTION_ERROR',
+            cause: expect.objectContaining({ message: 'JetStream setup failed' }),
+        });
+        expect(mockConnection.close).toHaveBeenCalledTimes(1);
+        expect(service.getState()).toMatchObject({ connected: false, lastError: 'JetStream setup failed' });
+    });
+
+    it('wraps flush timeout and rejection failures with the underlying cause', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        await service.onModuleInit();
+
+        mockConnection.flush.mockReturnValueOnce(new Promise<never>(() => undefined));
+        await expect(service.flush(5)).rejects.toMatchObject({
+            code: 'NATS_CONNECTION_ERROR',
+            message: expect.stringContaining('flush timed out after 5ms'),
+        });
+
+        const rootCause = new Error('flush failed');
+        mockConnection.flush.mockRejectedValueOnce(rootCause);
+        await expect(service.flush(50)).rejects.toMatchObject({
+            code: 'NATS_CONNECTION_ERROR',
+            cause: rootCause,
+        });
+        await service.close();
+    });
+
+    it('wraps publish and request validation or transport failures without losing causes', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await expect(service.publish({ subject: '' })).rejects.toMatchObject({
+            code: 'NATS_PUBLISH_ERROR',
+            cause: expect.any(TypeError),
+        });
+        mockConnection.publish.mockImplementationOnce(() => {
+            throw new Error('publish failed');
+        });
+        await expect(service.pubsub('resources.changed', new Uint8Array([1, 2, 3]))).rejects.toMatchObject({
+            code: 'NATS_PUBLISH_ERROR',
+            cause: expect.objectContaining({ message: 'publish failed' }),
+        });
+        await expect(service.request({ subject: 'resources.lookup', expectedResponseCount: 2 })).rejects.toMatchObject({
+            code: 'NATS_REQUEST_ERROR',
+        });
+        const requestCause = new Error('request failed');
+        mockConnection.request.mockRejectedValueOnce(requestCause);
+        await expect(service.request({ subject: 'resources.lookup' })).rejects.toMatchObject({
+            code: 'NATS_REQUEST_ERROR',
+            cause: requestCause,
+        });
+    });
+
+    it('uses the publish timeout as an explicit server flush deadline', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await service.publish({ subject: 'resources.changed', data: 'changed', timeout: 50 });
+        expect(mockConnection.flush).toHaveBeenCalledTimes(1);
+
+        mockConnection.flush.mockReturnValueOnce(new Promise<never>(() => undefined));
+        await expect(service.publish({ subject: 'resources.changed', timeout: 5 })).rejects.toMatchObject({
+            code: 'NATS_PUBLISH_ERROR',
+            message: expect.stringContaining('publish flush timed out after 5ms'),
+        });
+    });
+
+    it('maps timer, jitter, and sentinel multi-response strategies', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await service.requestMany({ subject: 'resources.lookup', strategy: 'timer', maxWait: 100 });
+        await service.requestMany({ subject: 'resources.lookup', strategy: 'jitter', jitter: 25, maxWait: 100 });
+        await service.requestMany({ subject: 'resources.lookup', strategy: 'sentinel', maxWait: 100 });
+
+        expect(mockConnection.requestMany.mock.calls.map((call: unknown[]) => call[2])).toEqual([
+            expect.objectContaining({ strategy: 'timer', maxWait: 100 }),
+            expect.objectContaining({ strategy: 'jitterTimer', jitter: 25, maxWait: 100 }),
+            expect.objectContaining({ strategy: 'sentinelMsg', maxWait: 100 }),
+        ]);
+    });
+
+    it('maps dedicated request subscriptions and validates their reply subjects', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+
+        await service.request({
+            subject: 'resources.lookup',
+            noMux: true,
+            reply: '_INBOX.resources.lookup',
+        });
+        expect(mockConnection.request).toHaveBeenCalledWith(
+            'resources.lookup',
+            expect.any(Uint8Array),
+            expect.objectContaining({ noMux: true, reply: '_INBOX.resources.lookup' }),
+        );
+
+        await service.requestMany({ subject: 'resources.lookup', strategy: 'timer', noMux: true });
+        expect(mockConnection.requestMany).toHaveBeenCalledWith(
+            'resources.lookup',
+            expect.any(Uint8Array),
+            expect.objectContaining({ noMux: true }),
+        );
+
+        await expect(service.request({ subject: 'resources.lookup', noMux: true })).rejects.toMatchObject({
+            code: 'NATS_REQUEST_ERROR',
+        });
+        await expect(
+            service.request({ subject: 'resources.lookup', reply: '_INBOX.resources.lookup' }),
+        ).rejects.toMatchObject({ code: 'NATS_REQUEST_ERROR' });
+    });
+
+    it.each([
+        [{ subject: 'resources.lookup', strategy: 'count' }, 'expectedResponseCount'],
+        [
+            { subject: 'resources.lookup', strategy: 'timer', expectedResponseCount: 2 },
+            'only be used with the count strategy',
+        ],
+        [{ subject: 'resources.lookup', strategy: 'timer', jitter: 5 }, 'only be used with the jitter strategy'],
+        [{ subject: 'resources.lookup', strategy: 'unknown' }, 'Unsupported request strategy'],
+        [{ subject: 'resources.lookup', maxWait: 0 }, 'maxWait must be a positive integer'],
+    ])('rejects invalid multi-response options %#', async (options, message) => {
+        await expect(new NatsServiceImpl({}).requestMany(options as any)).rejects.toMatchObject({
+            code: 'NATS_REQUEST_ERROR',
+            message: expect.stringContaining(message as string),
+        });
+    });
+
+    it('maps every JetStream delivery and acknowledgement policy branch', async () => {
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        const startTime = new Date('2026-02-03T04:05:06.000Z');
+        const configs = [
+            { deliverPolicy: 'all', ackPolicy: 'explicit', replayPolicy: 'instant' },
+            { deliverPolicy: 'last' },
+            { deliverPolicy: 'new' },
+            { deliverPolicy: 'last_per_subject' },
+            { deliverPolicy: 'by_start_sequence', startSeq: 12 },
+            { startSeq: 13 },
+            { startTime },
+        ] as const;
+
+        for (let index = 0; index < configs.length; index += 1) {
+            mockJetStream.subscribe.mockResolvedValueOnce(createSubscription(40 + index));
+            const subscription = await service.jsSubscribe(
+                { stream: 'RESOURCE_EVENTS', subject: 'resources.changed', config: configs[index] },
+                async () => undefined,
+            );
+            subscription.cancel();
+            await subscription.closed;
+        }
+
+        expect(mockConsumerOptions.deliverAll).toHaveBeenCalled();
+        expect(mockConsumerOptions.deliverLast).toHaveBeenCalled();
+        expect(mockConsumerOptions.deliverNew).toHaveBeenCalled();
+        expect(mockConsumerOptions.deliverLastPerSubject).toHaveBeenCalled();
+        expect(mockConsumerOptions.startSequence).toHaveBeenCalledWith(12);
+        expect(mockConsumerOptions.startSequence).toHaveBeenCalledWith(13);
+        expect(mockConsumerOptions.startTime).toHaveBeenCalledWith(startTime);
+        expect(mockConsumerOptions.ackExplicit).toHaveBeenCalled();
+        expect(mockConsumerOptions.replayInstantly).toHaveBeenCalled();
+        await service.close();
+    });
+
+    it('contains ordinary subscription handler failures and supports service-owned unsubscribe', async () => {
+        const message = {
+            subject: 'resources.changed',
+            sid: 51,
+            data: Buffer.from('not-json'),
+            headers: createHeaders(),
+            reply: undefined,
+            respond: jest.fn(() => false),
+        };
+        const nativeSubscription = createSubscription(51, [message]);
+        mockConnection.subscribe.mockReturnValueOnce(nativeSubscription);
+        const handler = jest.fn(async () => {
+            throw new Error('handler failed');
+        });
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        const logError = jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+
+        const subscription = await service.subscribe$('resources.changed', handler);
+        await waitForCalls(handler);
+        await waitForCalls(logError);
+        service.unsubscribe(subscription);
+        await subscription.closed;
+
+        expect(handler).toHaveBeenCalledWith('not-json');
+        expect(nativeSubscription.unsubscribe).toHaveBeenCalledTimes(1);
+        await subscription.drain();
+        await service.close();
+    });
+
+    it('rejects duplicate native subscription identifiers and contains acknowledgement failures', async () => {
+        const firstNative = createSubscription(60);
+        const duplicateNative = createSubscription(60);
+        mockConnection.subscribe.mockReturnValueOnce(firstNative).mockReturnValueOnce(duplicateNative);
+        const service = new NatsServiceImpl({ servers: ['nats://broker:4222'] });
+        const first = await service.subscribe({ subject: 'resources.first' }, async () => undefined);
+
+        await expect(service.subscribe({ subject: 'resources.second' }, async () => undefined)).rejects.toMatchObject({
+            code: 'NATS_SUBSCRIBE_ERROR',
+        });
+        expect(duplicateNative.unsubscribe).toHaveBeenCalledTimes(1);
+        first.cancel();
+        await first.closed;
+
+        const message = createJetStreamMessage();
+        message.ack.mockImplementationOnce(() => {
+            throw new Error('ack failed');
+        });
+        mockJetStream.subscribe.mockResolvedValueOnce(createSubscription(61, [message]));
+        const logError = jest.spyOn((service as any).logger, 'error').mockImplementation(() => undefined);
+        const subscription = await service.jsSubscribe(
+            { stream: 'RESOURCE_EVENTS', subject: 'resources.changed' },
+            async () => undefined,
+        );
+        await waitForCalls(message.ack);
+        expect(logError).toHaveBeenCalledWith('Failed to acknowledge message on resources.changed: ack failed');
+        subscription.cancel();
+        await subscription.closed;
+        await service.close();
     });
 });

--- a/packages/nats/src/__tests__/nats-options.spec.ts
+++ b/packages/nats/src/__tests__/nats-options.spec.ts
@@ -1,0 +1,108 @@
+import { createNatsConnectionOptions } from '../nats-options';
+
+describe('createNatsConnectionOptions', () => {
+    it('builds stable defaults without mutating the caller input', () => {
+        const input = {};
+
+        expect(createNatsConnectionOptions(input)).toEqual({
+            servers: ['nats://localhost:4222'],
+            name: 'nestjs-nats',
+            user: undefined,
+            pass: undefined,
+            token: undefined,
+            maxReconnectAttempts: -1,
+            reconnectTimeWait: 2_000,
+            timeout: 10_000,
+            pingInterval: 60_000,
+            maxPingOut: 2,
+        });
+        expect(input).toEqual({});
+    });
+
+    it('deduplicates servers and maps nested credentials plus file-based TLS', () => {
+        expect(
+            createNatsConnectionOptions({
+                servers: [' nats://one:4222 ', 'nats://one:4222', 'nats://two:4222'],
+                auth: { token: 'secret-token' },
+                tls: {
+                    certFile: '/run/certs/client.pem',
+                    keyFile: '/run/certs/client-key.pem',
+                    caFile: '/run/certs/ca.pem',
+                    rejectUnauthorized: true,
+                },
+                maxReconnectAttempts: 8,
+                reconnectTimeWait: 500,
+                timeout: 2_500,
+                pingInterval: 20_000,
+                maxPingOut: 3,
+            }),
+        ).toEqual({
+            servers: ['nats://one:4222', 'nats://two:4222'],
+            name: 'nestjs-nats',
+            user: undefined,
+            pass: undefined,
+            token: 'secret-token',
+            maxReconnectAttempts: 8,
+            reconnectTimeWait: 500,
+            timeout: 2_500,
+            pingInterval: 20_000,
+            maxPingOut: 3,
+            tls: {
+                certFile: '/run/certs/client.pem',
+                keyFile: '/run/certs/client-key.pem',
+                caFile: '/run/certs/ca.pem',
+                rejectUnauthorized: true,
+            },
+        });
+    });
+
+    it('accepts matching direct and nested credentials', () => {
+        expect(
+            createNatsConnectionOptions({
+                user: 'service',
+                pass: 'password',
+                auth: { user: 'service', pass: 'password' },
+            }),
+        ).toMatchObject({ user: 'service', pass: 'password' });
+    });
+
+    it.each([
+        [null, 'module options must be an object'],
+        [[], 'module options must be an object'],
+        [{ servers: [] }, 'servers must contain at least one server'],
+        [{ servers: [' '] }, 'servers[0] must be a non-empty string'],
+        [{ name: '' }, 'connection name must be a non-empty string'],
+        [{ auth: 'invalid' }, 'auth must be an object'],
+        [{ tls: 'invalid' }, 'tls must be an object'],
+        [{ jetstream: 'invalid' }, 'jetstream must be an object'],
+        [{ user: 'first', auth: { user: 'second' }, pass: 'password' }, 'user is configured with conflicting values'],
+        [{ user: 'service' }, 'username and password must be configured together'],
+        [{ token: 'token', user: 'service', pass: 'password' }, 'mutually exclusive'],
+        [{ maxReconnectAttempts: -2 }, 'maxReconnectAttempts must be -1 or a non-negative integer'],
+        [{ reconnectTimeWait: -1 }, 'reconnectTimeWait must be a non-negative integer'],
+        [{ timeout: 0 }, 'connection timeout must be a positive integer'],
+        [{ pingInterval: 0 }, 'pingInterval must be a positive integer'],
+        [{ maxPingOut: 0 }, 'maxPingOut must be a positive integer'],
+        [{ shutdownTimeoutMs: 0 }, 'shutdownTimeoutMs must be a positive integer'],
+        [{ requestTimeoutMs: 0 }, 'requestTimeoutMs must be a positive integer'],
+        [{ drainOnShutdown: 'yes' }, 'drainOnShutdown must be a boolean'],
+        [{ jetstream: { enabled: 'yes' } }, 'jetstream.enabled must be a boolean'],
+        [{ jetstream: { domain: '' } }, 'JetStream domain must be a non-empty string'],
+        [{ jetstream: { prefix: '' } }, 'JetStream API prefix must be a non-empty string'],
+        [{ tls: { certFile: 'file', cert: 'inline', key: 'key' } }, 'tls.certFile and tls.cert are mutually exclusive'],
+        [{ tls: { keyFile: 'file', key: 'inline', cert: 'cert' } }, 'tls.keyFile and tls.key are mutually exclusive'],
+        [{ tls: { caFile: 'file', ca: 'inline' } }, 'tls.caFile and tls.ca are mutually exclusive'],
+        [{ tls: { cert: 'certificate' } }, 'TLS client certificate and key must be configured together'],
+        [{ tls: { handshakeFirst: 'yes' } }, 'tls.handshakeFirst must be a boolean'],
+        [{ tls: { verify: 'yes' } }, 'tls.verify must be a boolean'],
+        [{ tls: { rejectUnauthorized: 'yes' } }, 'tls.rejectUnauthorized must be a boolean'],
+        [{ tls: { verify: true, rejectUnauthorized: false } }, 'tls.verify and tls.rejectUnauthorized must agree'],
+    ])('rejects invalid input %#', (input, message) => {
+        expect(() => createNatsConnectionOptions(input as any)).toThrow(message as string);
+        try {
+            createNatsConnectionOptions(input as any);
+        } catch (error) {
+            expect(error).toMatchObject({ code: 'NATS_CONFIGURATION_ERROR' });
+        }
+    });
+});

--- a/packages/nats/src/index.ts
+++ b/packages/nats/src/index.ts
@@ -1,5 +1,7 @@
 export * from './nats.module';
-export { NatsServiceImpl, NatsServiceImpl as NatsService } from './nats.service';
-export type { Subscription } from './nats.service';
-export * from './nats.types';
 export * from './nats.module-definition';
+export type { Subscription } from './nats.service';
+export { NatsServiceImpl, NatsServiceImpl as NatsService } from './nats.service';
+export * from './nats.types';
+export type { NatsConnectionOptions, NatsRuntimeTlsOptions } from './nats-options';
+export { createNatsConnectionOptions } from './nats-options';

--- a/packages/nats/src/nats-options.ts
+++ b/packages/nats/src/nats-options.ts
@@ -1,0 +1,212 @@
+import type { ConnectionOptions, TlsOptions as NativeTlsOptions } from 'nats';
+import { NatsConfigurationError, type NatsPackageOptions } from './nats.types';
+
+const DEFAULT_SERVERS = ['nats://localhost:4222'];
+const DEFAULT_REQUEST_TIMEOUT_MS = 5_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+
+export type NatsRuntimeTlsOptions = NativeTlsOptions & { rejectUnauthorized?: boolean };
+
+export interface NatsConnectionOptions extends Omit<ConnectionOptions, 'tls'> {
+    tls?: NatsRuntimeTlsOptions;
+}
+
+export interface NormalizedNatsPackageOptions extends Omit<NatsPackageOptions, 'servers' | 'tls'> {
+    servers: string[];
+    requestTimeoutMs: number;
+    shutdownTimeoutMs: number;
+    drainOnShutdown: boolean;
+    tls?: NatsRuntimeTlsOptions;
+}
+
+/** Build the exact validated options passed to the first-party NATS client. */
+export function createNatsConnectionOptions(input: NatsPackageOptions): NatsConnectionOptions {
+    return toNatsConnectionOptions(normalizeNatsPackageOptions(input));
+}
+
+export function normalizeNatsPackageOptions(input: NatsPackageOptions): NormalizedNatsPackageOptions {
+    try {
+        if (!input || typeof input !== 'object' || Array.isArray(input)) {
+            throw new TypeError('module options must be an object');
+        }
+
+        const servers = normalizeServers(input.servers);
+        const name = input.name ?? 'nestjs-nats';
+        assertNonEmptyString(name, 'connection name');
+
+        if (input.auth !== undefined && (!input.auth || typeof input.auth !== 'object' || Array.isArray(input.auth))) {
+            throw new TypeError('auth must be an object');
+        }
+        if (input.tls !== undefined && (!input.tls || typeof input.tls !== 'object' || Array.isArray(input.tls))) {
+            throw new TypeError('tls must be an object');
+        }
+        if (
+            input.jetstream !== undefined &&
+            (!input.jetstream || typeof input.jetstream !== 'object' || Array.isArray(input.jetstream))
+        ) {
+            throw new TypeError('jetstream must be an object');
+        }
+
+        const user = resolveCredential('user', input.user, input.auth?.user);
+        const pass = resolveCredential('pass', input.pass, input.auth?.pass);
+        const token = resolveCredential('token', input.token, input.auth?.token);
+        if (token !== undefined && (user !== undefined || pass !== undefined)) {
+            throw new RangeError('token authentication is mutually exclusive with username/password authentication');
+        }
+        if ((user === undefined) !== (pass === undefined)) {
+            throw new RangeError('username and password must be configured together');
+        }
+
+        const maxReconnectAttempts = input.maxReconnectAttempts ?? -1;
+        if (!Number.isInteger(maxReconnectAttempts) || maxReconnectAttempts < -1) {
+            throw new RangeError('maxReconnectAttempts must be -1 or a non-negative integer');
+        }
+        const reconnectTimeWait = input.reconnectTimeWait ?? 2_000;
+        assertNonNegativeInteger(reconnectTimeWait, 'reconnectTimeWait');
+        const timeout = input.timeout ?? 10_000;
+        assertPositiveInteger(timeout, 'connection timeout');
+        const pingInterval = input.pingInterval ?? 60_000;
+        assertPositiveInteger(pingInterval, 'pingInterval');
+        const maxPingOut = input.maxPingOut ?? 2;
+        assertPositiveInteger(maxPingOut, 'maxPingOut');
+        const shutdownTimeoutMs = input.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS;
+        assertPositiveInteger(shutdownTimeoutMs, 'shutdownTimeoutMs');
+        const requestTimeoutMs = input.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+        assertPositiveInteger(requestTimeoutMs, 'requestTimeoutMs');
+        if (input.drainOnShutdown !== undefined && typeof input.drainOnShutdown !== 'boolean') {
+            throw new TypeError('drainOnShutdown must be a boolean');
+        }
+
+        const jetstream = input.jetstream ? { ...input.jetstream } : undefined;
+        if (jetstream) {
+            if (jetstream.enabled !== undefined && typeof jetstream.enabled !== 'boolean') {
+                throw new TypeError('jetstream.enabled must be a boolean');
+            }
+            if (jetstream.domain !== undefined) assertNonEmptyString(jetstream.domain, 'JetStream domain');
+            if (jetstream.prefix !== undefined) assertNonEmptyString(jetstream.prefix, 'JetStream API prefix');
+        }
+
+        return {
+            servers,
+            name,
+            user,
+            pass,
+            token,
+            maxReconnectAttempts,
+            reconnectTimeWait,
+            timeout,
+            pingInterval,
+            maxPingOut,
+            tls: normalizeTlsOptions(input.tls),
+            auth: input.auth ? { ...input.auth } : undefined,
+            jetstream,
+            shutdownTimeoutMs,
+            drainOnShutdown: input.drainOnShutdown ?? true,
+            requestTimeoutMs,
+        };
+    } catch (error) {
+        if (error instanceof NatsConfigurationError) {
+            throw error;
+        }
+        throw new NatsConfigurationError(error instanceof Error ? error.message : String(error));
+    }
+}
+
+export function toNatsConnectionOptions(options: NormalizedNatsPackageOptions): NatsConnectionOptions {
+    return {
+        servers: options.servers,
+        name: options.name,
+        user: options.user,
+        pass: options.pass,
+        token: options.token,
+        maxReconnectAttempts: options.maxReconnectAttempts,
+        reconnectTimeWait: options.reconnectTimeWait,
+        timeout: options.timeout,
+        pingInterval: options.pingInterval,
+        maxPingOut: options.maxPingOut,
+        ...(options.tls && { tls: options.tls }),
+    };
+}
+
+function normalizeServers(input: NatsPackageOptions['servers']): string[] {
+    const values = input === undefined ? DEFAULT_SERVERS : typeof input === 'string' ? [input] : input;
+    if (!Array.isArray(values) || values.length === 0) {
+        throw new RangeError('servers must contain at least one server');
+    }
+    const servers = values.map((server, index) => {
+        assertNonEmptyString(server, `servers[${index}]`);
+        return server.trim();
+    });
+    return [...new Set(servers)];
+}
+
+function resolveCredential(name: string, direct: string | undefined, nested: string | undefined): string | undefined {
+    if (direct !== undefined) assertNonEmptyString(direct, name);
+    if (nested !== undefined) assertNonEmptyString(nested, `auth.${name}`);
+    if (direct !== undefined && nested !== undefined && direct !== nested) {
+        throw new RangeError(`${name} is configured with conflicting values`);
+    }
+    return direct ?? nested;
+}
+
+function normalizeTlsOptions(input: NatsPackageOptions['tls']): NatsRuntimeTlsOptions | undefined {
+    if (!input) {
+        return undefined;
+    }
+    for (const field of ['certFile', 'keyFile', 'caFile', 'cert', 'key', 'ca'] as const) {
+        if (input[field] !== undefined) assertNonEmptyString(input[field], `tls.${field}`);
+    }
+    if (input.certFile && input.cert) throw new RangeError('tls.certFile and tls.cert are mutually exclusive');
+    if (input.keyFile && input.key) throw new RangeError('tls.keyFile and tls.key are mutually exclusive');
+    if (input.caFile && input.ca) throw new RangeError('tls.caFile and tls.ca are mutually exclusive');
+    const hasCertificate = Boolean(input.certFile || input.cert);
+    const hasKey = Boolean(input.keyFile || input.key);
+    if (hasCertificate !== hasKey) {
+        throw new RangeError('TLS client certificate and key must be configured together');
+    }
+    if (input.handshakeFirst !== undefined && typeof input.handshakeFirst !== 'boolean') {
+        throw new TypeError('tls.handshakeFirst must be a boolean');
+    }
+    if (input.verify !== undefined && typeof input.verify !== 'boolean') {
+        throw new TypeError('tls.verify must be a boolean');
+    }
+    if (input.rejectUnauthorized !== undefined && typeof input.rejectUnauthorized !== 'boolean') {
+        throw new TypeError('tls.rejectUnauthorized must be a boolean');
+    }
+    if (
+        input.verify !== undefined &&
+        input.rejectUnauthorized !== undefined &&
+        input.verify !== input.rejectUnauthorized
+    ) {
+        throw new RangeError('tls.verify and tls.rejectUnauthorized must agree when both are configured');
+    }
+
+    return {
+        ...(input.handshakeFirst !== undefined && { handshakeFirst: input.handshakeFirst }),
+        ...(input.certFile && { certFile: input.certFile }),
+        ...(input.keyFile && { keyFile: input.keyFile }),
+        ...(input.caFile && { caFile: input.caFile }),
+        ...(input.cert && { cert: input.cert }),
+        ...(input.key && { key: input.key }),
+        ...(input.ca && { ca: input.ca }),
+        rejectUnauthorized: input.rejectUnauthorized ?? input.verify ?? true,
+    };
+}
+
+function assertNonEmptyString(value: unknown, name: string): asserts value is string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new TypeError(`${name} must be a non-empty string`);
+    }
+}
+
+function assertPositiveInteger(value: unknown, name: string): asserts value is number {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+        throw new RangeError(`${name} must be a positive integer`);
+    }
+}
+
+function assertNonNegativeInteger(value: unknown, name: string): asserts value is number {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        throw new RangeError(`${name} must be a non-negative integer`);
+    }
+}

--- a/packages/nats/src/nats.module.ts
+++ b/packages/nats/src/nats.module.ts
@@ -1,4 +1,4 @@
-import { Module, type DynamicModule } from '@nestjs/common';
+import { type DynamicModule, Module } from '@nestjs/common';
 import { ASYNC_OPTIONS_TYPE, ConfigurableModuleClass, OPTIONS_TYPE } from './nats.module-definition';
 import { NatsServiceImpl } from './nats.service';
 

--- a/packages/nats/src/nats.service.ts
+++ b/packages/nats/src/nats.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import {
+    type ConnectionOptions,
     type ConsumerOptsBuilder,
     connect,
     consumerOpts,
@@ -13,6 +14,8 @@ import {
     type NatsConnection,
     type Subscription as NatsSubscription,
     type PubAck,
+    RequestStrategy,
+    type Stats,
     StringCodec,
 } from 'nats';
 import { MODULE_OPTIONS_TOKEN } from './nats.module-definition';
@@ -22,41 +25,79 @@ import type {
     JetStreamSubscribeOptions,
     JetStreamSubscriptionHandler,
     NatsConnectionState,
+    NatsHealthResult,
     NatsMessage,
     NatsPackageOptions,
     PublishOptions,
+    RequestManyOptions,
     RequestOptions,
     StreamSubscriptionConfig,
     SubscribeOptions,
     SubscriptionHandler,
 } from './nats.types';
-import { NatsConnectionError, NatsPublishError, NatsRequestError, NatsSubscribeError } from './nats.types';
+import {
+    NatsConnectionError,
+    NatsJetStreamDisabledError,
+    NatsPublishError,
+    NatsRequestError,
+    NatsServiceClosedError,
+    NatsSubscribeError,
+    NatsSubscriptionOwnershipError,
+} from './nats.types';
+import {
+    type NormalizedNatsPackageOptions,
+    normalizeNatsPackageOptions,
+    toNatsConnectionOptions,
+} from './nats-options';
+
+interface SubscriptionRecord {
+    native: SubscriptionLifecycle;
+    handle: Subscription;
+}
+
+type SettleResult<T> =
+    | { status: 'fulfilled'; value: T }
+    | { status: 'rejected'; reason: unknown }
+    | { status: 'timeout' };
 
 // Local type for subscription return values (not an interface - no implementation contract)
 export interface Subscription {
     sid: number;
     subject: string;
     queue?: string;
+    /** Resolves after the subscription iterator and any active handler finish. */
+    closed: Promise<void>;
     cancel(): void;
+    /** Gracefully process messages already received by the client, then close. */
+    drain(): Promise<void>;
     isCancelled(): boolean;
 }
 
-type SubscriptionLifecycle = Pick<NatsSubscription, 'getID' | 'isClosed' | 'unsubscribe'>;
+type SubscriptionLifecycle = Pick<NatsSubscription, 'drain' | 'getID' | 'isClosed' | 'unsubscribe'>;
 
 @Injectable()
 export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
     private connection: NatsConnection | null = null;
     private jetStream: JetStreamClient | null = null;
     private readonly subscriptions = new Map<number, SubscriptionLifecycle>();
+    private readonly subscriptionRecords = new Map<number, SubscriptionRecord>();
+    private readonly ownedSubscriptions = new WeakSet<Subscription>();
     private readonly subscriptionTasks = new Map<number, Promise<void>>();
     private readonly pendingSubscriptionSetups = new Set<Promise<Subscription>>();
+    private readonly inFlightOperations = new Set<Promise<unknown>>();
+    private readonly connectionTasks = new Set<Promise<void>>();
     private connectionState: NatsConnectionState;
+    private connectionPromise: Promise<NatsConnection> | null = null;
     private disconnectPromise: Promise<void> | null = null;
     private shuttingDown = false;
     private readonly logger = new Logger(NatsServiceImpl.name);
     private readonly stringCodec = StringCodec();
+    private readonly options: NormalizedNatsPackageOptions;
+    private readonly connectionOptions: ConnectionOptions;
 
-    constructor(@Inject(MODULE_OPTIONS_TOKEN) private readonly options: NatsPackageOptions) {
+    constructor(@Inject(MODULE_OPTIONS_TOKEN) options: NatsPackageOptions) {
+        this.options = normalizeNatsPackageOptions(options);
+        this.connectionOptions = toNatsConnectionOptions(this.options);
         this.connectionState = {
             connected: false,
             server: '',
@@ -64,46 +105,28 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         };
     }
 
-    async onModuleInit() {
-        await this.connect();
+    async onModuleInit(): Promise<void> {
+        await this.getConnection();
     }
 
-    async onModuleDestroy() {
-        await this.disconnect();
+    async onModuleDestroy(): Promise<void> {
+        await this.close();
     }
 
     // =========================================================================
     // Connection Management
     // =========================================================================
 
-    private async connect(): Promise<void> {
+    private async openConnection(): Promise<NatsConnection> {
+        let openedConnection: NatsConnection | null = null;
         try {
             this.assertRunning();
-            const servers = this.options.servers || ['nats://localhost:4222'];
-
-            const connection = await connect({
-                servers,
-                name: this.options.name || 'nestjs-nats',
-                user: this.options.user,
-                pass: this.options.pass,
-                token: this.options.token,
-                maxReconnectAttempts: this.options.maxReconnectAttempts ?? -1,
-                reconnectTimeWait: this.options.reconnectTimeWait ?? 2000,
-                timeout: this.options.timeout ?? 10000,
-                pingInterval: this.options.pingInterval ?? 60000,
-                maxPingOut: this.options.maxPingOut ?? 2,
-                ...(this.options.tls && {
-                    tls: {
-                        certFile: this.options.tls.certFile,
-                        keyFile: this.options.tls.keyFile,
-                        caFile: this.options.tls.caFile,
-                    },
-                }),
-            });
+            const connection = await connect(this.connectionOptions);
+            openedConnection = connection;
 
             if (this.shuttingDown) {
-                await connection.close();
-                throw new Error('NATS service is shutting down');
+                await this.closeLateConnection(connection);
+                throw new NatsServiceClosedError();
             }
 
             this.connection = connection;
@@ -114,46 +137,52 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
                 reconnectCount: 0,
             };
 
-            void connection
-                .closed()
-                .then(err => {
-                    if (err) {
-                        this.logger.error(`NATS connection closed with error: ${err.message}`);
-                    }
-                    if (this.connection === connection) {
-                        this.connectionState.connected = false;
-                    }
-                })
-                .catch(error => {
-                    this.logger.error(`Error waiting for NATS connection close: ${this.errorMessage(error)}`);
-                });
-
-            void this.monitorStatus(connection);
+            this.trackConnectionTask(this.observeConnectionClose(connection));
+            this.trackConnectionTask(this.monitorStatus(connection));
 
             if (this.options.jetstream?.enabled !== false) {
                 this.jetStream = connection.jetstream(this.getJetStreamOptions());
             }
 
             this.logger.log(`Connected to NATS at ${this.connectionState.server}`);
+            return connection;
         } catch (error) {
-            const err = error as Error;
-            this.connectionState.lastError = err.message;
+            if (openedConnection && this.connection === openedConnection) {
+                this.connection = null;
+                this.jetStream = null;
+                await this.closeLateConnection(openedConnection);
+            }
+
+            const message = this.errorMessage(error);
+            this.connectionState.lastError = message;
             this.connectionState.connected = false;
-            throw new NatsConnectionError(this.options.servers?.[0] || 'localhost:4222', err.message);
+            if (error instanceof NatsServiceClosedError) {
+                throw error;
+            }
+            throw new NatsConnectionError(this.options.servers.join(', '), message, error);
         }
     }
 
-    private disconnect(): Promise<void> {
+    close(): Promise<void> {
         this.shuttingDown = true;
         this.disconnectPromise ??= this.performDisconnect();
         return this.disconnectPromise;
     }
 
     private async performDisconnect(): Promise<void> {
+        const deadline = Date.now() + this.options.shutdownTimeoutMs;
+
+        if (this.options.drainOnShutdown) {
+            await this.drainSubscriptions(deadline);
+        }
         this.unsubscribeAll();
-        await Promise.allSettled([...this.pendingSubscriptionSetups]);
+        await this.awaitTasks([...this.pendingSubscriptionSetups], deadline, 'pending subscription setup');
+        await this.awaitTasks([...this.inFlightOperations], deadline, 'in-flight operation');
+        if (this.connectionPromise) {
+            await this.awaitTasks([this.connectionPromise], deadline, 'pending connection');
+        }
         this.unsubscribeAll();
-        await Promise.allSettled([...this.subscriptionTasks.values()]);
+        await this.awaitTasks([...this.subscriptionTasks.values()], deadline, 'subscription handler');
 
         const connection = this.connection;
         this.connection = null;
@@ -161,32 +190,88 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         this.connectionState.connected = false;
 
         if (!connection) {
+            await this.awaitTasks([...this.connectionTasks], deadline, 'connection monitor');
             return;
         }
 
-        try {
-            await connection.close();
-            this.logger.log('NATS connection closed');
-        } catch (error) {
-            this.logger.error(`Error closing NATS connection: ${this.errorMessage(error)}`);
+        let drained = false;
+        if (this.options.drainOnShutdown) {
+            const drainResult = await settleWithin(
+                this.invoke(() => connection.drain()),
+                remainingMs(deadline),
+            );
+            if (drainResult.status === 'fulfilled') {
+                drained = true;
+                this.logger.log('NATS connection drained and closed');
+            } else {
+                this.logSettlementFailure('draining NATS connection', drainResult);
+            }
         }
+
+        if (!drained) {
+            const closeResult = await settleWithin(
+                this.invoke(() => connection.close()),
+                remainingMs(deadline),
+            );
+            if (closeResult.status === 'fulfilled') {
+                this.logger.log('NATS connection closed');
+            } else {
+                this.logSettlementFailure('closing NATS connection', closeResult);
+            }
+        }
+
+        await this.awaitTasks([...this.connectionTasks], deadline, 'connection monitor');
+    }
+
+    private async drainSubscriptions(deadline: number): Promise<void> {
+        const drains = [...this.subscriptions].map(async ([sid, subscription]) => {
+            try {
+                if (!subscription.isClosed()) {
+                    await subscription.drain();
+                }
+            } catch (error) {
+                this.logger.error(`Error draining NATS subscription ${sid}: ${this.errorMessage(error)}`);
+            }
+        });
+        await this.awaitTasks(drains, deadline, 'subscription drain');
     }
 
     async getConnection(): Promise<NatsConnection> {
         this.assertRunning();
-        if (!this.connection) {
-            await this.connect();
+        if (this.connection && this.isConnectionUsable(this.connection)) {
+            return this.connection;
         }
-        this.assertRunning();
-        return this.connection!;
+
+        this.connection = null;
+        this.jetStream = null;
+
+        const pending = this.connectionPromise ?? this.openConnection();
+        this.connectionPromise = pending;
+        try {
+            const connection = await pending;
+            this.assertRunning();
+            if (!this.isConnectionUsable(connection)) {
+                if (this.connection === connection) {
+                    this.connection = null;
+                    this.jetStream = null;
+                }
+                throw new NatsConnectionError(connection.getServer(), 'Connection closed before it became ready');
+            }
+            return connection;
+        } finally {
+            if (this.connectionPromise === pending) {
+                this.connectionPromise = null;
+            }
+        }
     }
 
     async getJetStream(): Promise<JetStreamClient> {
         if (this.options.jetstream?.enabled === false) {
-            throw new Error('JetStream is disabled by module configuration');
+            throw new NatsJetStreamDisabledError();
         }
         if (!this.jetStream) {
             const connection = await this.getConnection();
+            this.assertRunning();
             this.jetStream = connection.jetstream(this.getJetStreamOptions());
         }
         return this.jetStream;
@@ -196,15 +281,72 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         return { ...this.connectionState };
     }
 
-    async isHealthy(): Promise<boolean> {
-        try {
-            if (!this.connection || this.connectionState.connected === false) {
-                return false;
-            }
-            return true;
-        } catch {
-            return false;
+    async healthCheck(timeoutMs: number = this.options.requestTimeoutMs): Promise<NatsHealthResult> {
+        assertPositiveInteger(timeoutMs, 'health check timeout');
+        const startedAt = Date.now();
+        const connection = this.connection;
+        if (
+            this.shuttingDown ||
+            !connection ||
+            !this.connectionState.connected ||
+            !this.isConnectionUsable(connection)
+        ) {
+            return {
+                healthy: false,
+                server: this.connectionState.server,
+                latencyMs: Date.now() - startedAt,
+                error: this.shuttingDown ? 'NATS service is shutting down' : 'NATS connection is not active',
+            };
         }
+
+        const result = await settleWithin(
+            this.invoke(() => connection.flush()),
+            timeoutMs,
+        );
+        if (result.status === 'fulfilled') {
+            return {
+                healthy: true,
+                server: connection.getServer(),
+                latencyMs: Date.now() - startedAt,
+            };
+        }
+
+        const error =
+            result.status === 'timeout'
+                ? `NATS health check timed out after ${timeoutMs}ms`
+                : this.errorMessage(result.reason);
+        this.connectionState.lastError = error;
+        return {
+            healthy: false,
+            server: this.connectionState.server,
+            latencyMs: Date.now() - startedAt,
+            error,
+        };
+    }
+
+    async isHealthy(): Promise<boolean> {
+        return (await this.healthCheck()).healthy;
+    }
+
+    async flush(timeoutMs: number = this.options.requestTimeoutMs): Promise<void> {
+        assertPositiveInteger(timeoutMs, 'flush timeout');
+        return this.runOperation(async () => {
+            const connection = await this.getConnection();
+            const result = await settleWithin(
+                this.invoke(() => connection.flush()),
+                timeoutMs,
+            );
+            if (result.status === 'timeout') {
+                throw new NatsConnectionError(connection.getServer(), `flush timed out after ${timeoutMs}ms`);
+            }
+            if (result.status === 'rejected') {
+                throw new NatsConnectionError(connection.getServer(), this.errorMessage(result.reason), result.reason);
+            }
+        });
+    }
+
+    async getStats(): Promise<Stats> {
+        return this.runOperation(async () => (await this.getConnection()).stats());
     }
 
     // =========================================================================
@@ -213,21 +355,41 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
 
     async publish(options: PublishOptions): Promise<void> {
         try {
-            const conn = await this.getConnection();
-            const data = this.encodeData(options.data);
+            await this.runOperation(async () => {
+                assertNonEmptyString(options.subject, 'publish subject');
+                if (options.timeout !== undefined) {
+                    assertPositiveInteger(options.timeout, 'publish timeout');
+                }
+                const conn = await this.getConnection();
+                const data = this.encodeData(options.data);
 
-            conn.publish(options.subject, data, {
-                ...(options.headers && { headers: this.toHeaders(options.headers) }),
-                ...(options.reply && { reply: options.reply }),
+                conn.publish(options.subject, data, {
+                    ...(options.headers && { headers: this.toHeaders(options.headers) }),
+                    ...(options.reply && { reply: options.reply }),
+                });
+
+                if (options.timeout !== undefined) {
+                    const result = await settleWithin(
+                        this.invoke(() => conn.flush()),
+                        options.timeout,
+                    );
+                    if (result.status === 'timeout') {
+                        throw new Error(`publish flush timed out after ${options.timeout}ms`);
+                    }
+                    if (result.status === 'rejected') {
+                        throw result.reason;
+                    }
+                }
+
+                this.logger.debug(`Published to ${options.subject}`);
             });
-
-            this.logger.debug(`Published to ${options.subject}`);
         } catch (error) {
-            throw new NatsPublishError(options.subject, (error as Error).message);
+            this.rethrowServiceClosed(error);
+            throw new NatsPublishError(options.subject, this.errorMessage(error), error);
         }
     }
 
-    async pubsub(subject: string, data: object): Promise<void> {
+    async pubsub(subject: string, data?: Uint8Array | string | object): Promise<void> {
         await this.publish({
             subject,
             data,
@@ -240,18 +402,75 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
 
     async request(options: RequestOptions): Promise<NatsMessage> {
         try {
-            const conn = await this.getConnection();
-            const data = this.encodeData(options.data);
-            const timeout = options.timeout ?? 5000;
+            return await this.runOperation(async () => {
+                assertNonEmptyString(options.subject, 'request subject');
+                if (options.expectedResponseCount !== undefined && options.expectedResponseCount !== 1) {
+                    throw new RangeError('expectedResponseCount is only supported by requestMany()');
+                }
+                validateDedicatedReply(options.noMux, options.reply);
+                const timeout = options.timeout ?? this.options.requestTimeoutMs;
+                assertPositiveInteger(timeout, 'request timeout');
+                const conn = await this.getConnection();
+                const data = this.encodeData(options.data);
 
-            const msg = await conn.request(options.subject, data, {
-                timeout,
-                ...(options.headers && { headers: this.toHeaders(options.headers) }),
+                const msg = await conn.request(options.subject, data, {
+                    timeout,
+                    ...(options.headers && { headers: this.toHeaders(options.headers) }),
+                    ...(options.noMux && { noMux: true, reply: options.reply }),
+                });
+
+                return this.convertMessage(msg);
             });
-
-            return this.convertMessage(msg);
         } catch (error) {
-            throw new NatsRequestError(options.subject, (error as Error).message);
+            this.rethrowServiceClosed(error);
+            throw new NatsRequestError(options.subject, this.errorMessage(error), error);
+        }
+    }
+
+    async requestMany(options: RequestManyOptions): Promise<NatsMessage[]> {
+        try {
+            return await this.runOperation(async () => {
+                assertNonEmptyString(options.subject, 'request subject');
+                const maxWait = options.maxWait ?? this.options.requestTimeoutMs;
+                assertPositiveInteger(maxWait, 'request maxWait');
+
+                const strategy =
+                    options.strategy ??
+                    (options.expectedResponseCount === undefined ? RequestStrategy.Timer : RequestStrategy.Count);
+                const nativeStrategy = toRequestStrategy(strategy);
+                if (nativeStrategy === RequestStrategy.Count) {
+                    assertPositiveInteger(options.expectedResponseCount, 'expectedResponseCount');
+                } else if (options.expectedResponseCount !== undefined) {
+                    throw new RangeError('expectedResponseCount can only be used with the count strategy');
+                }
+                if (options.jitter !== undefined) {
+                    assertNonNegativeInteger(options.jitter, 'request jitter');
+                    if (nativeStrategy !== RequestStrategy.JitterTimer) {
+                        throw new RangeError('jitter can only be used with the jitter strategy');
+                    }
+                }
+                if (options.noMux !== undefined && typeof options.noMux !== 'boolean') {
+                    throw new TypeError('noMux must be a boolean');
+                }
+
+                const conn = await this.getConnection();
+                const messages = await conn.requestMany(options.subject, this.encodeData(options.data), {
+                    strategy: nativeStrategy,
+                    maxWait,
+                    ...(options.expectedResponseCount !== undefined && { maxMessages: options.expectedResponseCount }),
+                    ...(options.jitter !== undefined && { jitter: options.jitter }),
+                    ...(options.noMux !== undefined && { noMux: options.noMux }),
+                    ...(options.headers && { headers: this.toHeaders(options.headers) }),
+                });
+                const responses: NatsMessage[] = [];
+                for await (const message of messages) {
+                    responses.push(this.convertMessage(message));
+                }
+                return responses;
+            });
+        } catch (error) {
+            this.rethrowServiceClosed(error);
+            throw new NatsRequestError(options.subject, this.errorMessage(error), error);
         }
     }
 
@@ -274,17 +493,18 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
 
     private async createSubscription(options: SubscribeOptions, handler: SubscriptionHandler): Promise<Subscription> {
         try {
+            validateSubscribeOptions(options);
+            assertFunction(handler, 'subscription handler');
             const conn = await this.getConnection();
             this.assertRunning();
 
             const sub = conn.subscribe(options.subject, {
                 queue: options.queue,
+                max: options.maxMessages,
+                timeout: options.timeout,
             });
 
-            const sid = sub.getID();
-            this.subscriptions.set(sid, sub);
-
-            this.startSubscriptionLoop(sid, sub, options.subject, async msg => {
+            const subscription = this.registerSubscription(sub, options.subject, options.queue, async msg => {
                 try {
                     await handler(this.convertMessage(msg));
                 } catch (error) {
@@ -293,29 +513,27 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
             });
 
             this.logger.log(`Subscribed to ${options.subject}${options.queue ? ` (queue: ${options.queue})` : ''}`);
-
-            return {
-                sid,
-                subject: options.subject,
-                queue: options.queue,
-                cancel: () => {
-                    this.cancelSubscription(sid, sub);
-                },
-                isCancelled: () => sub.isClosed(),
-            };
+            return subscription;
         } catch (error) {
-            throw new NatsSubscribeError(options.subject, (error as Error).message);
+            this.rethrowServiceClosed(error);
+            throw new NatsSubscribeError(options.subject, this.errorMessage(error), error);
         }
     }
 
-    async subscribe$(subject: string, handler: (data: unknown) => Promise<void>): Promise<Subscription> {
+    async subscribe$<T = unknown>(subject: string, handler: (data: T) => Promise<void> | void): Promise<Subscription> {
         return this.subscribe({ subject }, async (msg: NatsMessage) => {
-            const data = this.decodeData(msg.data);
+            const data = this.decodeData(msg.data) as T;
             await handler(data);
         });
     }
 
     unsubscribe(subscription: Subscription): void {
+        if (!this.ownedSubscriptions.has(subscription)) {
+            throw new NatsSubscriptionOwnershipError();
+        }
+        if (this.subscriptionRecords.get(subscription.sid)?.handle !== subscription) {
+            return;
+        }
         const sub = this.subscriptions.get(subscription.sid);
         if (sub) {
             this.cancelSubscription(subscription.sid, sub);
@@ -328,19 +546,30 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
 
     async jsPublish(options: JetStreamPublishOptions): Promise<PubAck> {
         try {
-            const js = await this.getJetStream();
-            const data = this.encodeData(options.data);
+            return await this.runOperation(async () => {
+                assertNonEmptyString(options.stream, 'JetStream stream');
+                assertNonEmptyString(options.subject, 'JetStream publish subject');
+                const timeout = options.timeout ?? this.options.requestTimeoutMs;
+                assertPositiveInteger(timeout, 'JetStream publish timeout');
+                const js = await this.getJetStream();
+                const data = this.encodeData(options.data);
 
-            const pubAck = await js.publish(options.subject, data, {
-                timeout: options.timeout ?? 5000,
-                headers: this.toHeaders(options.headers),
+                const pubAck = await js.publish(options.subject, data, {
+                    timeout,
+                    headers: this.toHeaders(options.headers),
+                });
+
+                if (pubAck.stream !== options.stream) {
+                    throw new Error(`JetStream acknowledged stream ${pubAck.stream}, expected ${options.stream}`);
+                }
+
+                this.logger.debug(`JetStream published to ${options.subject} in stream ${options.stream}`);
+
+                return pubAck;
             });
-
-            this.logger.debug(`JetStream published to ${options.subject} in stream ${options.stream}`);
-
-            return pubAck;
         } catch (error) {
-            throw new NatsPublishError(`${options.stream}:${options.subject}`, (error as Error).message);
+            this.rethrowServiceClosed(error);
+            throw new NatsPublishError(`${options.stream}:${options.subject}`, this.errorMessage(error), error);
         }
     }
 
@@ -353,6 +582,8 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         handler: JetStreamSubscriptionHandler,
     ): Promise<Subscription> {
         try {
+            validateJetStreamSubscribeOptions(options);
+            assertFunction(handler, 'JetStream subscription handler');
             const js = await this.getJetStream();
             this.assertRunning();
             const consumerOptions = this.createConsumerOptions(options);
@@ -360,13 +591,10 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
 
             if (this.shuttingDown) {
                 sub.unsubscribe();
-                throw new Error('NATS service is shutting down');
+                throw new NatsServiceClosedError();
             }
 
-            const sid = sub.getID();
-            this.subscriptions.set(sid, sub);
-
-            this.startSubscriptionLoop(sid, sub, options.subject, async msg => {
+            const subscription = this.registerSubscription(sub, options.subject, options.queue, async msg => {
                 const natsMsg = this.convertJetStreamMessage(msg);
                 const shouldAcknowledge = !options.manualAck && options.config?.ackPolicy !== 'none';
 
@@ -386,18 +614,10 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
             });
 
             this.logger.log(`JetStream subscribed to ${options.subject} in stream ${options.stream}`);
-
-            return {
-                sid,
-                subject: options.subject,
-                queue: options.queue,
-                cancel: () => {
-                    this.cancelSubscription(sid, sub);
-                },
-                isCancelled: () => sub.isClosed(),
-            };
+            return subscription;
         } catch (error) {
-            throw new NatsSubscribeError(`${options.stream}:${options.subject}`, (error as Error).message);
+            this.rethrowServiceClosed(error);
+            throw new NatsSubscribeError(`${options.stream}:${options.subject}`, this.errorMessage(error), error);
         }
     }
 
@@ -423,10 +643,6 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
             return;
         }
 
-        if (config.startSeq !== undefined && config.startTime !== undefined) {
-            throw new Error('startSeq and startTime are mutually exclusive');
-        }
-
         switch (config.deliverPolicy) {
             case 'all':
                 consumerOptions.deliverAll();
@@ -441,16 +657,10 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
                 consumerOptions.deliverLastPerSubject();
                 break;
             case 'by_start_sequence':
-                if (config.startSeq === undefined) {
-                    throw new Error('deliverPolicy by_start_sequence requires startSeq');
-                }
-                consumerOptions.startSequence(config.startSeq);
+                consumerOptions.startSequence(config.startSeq!);
                 break;
             case 'by_start_time':
-                if (config.startTime === undefined) {
-                    throw new Error('deliverPolicy by_start_time requires startTime');
-                }
-                consumerOptions.startTime(config.startTime);
+                consumerOptions.startTime(config.startTime!);
                 break;
             case undefined:
                 if (config.startSeq !== undefined) {
@@ -503,12 +713,42 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         return setup;
     }
 
+    private registerSubscription<T>(
+        sub: SubscriptionLifecycle & AsyncIterable<T>,
+        subject: string,
+        queue: string | undefined,
+        handler: (message: T) => Promise<void>,
+    ): Subscription {
+        const sid = sub.getID();
+        const existing = this.subscriptions.get(sid);
+        if (existing && existing !== sub) {
+            sub.unsubscribe();
+            throw new Error(`NATS subscription id ${sid} is already managed`);
+        }
+
+        this.subscriptions.set(sid, sub);
+        const closed = this.startSubscriptionLoop(sid, sub, subject, handler);
+        let handle!: Subscription;
+        handle = {
+            sid,
+            subject,
+            queue,
+            closed,
+            cancel: () => this.cancelOwnedSubscription(handle, sub),
+            drain: () => this.drainOwnedSubscription(handle, sub),
+            isCancelled: () => sub.isClosed(),
+        };
+        this.subscriptionRecords.set(sid, { native: sub, handle });
+        this.ownedSubscriptions.add(handle);
+        return handle;
+    }
+
     private startSubscriptionLoop<T>(
         sid: number,
         sub: SubscriptionLifecycle & AsyncIterable<T>,
         subject: string,
         handler: (message: T) => Promise<void>,
-    ): void {
+    ): Promise<void> {
         const task = (async () => {
             try {
                 for await (const message of sub) {
@@ -527,6 +767,9 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
                     if (this.subscriptions.get(sid) === sub) {
                         this.subscriptions.delete(sid);
                     }
+                    if (this.subscriptionRecords.get(sid)?.native === sub) {
+                        this.subscriptionRecords.delete(sid);
+                    }
                 }
             }
         })();
@@ -538,6 +781,25 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
             }
         };
         void task.then(clearTask, clearTask);
+        return task;
+    }
+
+    private cancelOwnedSubscription(handle: Subscription, sub: SubscriptionLifecycle): void {
+        if (this.subscriptionRecords.get(handle.sid)?.handle !== handle) {
+            return;
+        }
+        this.cancelSubscription(handle.sid, sub);
+    }
+
+    private async drainOwnedSubscription(handle: Subscription, sub: SubscriptionLifecycle): Promise<void> {
+        if (this.subscriptionRecords.get(handle.sid)?.handle !== handle) {
+            await handle.closed;
+            return;
+        }
+        if (!sub.isClosed()) {
+            await sub.drain();
+        }
+        await handle.closed;
     }
 
     private cancelSubscription(sid: number, sub: SubscriptionLifecycle): void {
@@ -548,6 +810,9 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         } finally {
             if (this.subscriptions.get(sid) === sub) {
                 this.subscriptions.delete(sid);
+            }
+            if (this.subscriptionRecords.get(sid)?.native === sub) {
+                this.subscriptionRecords.delete(sid);
             }
         }
     }
@@ -579,7 +844,7 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
     // =========================================================================
 
     private encodeData(data?: Uint8Array | string | object): Uint8Array {
-        if (!data) {
+        if (data === undefined) {
             return new Uint8Array(0);
         }
 
@@ -626,7 +891,7 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
     }
 
     private convertMessageFields(
-        msg: Pick<Msg, 'data' | 'headers' | 'sid' | 'subject'> & Partial<Pick<Msg, 'reply'>>,
+        msg: Pick<Msg, 'data' | 'headers' | 'sid' | 'subject'> & Partial<Pick<Msg, 'reply' | 'respond'>>,
     ): NatsMessage {
         const headers: Record<string, string> = {};
         if (msg.headers) {
@@ -642,6 +907,14 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
             headers,
             reply: msg.reply,
             timestamp: Date.now(),
+            respond: (data, responseHeaders) => {
+                if (!msg.respond) {
+                    return false;
+                }
+                return msg.respond(this.encodeData(data), {
+                    ...(responseHeaders && { headers: this.toHeaders(responseHeaders) }),
+                });
+            },
         };
     }
 
@@ -654,7 +927,13 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
 
     private assertRunning(): void {
         if (this.shuttingDown) {
-            throw new Error('NATS service is shutting down');
+            throw new NatsServiceClosedError();
+        }
+    }
+
+    private rethrowServiceClosed(error: unknown): void {
+        if (error instanceof NatsServiceClosedError) {
+            throw error;
         }
     }
 
@@ -668,14 +947,110 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
         }
         const hdrs = createNatsHeaders();
         for (const [key, value] of Object.entries(input)) {
+            assertNonEmptyString(key, 'header name');
+            if (typeof value !== 'string') {
+                throw new TypeError(`header ${key} must be a string`);
+            }
             hdrs.set(key, value);
         }
         return hdrs;
     }
 
+    private runOperation<T>(operation: () => Promise<T>): Promise<T> {
+        this.assertRunning();
+        const task = Promise.resolve().then(() => {
+            this.assertRunning();
+            return operation();
+        });
+        this.inFlightOperations.add(task);
+        void task.then(
+            () => this.inFlightOperations.delete(task),
+            () => this.inFlightOperations.delete(task),
+        );
+        return task;
+    }
+
+    private invoke<T>(operation: () => Promise<T>): Promise<T> {
+        try {
+            return operation();
+        } catch (error) {
+            return Promise.reject(error);
+        }
+    }
+
+    private isConnectionUsable(connection: NatsConnection): boolean {
+        try {
+            return !connection.isClosed() && !connection.isDraining();
+        } catch {
+            return false;
+        }
+    }
+
+    private trackConnectionTask(task: Promise<void>): void {
+        this.connectionTasks.add(task);
+        void task.then(
+            () => this.connectionTasks.delete(task),
+            () => this.connectionTasks.delete(task),
+        );
+    }
+
+    private async observeConnectionClose(connection: NatsConnection): Promise<void> {
+        try {
+            const error = await connection.closed();
+            if (error) {
+                this.logger.error(`NATS connection closed with error: ${error.message}`);
+            }
+            if (this.connection === connection) {
+                this.connection = null;
+                this.jetStream = null;
+                this.connectionState.connected = false;
+                if (error) {
+                    this.connectionState.lastError = error.message;
+                }
+            }
+        } catch (error) {
+            this.logger.error(`Error waiting for NATS connection close: ${this.errorMessage(error)}`);
+        }
+    }
+
+    private async closeLateConnection(connection: NatsConnection): Promise<void> {
+        const result = await settleWithin(
+            this.invoke(() => connection.close()),
+            this.options.shutdownTimeoutMs,
+        );
+        if (result.status !== 'fulfilled') {
+            this.logSettlementFailure('closing late NATS connection', result);
+        }
+    }
+
+    private async awaitTasks(tasks: Promise<unknown>[], deadline: number, description: string): Promise<void> {
+        if (tasks.length === 0) {
+            return;
+        }
+        const result = await settleWithin(Promise.allSettled(tasks), remainingMs(deadline));
+        if (result.status !== 'fulfilled') {
+            this.logSettlementFailure(`waiting for ${description}s`, result);
+        }
+    }
+
+    private logSettlementFailure(
+        action: string,
+        result: Exclude<SettleResult<unknown>, { status: 'fulfilled' }>,
+    ): void {
+        const message =
+            result.status === 'timeout'
+                ? `Timed out ${action} after ${this.options.shutdownTimeoutMs}ms total shutdown time`
+                : `Failed ${action}: ${this.errorMessage(result.reason)}`;
+        this.connectionState.lastError = message;
+        this.logger.error(message);
+    }
+
     private async monitorStatus(connection: NatsConnection): Promise<void> {
         try {
             for await (const status of connection.status()) {
+                if (this.connection !== connection) {
+                    continue;
+                }
                 if (status.type === Events.Reconnect) {
                     this.connectionState.connected = true;
                     this.connectionState.server = connection.getServer() || '';
@@ -690,7 +1065,135 @@ export class NatsServiceImpl implements OnModuleInit, OnModuleDestroy {
                 }
             }
         } catch (error) {
-            this.logger.error(`NATS status monitor stopped: ${this.errorMessage(error)}`);
+            if (this.connection === connection) {
+                const message = this.errorMessage(error);
+                this.connectionState.lastError = message;
+                this.logger.error(`NATS status monitor stopped: ${message}`);
+            }
         }
     }
+}
+
+function validateSubscribeOptions(options: SubscribeOptions): void {
+    assertNonEmptyString(options.subject, 'subscription subject');
+    if (options.queue !== undefined) assertNonEmptyString(options.queue, 'subscription queue');
+    if (options.maxMessages !== undefined) assertPositiveInteger(options.maxMessages, 'maxMessages');
+    if (options.timeout !== undefined) assertPositiveInteger(options.timeout, 'subscription timeout');
+}
+
+function validateDedicatedReply(noMux: boolean | undefined, reply: string | undefined): void {
+    if (noMux !== undefined && typeof noMux !== 'boolean') {
+        throw new TypeError('noMux must be a boolean');
+    }
+    if (reply !== undefined) {
+        assertNonEmptyString(reply, 'request reply subject');
+    }
+    if (noMux === true && reply === undefined) {
+        throw new RangeError('request reply is required when noMux is true');
+    }
+    if (reply !== undefined && noMux !== true) {
+        throw new RangeError('request noMux must be true when reply is configured');
+    }
+}
+
+function validateJetStreamSubscribeOptions(options: JetStreamSubscribeOptions): void {
+    validateSubscribeOptions(options);
+    assertNonEmptyString(options.stream, 'JetStream stream');
+    if (options.durable !== undefined) assertNonEmptyString(options.durable, 'JetStream durable name');
+    if (options.deliverSubject !== undefined) assertNonEmptyString(options.deliverSubject, 'JetStream deliver subject');
+    if (options.manualAck !== undefined && typeof options.manualAck !== 'boolean') {
+        throw new TypeError('manualAck must be a boolean');
+    }
+
+    const config = options.config;
+    if (!config) return;
+    if (config.startSeq !== undefined && config.startTime !== undefined) {
+        throw new RangeError('startSeq and startTime are mutually exclusive');
+    }
+    if (config.startSeq !== undefined) assertPositiveInteger(config.startSeq, 'startSeq');
+    if (
+        config.startTime !== undefined &&
+        (!(config.startTime instanceof Date) || Number.isNaN(config.startTime.getTime()))
+    ) {
+        throw new TypeError('startTime must be a valid Date');
+    }
+    if (config.deliverPolicy === 'by_start_sequence' && config.startSeq === undefined) {
+        throw new RangeError('deliverPolicy by_start_sequence requires startSeq');
+    }
+    if (config.deliverPolicy === 'by_start_time' && config.startTime === undefined) {
+        throw new RangeError('deliverPolicy by_start_time requires startTime');
+    }
+    if (config.ackWait !== undefined) assertPositiveInteger(config.ackWait, 'ackWait');
+    if (config.maxDeliver !== undefined && config.maxDeliver !== -1) {
+        assertPositiveInteger(config.maxDeliver, 'maxDeliver');
+    }
+    if (config.maxAckPending !== undefined) assertPositiveInteger(config.maxAckPending, 'maxAckPending');
+    if (config.rateLimit !== undefined) assertPositiveInteger(config.rateLimit, 'rateLimit');
+    if (config.samplingRate !== undefined) {
+        assertNonNegativeInteger(config.samplingRate, 'samplingRate');
+        if (config.samplingRate > 100) throw new RangeError('samplingRate must be between 0 and 100');
+    }
+    if (config.maxMessages !== undefined) assertPositiveInteger(config.maxMessages, 'maxMessages');
+    if (config.filterSubject !== undefined) assertNonEmptyString(config.filterSubject, 'filterSubject');
+    if (config.idleHeartbeat !== undefined) assertPositiveInteger(config.idleHeartbeat, 'idleHeartbeat');
+}
+
+function toRequestStrategy(strategy: NonNullable<RequestManyOptions['strategy']>): RequestStrategy {
+    switch (strategy) {
+        case 'count':
+            return RequestStrategy.Count;
+        case 'timer':
+            return RequestStrategy.Timer;
+        case 'jitter':
+            return RequestStrategy.JitterTimer;
+        case 'sentinel':
+            return RequestStrategy.SentinelMsg;
+        default:
+            throw new RangeError(`Unsupported request strategy: ${String(strategy)}`);
+    }
+}
+
+function assertNonEmptyString(value: unknown, name: string): asserts value is string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new TypeError(`${name} must be a non-empty string`);
+    }
+}
+
+function assertFunction(value: unknown, name: string): asserts value is (...args: unknown[]) => unknown {
+    if (typeof value !== 'function') {
+        throw new TypeError(`${name} must be a function`);
+    }
+}
+
+function assertPositiveInteger(value: unknown, name: string): asserts value is number {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+        throw new RangeError(`${name} must be a positive integer`);
+    }
+}
+
+function assertNonNegativeInteger(value: unknown, name: string): asserts value is number {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+        throw new RangeError(`${name} must be a non-negative integer`);
+    }
+}
+
+function remainingMs(deadline: number): number {
+    return Math.max(0, deadline - Date.now());
+}
+
+function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<SettleResult<T>> {
+    return new Promise(resolve => {
+        let completed = false;
+        const finish = (result: SettleResult<T>) => {
+            if (completed) return;
+            completed = true;
+            clearTimeout(timer);
+            resolve(result);
+        };
+        const timer = setTimeout(() => finish({ status: 'timeout' }), Math.max(0, timeoutMs));
+        void promise.then(
+            value => finish({ status: 'fulfilled', value }),
+            reason => finish({ status: 'rejected', reason }),
+        );
+    });
 }

--- a/packages/nats/src/nats.types.ts
+++ b/packages/nats/src/nats.types.ts
@@ -5,7 +5,7 @@
 import type { PubAck } from 'nats';
 
 export interface NatsPackageOptions {
-    servers?: string[];
+    servers?: string | string[];
     name?: string;
     user?: string;
     pass?: string;
@@ -18,16 +18,29 @@ export interface NatsPackageOptions {
     tls?: TlsOptions;
     auth?: AuthOptions;
     jetstream?: JetStreamOptions;
+    /** Maximum total time spent draining operations and closing the connection. Defaults to 10 seconds. */
+    shutdownTimeoutMs?: number;
+    /** Drain buffered messages before closing. Defaults to true. */
+    drainOnShutdown?: boolean;
+    /** Default timeout for request/reply and health probes. Defaults to 5 seconds. */
+    requestTimeoutMs?: number;
 }
 
 /** @deprecated Use NatsPackageOptions instead */
 export type NatsModuleOptions = NatsPackageOptions;
 
 export interface TlsOptions {
+    handshakeFirst?: boolean;
     certFile?: string;
     keyFile?: string;
     caFile?: string;
+    cert?: string;
+    key?: string;
+    ca?: string;
+    /** Verify the server certificate. This compatibility alias defaults to true. */
     verify?: boolean;
+    /** Verify the server certificate. Prefer this explicit Node.js TLS name for new configurations. */
+    rejectUnauthorized?: boolean;
 }
 
 export interface AuthOptions {
@@ -58,12 +71,36 @@ export interface PublishOptions {
     data?: Uint8Array | string | object;
     headers?: Record<string, string>;
     reply?: string;
+    /** When set, flush the connection and require a server round trip within this duration. */
     timeout?: number;
 }
 
 export interface RequestOptions extends PublishOptions {
+    /** Maximum time to wait for the response. */
+    timeout?: number;
+    /** @deprecated Use `requestMany()` for more than one response. */
     expectedResponseCount?: number;
+    /** Use a dedicated response subscription. Requires `reply`. */
+    noMux?: boolean;
     headers?: Record<string, string>;
+}
+
+export type RequestManyStrategy = 'count' | 'timer' | 'jitter' | 'sentinel';
+
+export interface RequestManyOptions {
+    subject: string;
+    data?: Uint8Array | string | object;
+    headers?: Record<string, string>;
+    /** Maximum collection window. Defaults to the package request timeout. */
+    maxWait?: number;
+    /** Completion strategy. Defaults to `count` when a response count is supplied, otherwise `timer`. */
+    strategy?: RequestManyStrategy;
+    /** Required for the `count` strategy. */
+    expectedResponseCount?: number;
+    /** Jitter window for the `jitter` strategy. */
+    jitter?: number;
+    /** Use a dedicated response subscription rather than the shared request multiplexer. */
+    noMux?: boolean;
 }
 
 export interface PubAckPromise {
@@ -79,6 +116,10 @@ export interface PubAckPromise {
 export interface SubscribeOptions {
     subject: string;
     queue?: string;
+    /** Automatically stop after receiving this many messages. */
+    maxMessages?: number;
+    /** Fail the subscription iterator if no first message arrives within this duration. */
+    timeout?: number;
 }
 
 export interface SubscriptionConfig {
@@ -110,6 +151,8 @@ export interface NatsMessage {
     headers?: Record<string, string>;
     reply?: string;
     timestamp: number;
+    /** Respond to the message's reply subject. Returns false when no reply subject exists. */
+    respond(data?: Uint8Array | string | object, headers?: Record<string, string>): boolean;
 }
 
 export interface JetStreamMessage extends NatsMessage {
@@ -212,6 +255,13 @@ export interface PeerInfo {
     lag?: number;
 }
 
+export interface NatsHealthResult {
+    healthy: boolean;
+    server: string;
+    latencyMs: number;
+    error?: string;
+}
+
 // ============================================================================
 // Errors
 // ============================================================================
@@ -221,32 +271,85 @@ export class NatsError extends Error {
         message: string,
         public code: string,
         public statusCode: number = 500,
+        options?: ErrorOptions,
     ) {
-        super(message);
+        super(message, options);
         this.name = 'NatsError';
     }
 }
 
 export class NatsConnectionError extends NatsError {
-    constructor(server: string, reason?: string) {
-        super(`Failed to connect to NATS server ${server}: ${reason || 'Unknown error'}`, 'NATS_CONNECTION_ERROR', 503);
+    constructor(server: string, reason?: string, cause?: unknown) {
+        super(
+            `Failed to connect to NATS server ${server}: ${reason || 'Unknown error'}`,
+            'NATS_CONNECTION_ERROR',
+            503,
+            cause === undefined ? undefined : { cause },
+        );
+        this.name = 'NatsConnectionError';
     }
 }
 
 export class NatsPublishError extends NatsError {
-    constructor(subject: string, reason?: string) {
-        super(`Failed to publish to ${subject}: ${reason || 'Unknown error'}`, 'NATS_PUBLISH_ERROR', 500);
+    constructor(subject: string, reason?: string, cause?: unknown) {
+        super(
+            `Failed to publish to ${subject}: ${reason || 'Unknown error'}`,
+            'NATS_PUBLISH_ERROR',
+            500,
+            cause === undefined ? undefined : { cause },
+        );
+        this.name = 'NatsPublishError';
     }
 }
 
 export class NatsSubscribeError extends NatsError {
-    constructor(subject: string, reason?: string) {
-        super(`Failed to subscribe to ${subject}: ${reason || 'Unknown error'}`, 'NATS_SUBSCRIBE_ERROR', 500);
+    constructor(subject: string, reason?: string, cause?: unknown) {
+        super(
+            `Failed to subscribe to ${subject}: ${reason || 'Unknown error'}`,
+            'NATS_SUBSCRIBE_ERROR',
+            500,
+            cause === undefined ? undefined : { cause },
+        );
+        this.name = 'NatsSubscribeError';
     }
 }
 
 export class NatsRequestError extends NatsError {
-    constructor(subject: string, reason?: string) {
-        super(`Request to ${subject} failed: ${reason || 'Unknown error'}`, 'NATS_REQUEST_ERROR', 504);
+    constructor(subject: string, reason?: string, cause?: unknown) {
+        super(
+            `Request to ${subject} failed: ${reason || 'Unknown error'}`,
+            'NATS_REQUEST_ERROR',
+            504,
+            cause === undefined ? undefined : { cause },
+        );
+        this.name = 'NatsRequestError';
+    }
+}
+
+export class NatsConfigurationError extends NatsError {
+    constructor(reason: string) {
+        super(`Invalid NATS configuration: ${reason}`, 'NATS_CONFIGURATION_ERROR', 500);
+        this.name = 'NatsConfigurationError';
+    }
+}
+
+export class NatsServiceClosedError extends NatsError {
+    constructor() {
+        super('NATS service is shutting down', 'NATS_SERVICE_CLOSED', 503);
+        this.name = 'NatsServiceClosedError';
+    }
+}
+
+export class NatsJetStreamDisabledError extends NatsError {
+    constructor() {
+        super('JetStream is disabled by module configuration', 'NATS_JETSTREAM_DISABLED', 503);
+        this.name = 'NatsJetStreamDisabledError';
+    }
+}
+
+export class NatsSubscriptionOwnershipError extends NatsError {
+    constructor() {
+        super('The subscription is not managed by this NatsService instance', 'NATS_SUBSCRIPTION_OWNERSHIP_ERROR', 400);
+        this.name = 'NatsSubscriptionOwnershipError';
     }
 }

--- a/scripts/smoke-core-install.mjs
+++ b/scripts/smoke-core-install.mjs
@@ -151,7 +151,14 @@ import { ResilienceModule, RetryService } from '@a3s-lab/resilience';
 import { KyselyModule, createPostgresPoolConfig } from '@a3s-lab/kysely';
 import { RedissonModule, createRedissonModuleOptions } from '@a3s-lab/redisson';
 import { BullMQModule } from '@a3s-lab/bullmq';
-import { NatsModule } from '@a3s-lab/nats';
+import {
+    type NatsConnectionOptions,
+    type NatsHealthResult,
+    NatsModule,
+    NatsServiceClosedError,
+    type RequestManyOptions,
+    createNatsConnectionOptions,
+} from '@a3s-lab/nats';
 import { RustFSModule } from '@a3s-lab/rustfs';
 import { EtcdModule } from '@a3s-lab/etcd';
 import { CLICKHOUSE_OPTIONS_TOKEN, ClickHouseModule } from '@a3s-lab/clickhouse';
@@ -179,6 +186,21 @@ const logger = new LoggerServiceImpl({ json: true });
 const retry = new RetryService();
 const pool = createPostgresPoolConfig({ host: 'localhost', port: '5432' });
 const redis = createRedissonModuleOptions({ host: 'localhost', port: '6379' });
+const natsConnection: NatsConnectionOptions = createNatsConnectionOptions({
+    servers: 'nats://localhost:4222',
+    auth: { token: 'smoke-token' },
+});
+const natsHealth: NatsHealthResult = {
+    healthy: true,
+    server: 'nats://localhost:4222',
+    latencyMs: 1,
+};
+const natsRequestMany: RequestManyOptions = {
+    subject: 'resources.lookup',
+    strategy: 'count',
+    expectedResponseCount: 2,
+};
+const natsClosedError = new NatsServiceClosedError();
 const provider = createNestCqrsDomainEventPublisherProvider();
 const sandboxConnection = createA3SBoxConnectionConfig({
     apiUrl: 'https://api.box.test',
@@ -211,6 +233,10 @@ void logger;
 void retry;
 void pool;
 void redis;
+void natsConnection;
+void natsHealth;
+void natsRequestMany;
+void natsClosedError;
 void provider;
 void moduleRefs;
 void serviceRefs;
@@ -250,7 +276,12 @@ const expectedExports = {
     '@a3s-lab/kysely': ['KyselyModule', 'createPostgresPoolConfig'],
     '@a3s-lab/redisson': ['RedissonModule', 'createRedissonModuleOptions'],
     '@a3s-lab/bullmq': ['BullMQModule', 'BullMQService'],
-    '@a3s-lab/nats': ['NatsModule', 'NatsServiceImpl'],
+    '@a3s-lab/nats': [
+        'NatsModule',
+        'NatsServiceImpl',
+        'NatsServiceClosedError',
+        'createNatsConnectionOptions',
+    ],
     '@a3s-lab/rustfs': ['RustFSModule', 'RustFSServiceImpl'],
     '@a3s-lab/etcd': ['EtcdModule', 'EtcdService'],
     '@a3s-lab/clickhouse': ['CLICKHOUSE_OPTIONS_TOKEN', 'ClickHouseModule', 'ClickHouseService'],


### PR DESCRIPTION
## Summary
- validate and normalize first-party NATS connection, authentication, TLS, retry, timeout, and JetStream options
- add race-safe connection recovery, bounded health/flush/request APIs, request-many strategies, owned subscriptions, exact acknowledgements, and deterministic shutdown
- expand public types and structured errors, update package/root architecture documentation, changeset, and packed-consumer smoke coverage

## Verification
- `pnpm release:check`
- `pnpm smoke:core-install`
- `pnpm audit:prod`
- `pnpm --filter @a3s-lab/nats exec jest --coverage --runInBand --silent` (86 tests; 95.77% statements, 90.60% branches)