### PR TITLE
feat: harden ClickHouse client lifecycle

### DIFF
--- a/.changeset/safe-clickhouse-lifecycle.md
+++ b/.changeset/safe-clickhouse-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/clickhouse": minor
+---
+
+Add validated first-party client options, request cancellation and authentication controls, typed command and insert results, structured health and service statistics, a hard-bounded LRU database client pool, lifecycle-owned advanced SDK access, structured errors, and deterministic aggregate shutdown.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
-| `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
+| `@a3s-lab/clickhouse` | Validated official ClickHouse client integration with cancellable requests, typed query/insert helpers, bounded database-client pooling, health reporting, and deterministic shutdown. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run NestJS module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
 | `@a3s-lab/ai` | NestJS integration for the A3S coding-agent runtime through `@a3s-lab/code`, with injectable configuration and lifecycle-safe agent access. |
@@ -176,6 +176,8 @@ an `NPM_TOKEN` secret with access to the `@a3s-lab` scope.
 - HTTP metrics use route templates rather than raw URLs. Histogram memory is constant per series, and counters, gauges,
   and histograms cap label cardinality with an explicit overflow series.
 - Startup database migrations remain disabled in every environment unless the application explicitly opts in.
+- ClickHouse database overrides use a bounded LRU client pool. New work is rejected during shutdown, request signals are
+  combined with timeouts, and failed eviction never silently grows the pool.
 
 ## Design Boundaries
 

--- a/docs/framework-core.md
+++ b/docs/framework-core.md
@@ -19,7 +19,7 @@ Nestify separates reusable backend API capabilities from the sample application.
 | `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
-| `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
+| `@a3s-lab/clickhouse` | Validated official ClickHouse client integration with cancellable requests, typed helpers, bounded database-client pooling, health reporting, and deterministic shutdown. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
 | `@a3s-lab/ai` | NestJS module and service integration for the A3S coding-agent runtime provided by `@a3s-lab/code`. |
@@ -63,6 +63,8 @@ The NestJS integration packages accept NestJS 10 and 11 peers. Workspace builds,
   excess labels aggregate into a fixed overflow series, and HTTP paths come only from route templates or a fixed
   unmatched label.
 - Automatic migrations are fail-closed and require an explicit module or environment opt-in in production.
+- ClickHouse request cancellation combines caller signals with timeouts; database override clients are LRU-bounded, and
+  shutdown rejects new operations before draining tracked work and closing every owned client.
 
 ## Sample API Wiring
 
@@ -137,7 +139,7 @@ The framework core is covered by package tests for:
 - NATS module registration, publish/request encoding, subscriptions, JetStream publishing, and lifecycle cleanup
 - RustFS client registration, bucket/object commands, presigned URLs, multipart uploads, error mapping, and health checks
 - Etcd client registration, key-value operations, config cache, watches, leases, compare-and-set, health checks, and lifecycle cleanup
-- ClickHouse client routing and lifecycle
+- ClickHouse option normalization, SQL/format routing, request cancellation, bounded LRU client pooling, health probes, and failure-safe lifecycle cleanup
 - Migration provider wrapping and module registration
 - File upload validation, storage key handling, module registration, and upload interceptors
 - AI module registration, injected runtime access, session delegation, and lifecycle cleanup

--- a/packages/clickhouse/README.md
+++ b/packages/clickhouse/README.md
@@ -1,42 +1,184 @@
 # @a3s-lab/clickhouse
 
-NestJS wrapper for the official ClickHouse JavaScript client.
+Lifecycle-safe NestJS integration for the official ClickHouse JavaScript client. It provides validated configuration, bounded per-database client reuse, request cancellation, typed query helpers, health reporting, and deterministic shutdown.
 
 ## Install
 
 ```bash
-pnpm add @a3s-lab/clickhouse
-pnpm add @nestjs/common
+pnpm add @a3s-lab/clickhouse @nestjs/common
 ```
+
+`@clickhouse/client` is installed as a direct dependency of this package.
 
 ## Use
 
+Register one default database:
+
 ```ts
-import { ClickHouseModule, ClickHouseService } from '@a3s-lab/clickhouse';
+import { Module } from '@nestjs/common';
+import { ClickHouseModule } from '@a3s-lab/clickhouse';
 
-ClickHouseModule.register({
-    url: 'http://localhost:8123',
-    database: 'analytics',
-    application: 'api',
+@Module({
+    imports: [
+        ClickHouseModule.register({
+            url: 'https://clickhouse.example.com:8443',
+            database: 'analytics',
+            username: 'api',
+            password: process.env.CLICKHOUSE_PASSWORD,
+            application: 'reporting-api',
+            requestTimeoutMs: 10_000,
+            maxOpenConnections: 10,
+            maxDatabaseClients: 16,
+        }),
+    ],
+})
+export class AppModule {}
+```
+
+`registerAsync()` supports configuration services and secret providers:
+
+```ts
+ClickHouseModule.registerAsync({
+    inject: [ConfigService],
+    useFactory: (config: ConfigService) => ({
+        url: config.getOrThrow('CLICKHOUSE_URL'),
+        accessToken: config.get('CLICKHOUSE_ACCESS_TOKEN'),
+        database: 'analytics',
+    }),
 });
+```
 
-class EventReader {
+JWT access tokens are mutually exclusive with URL or explicit username/password authentication. Advanced options from the first-party SDK, including TLS, tracing, custom logging, compression, and HTTP agents, can be supplied through `clientOptions`. Named package options take precedence:
+
+```ts
+ClickHouseModule.register({
+    url: 'https://clickhouse.example.com:8443',
+    database: 'analytics',
+    clientOptions: {
+        tls: { ca_cert: trustedCa },
+        compression: { response: true, request: true },
+        keep_alive: { enabled: true, idle_socket_ttl: 2_500 },
+        clickhouse_settings: { async_insert: 1 },
+    },
+});
+```
+
+Use `createClickHouseClientOptions()` when the exact normalized first-party client configuration is needed outside Nest dependency injection:
+
+```ts
+import { createClickHouseClientOptions } from '@a3s-lab/clickhouse';
+
+const clientOptions = createClickHouseClientOptions({
+    url: process.env.CLICKHOUSE_URL,
+    database: 'analytics',
+    requestTimeoutMs: 5_000,
+});
+```
+
+### Queries and commands
+
+Prefer the explicit method matching the SQL result contract:
+
+```ts
+import { Injectable } from '@nestjs/common';
+import { ClickHouseService } from '@a3s-lab/clickhouse';
+
+@Injectable()
+export class EventReader {
     constructor(private readonly clickhouse: ClickHouseService) {}
 
-    async read() {
-        return this.clickhouse.queryJson<{ id: string }>('select id from events limit 10');
+    read(tenantId: string) {
+        return this.clickhouse.queryJson<{ id: string; kind: string }>(
+            `select id, kind from events where tenant_id = {tenantId:String}`,
+            {
+                queryParams: { tenantId },
+                queryId: `events-${tenantId}`,
+                timeoutMs: 2_000,
+            },
+        );
+    }
+
+    optimize() {
+        return this.clickhouse.command('optimize table events final');
     }
 }
 ```
 
+- `queryJson<T>()` consumes a `FORMAT JSON` response and returns its typed `data` envelope.
+- `queryText()` consumes any supported text format; a trailing `FORMAT <name>` is parsed safely outside strings and comments.
+- `command()` returns the official `CommandResult`, including its query id and server summary.
+- `execute()` remains as a compatibility convenience and routes common result-producing statements to `queryText()`; new code should prefer explicit methods.
+
+Request options support caller cancellation, bounded timeouts, query parameters, settings, sessions, roles, per-request authentication, HTTP headers, multipart parameters, and database routing:
+
+```ts
+const controller = new AbortController();
+
+await clickhouse.queryText('select count() from events', {
+    database: 'reporting',
+    timeoutMs: 1_500,
+    abortSignal: controller.signal,
+    clickHouseSettings: { max_threads: 2 },
+    role: 'reader',
+});
+```
+
+The package combines the caller's signal with its timeout signal, so either condition cancels the request.
+
+### Inserts
+
+```ts
+await clickhouse.insertJsonEachRow('events', [
+    { id: 'event-1', kind: 'created' },
+    { id: 'event-2', kind: 'confirmed' },
+]);
+
+const result = await clickhouse.insert('events', [{ id: 'event-3', kind: 'cancelled' }]);
+```
+
+`insertJsonEachRow()` preserves the original no-op behavior for an empty array. `insert()` delegates empty arrays to the official client and returns its `InsertResult`.
+
+### Database client pool
+
+The configured database owns one client. Request-level database overrides use an LRU pool capped by `maxDatabaseClients` (default `16`). `database: null` selects `rootDatabase` (default `default`).
+
+Idle clients are closed before replacement. If every override client is busy, or an evicted client cannot be closed, allocation fails with `ClickHouseClientPoolExhaustedError` instead of exceeding the bound or reusing a closing client.
+
+For advanced SDK operations, keep all work—including stream consumption—inside `withClient()` so shutdown and pool ownership remain correct:
+
+```ts
+await clickhouse.withClient(async client => {
+    const result = await client.query({ query: 'select * from events', format: 'JSONEachRow' });
+    for await (const rows of result.stream<{ id: string }>()) {
+        consume(rows);
+    }
+}, { database: 'analytics' });
+```
+
+### Health and lifecycle
+
+```ts
+const health = await clickhouse.healthCheck();
+const healthy = await clickhouse.ping();
+const stats = clickhouse.getStats();
+```
+
+Health checks use an authenticated `SELECT` probe and return the database, latency, and failure message. `ping()` is the boolean compatibility helper.
+
+Nest calls `close()` through `onModuleDestroy()`. Shutdown rejects new work, waits for registered operations within one total `shutdownTimeoutMs` deadline, attempts every client close concurrently, and reports aggregate failures as `ClickHouseShutdownError`. `close()` is public and idempotent for non-Nest runtimes.
+
 ## Exports
 
-- `ClickHouseModule`
-- `ClickHouseService`
-- Module options, async options, request options, and JSON response types
+- `ClickHouseModule`, `ClickHouseService`, and `CLICKHOUSE_OPTIONS_TOKEN`
+- `createClickHouseClientOptions`
+- Module, request, health, statistics, JSON response, official client, result, format, authentication, and settings types
+- `ClickHousePackageError` and configuration, request, closed-service, pool-exhaustion, and shutdown error classes
 
 ## Notes
 
-This package owns connection and query helpers only. Table schemas, query text, credentials, and deployment choices belong in the consuming API.
+- Use `queryParams` for values. SQL text, table names, database names, roles, and settings remain caller-owned policy; never interpolate untrusted identifiers.
+- The package does not retry commands or inserts because doing so without application idempotency rules can duplicate work.
+- Fully consume or close first-party result streams inside `withClient()`. Returning an unconsumed stream from the callback releases its lifecycle lease too early.
+- The client pool is per Nest provider instance. It is not a cross-process connection coordinator.
 
-See the [framework core guide](../../docs/framework-core.md) for package boundaries.
+See the [framework core guide](../../docs/framework-core.md) for package boundaries and release verification.

--- a/packages/clickhouse/package.json
+++ b/packages/clickhouse/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@a3s-lab/clickhouse",
     "version": "0.1.0",
-    "description": "NestJS wrapper for the official ClickHouse JavaScript client",
+    "description": "Lifecycle-safe NestJS integration for the official ClickHouse JavaScript client",
     "author": "A3S Lab",
     "license": "MIT",
     "homepage": "https://github.com/A3S-Lab/nestify/tree/main/packages/clickhouse#readme",
@@ -18,6 +18,8 @@
         "clickhouse",
         "database",
         "analytics",
+        "connection-pool",
+        "observability",
         "sql",
         "typescript"
     ],
@@ -48,7 +50,7 @@
         "prepublishOnly": "pnpm run build"
     },
     "dependencies": {
-        "@clickhouse/client": "^1.18.5"
+        "@clickhouse/client": "^1.22.0"
     },
     "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0"

--- a/packages/clickhouse/src/__tests__/clickhouse-options.spec.ts
+++ b/packages/clickhouse/src/__tests__/clickhouse-options.spec.ts
@@ -1,0 +1,133 @@
+import { ClickHouseConfigurationError, createClickHouseClientOptions } from '../index';
+
+describe('ClickHouse connection options', () => {
+    it('provides secure, bounded defaults without mutating the input', () => {
+        const input = {
+            clientOptions: {
+                compression: { response: true },
+            },
+        };
+
+        const result = createClickHouseClientOptions(input);
+
+        expect(result).toMatchObject({
+            url: 'http://localhost:8123',
+            database: 'default',
+            request_timeout: 10_000,
+            application: '@a3s-lab/clickhouse',
+            compression: { response: true },
+        });
+        expect(input).toEqual({ clientOptions: { compression: { response: true } } });
+        expect(result).not.toBe(input.clientOptions);
+    });
+
+    it('maps convenience options over advanced first-party client options', () => {
+        const result = createClickHouseClientOptions({
+            url: new URL('https://clickhouse.example.test///'),
+            database: ' analytics ',
+            accessToken: 'cloud-token',
+            requestTimeoutMs: 4_000,
+            maxOpenConnections: 8,
+            application: 'reporting-api',
+            pathname: '/proxy/clickhouse',
+            keepAlive: { enabled: true, idle_socket_ttl: 1_500 },
+            httpHeaders: { ' x-request-source ': 'nestify' },
+            role: ['reader', ' analyst '],
+            useMultipartParamsAuto: true,
+            clientOptions: {
+                url: 'http://ignored:8123',
+                database: 'ignored',
+                request_timeout: 1,
+                max_open_connections: 2,
+                capture_enhanced_stack_trace: true,
+            },
+        });
+
+        expect(result).toMatchObject({
+            url: 'https://clickhouse.example.test',
+            database: 'analytics',
+            access_token: 'cloud-token',
+            request_timeout: 4_000,
+            max_open_connections: 8,
+            application: 'reporting-api',
+            pathname: '/proxy/clickhouse',
+            keep_alive: { enabled: true, idle_socket_ttl: 1_500 },
+            http_headers: { 'x-request-source': 'nestify' },
+            role: ['reader', 'analyst'],
+            use_multipart_params_auto: true,
+            capture_enhanced_stack_trace: true,
+        });
+    });
+
+    it('normalizes deprecated host input into url and preserves proxy paths', () => {
+        expect(
+            createClickHouseClientOptions({
+                clientOptions: { host: 'https://proxy.example.test/clickhouse/' },
+            }),
+        ).toMatchObject({
+            url: 'https://proxy.example.test/clickhouse/',
+        });
+    });
+
+    it('supports basic authentication including an empty password', () => {
+        expect(
+            createClickHouseClientOptions({
+                username: 'default',
+                password: '',
+            }),
+        ).toMatchObject({ username: 'default', password: '' });
+    });
+
+    it.each([
+        { accessToken: 'token', username: 'default' },
+        { accessToken: 'token', password: 'secret' },
+        { accessToken: 'token', url: 'https://user:secret@clickhouse.example.test' },
+    ])('rejects conflicting authentication %#', options => {
+        expect(() => createClickHouseClientOptions(options)).toThrow(
+            'accessToken cannot be combined with username/password',
+        );
+    });
+
+    it.each([
+        'ftp://clickhouse.example.test',
+        'not a url',
+        'https://clickhouse.example.test/#fragment',
+    ])('rejects invalid endpoint %s', url => {
+        expect(() => createClickHouseClientOptions({ url })).toThrow(ClickHouseConfigurationError);
+    });
+
+    it.each([
+        ['requestTimeoutMs', 0],
+        ['requestTimeoutMs', 1.5],
+        ['pingTimeoutMs', -1],
+        ['shutdownTimeoutMs', Number.POSITIVE_INFINITY],
+        ['maxOpenConnections', 0],
+        ['maxDatabaseClients', -1],
+    ] as const)('rejects invalid numeric option %s=%s', (name, value) => {
+        expect(() => createClickHouseClientOptions({ [name]: value })).toThrow(ClickHouseConfigurationError);
+    });
+
+    it.each([
+        { database: '   ' },
+        { rootDatabase: '' },
+        { application: '' },
+        { username: '' },
+        { accessToken: '' },
+        { role: [] },
+        { role: ['reader', ''] },
+        { httpHeaders: { 'bad\nname': 'value' } },
+        { httpHeaders: { good: 'bad\rvalue' } },
+        { clientOptions: [] as never },
+    ])('rejects malformed structured options %#', options => {
+        expect(() => createClickHouseClientOptions(options)).toThrow(ClickHouseConfigurationError);
+    });
+
+    it('rejects host and url when both are supplied', () => {
+        expect(() =>
+            createClickHouseClientOptions({
+                url: 'http://clickhouse:8123',
+                clientOptions: { host: 'http://legacy:8123' },
+            }),
+        ).toThrow('clientOptions.host cannot be combined with url');
+    });
+});

--- a/packages/clickhouse/src/__tests__/index.spec.ts
+++ b/packages/clickhouse/src/__tests__/index.spec.ts
@@ -1,5 +1,14 @@
 import { createClient } from '@clickhouse/client';
-import { CLICKHOUSE_OPTIONS_TOKEN, ClickHouseModule, ClickHouseService } from '../index';
+import {
+    CLICKHOUSE_OPTIONS_TOKEN,
+    ClickHouseClientPoolExhaustedError,
+    ClickHouseModule,
+    ClickHouseRequestError,
+    ClickHouseService,
+    ClickHouseServiceClosedError,
+    ClickHouseShutdownError,
+    createClickHouseClientOptions,
+} from '../index';
 
 jest.mock('@clickhouse/client', () => ({
     createClient: jest.fn(),
@@ -7,40 +16,46 @@ jest.mock('@clickhouse/client', () => ({
 
 const mockedCreateClient = createClient as jest.MockedFunction<typeof createClient>;
 
-describe('clickhouse service', () => {
+describe('clickhouse package', () => {
     beforeEach(() => {
         mockedCreateClient.mockReset();
         mockedCreateClient.mockImplementation(() => createMockClient() as never);
     });
 
-    it('normalizes client options and registers Nest providers', () => {
-        const module = ClickHouseModule.register({
-            url: 'http://clickhouse:8123///',
-            username: 'default',
-            password: 'secret',
-            database: 'analytics',
-            application: 'api',
+    it('exports static and async Nest module registrations', () => {
+        const options = { url: 'http://clickhouse:8123', database: 'analytics' };
+        const staticModule = ClickHouseModule.register(options);
+        const factory = jest.fn(() => options);
+        const asyncModule = ClickHouseModule.registerAsync({
+            imports: [],
+            inject: ['CONFIG'],
+            useFactory: factory,
         });
 
-        expect(module.providers).toEqual([
+        expect(staticModule).toEqual({
+            module: ClickHouseModule,
+            providers: [{ provide: CLICKHOUSE_OPTIONS_TOKEN, useValue: options }, ClickHouseService],
+            exports: [ClickHouseService],
+        });
+        expect(asyncModule.module).toBe(ClickHouseModule);
+        expect(asyncModule.imports).toEqual([]);
+        expect(asyncModule.providers).toEqual([
             {
                 provide: CLICKHOUSE_OPTIONS_TOKEN,
-                useValue: {
-                    url: 'http://clickhouse:8123///',
-                    username: 'default',
-                    password: 'secret',
-                    database: 'analytics',
-                    application: 'api',
-                },
+                useFactory: factory,
+                inject: ['CONFIG'],
             },
             ClickHouseService,
         ]);
+        expect(createClickHouseClientOptions).toBeInstanceOf(Function);
+    });
 
+    it('normalizes client options before creating the default client', () => {
         new ClickHouseService({
             url: 'http://clickhouse:8123///',
             username: 'default',
             password: 'secret',
-            database: 'analytics',
+            database: ' analytics ',
             application: 'api',
         });
 
@@ -50,43 +65,148 @@ describe('clickhouse service', () => {
                 username: 'default',
                 password: 'secret',
                 database: 'analytics',
-                request_timeout: 10000,
+                request_timeout: 10_000,
                 application: 'api',
             }),
         );
     });
 
-    it('routes execute calls to query or command based on SQL kind', async () => {
+    it('routes result statements safely through query and commands through command', async () => {
         const client = createMockClient();
         mockedCreateClient.mockReturnValue(client as never);
         const service = new ClickHouseService({ url: 'http://clickhouse:8123' });
 
-        await expect(service.execute('select 1 FORMAT JSON')).resolves.toBe('query-result');
+        await expect(service.execute('/* leading comment */ SELECT 1 FORMAT JSON; -- trailing comment')).resolves.toBe(
+            'query-result',
+        );
+        await expect(service.execute('WITH 1 AS value SELECT value')).resolves.toBe('query-result');
         await expect(service.execute('create table events (id UInt64)')).resolves.toBe('');
 
-        expect(client.query).toHaveBeenCalledWith(
+        expect(client.query).toHaveBeenNthCalledWith(
+            1,
             expect.objectContaining({
-                query: 'select 1',
+                query: '/* leading comment */ SELECT 1',
                 format: 'JSON',
             }),
         );
         expect(client.command).toHaveBeenCalledWith(
+            expect.objectContaining({ query: 'create table events (id UInt64)' }),
+        );
+    });
+
+    it('does not treat FORMAT text inside strings or comments as a trailing format clause', async () => {
+        const client = createMockClient();
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({});
+
+        await service.queryText("select 'FORMAT CSV' as value -- FORMAT JSON");
+        await service.queryText("select 'it\\'s FORMAT CSV' as value");
+        await service.queryText("select 'it''s FORMAT CSV' as value");
+
+        expect(client.query).toHaveBeenCalledWith(
             expect.objectContaining({
-                query: 'create table events (id UInt64)',
+                query: "select 'FORMAT CSV' as value",
+                format: 'TabSeparated',
             }),
         );
     });
 
-    it('skips empty inserts and sends JSONEachRow for non-empty rows', async () => {
+    it('validates query formats and JSON response contracts', async () => {
         const client = createMockClient();
         mockedCreateClient.mockReturnValue(client as never);
-        const service = new ClickHouseService({ url: 'http://clickhouse:8123' });
+        const service = new ClickHouseService({});
+
+        await expect(service.queryJson<{ id: number }>('select 1 FORMAT JSON')).resolves.toEqual({
+            data: [{ id: 1 }],
+        });
+        await expect(service.queryJson('select 1 FORMAT CSV')).rejects.toThrow(
+            'queryJson only supports the JSON response format',
+        );
+        await expect(service.queryText('select 1 FORMAT UnknownRows')).rejects.toThrow(
+            "Unsupported ClickHouse response format 'UnknownRows'",
+        );
+        await expect(service.queryText("select 1 FORMAT 'JSON'")).rejects.toThrow(
+            'FORMAT must be followed by a supported format name',
+        );
+        await expect(service.queryText('FORMAT JSON')).rejects.toThrow('SQL before FORMAT must not be empty');
+        await expect(service.queryText(' -- only a comment')).rejects.toThrow('sql must contain a statement');
+    });
+
+    it('forwards complete request context and composes caller cancellation with timeout', async () => {
+        const client = createMockClient();
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({ requestTimeoutMs: 5_000 });
+        const controller = new AbortController();
+
+        await service.command('optimize table events', {
+            queryId: 'query-1',
+            clickHouseSettings: { max_threads: 2 },
+            queryParams: { tenant: 'a3s' },
+            timeoutMs: 100,
+            abortSignal: controller.signal,
+            sessionId: 'session-1',
+            role: ['reader'],
+            auth: { username: 'api', password: 'secret' },
+            httpHeaders: { 'x-request-id': 'request-1' },
+            useMultipartParams: true,
+            useMultipartParamsAuto: false,
+        });
+
+        const request = client.command.mock.calls[0][0];
+        expect(request).toMatchObject({
+            query: 'optimize table events',
+            query_id: 'query-1',
+            clickhouse_settings: { max_threads: 2 },
+            query_params: { tenant: 'a3s' },
+            session_id: 'session-1',
+            role: ['reader'],
+            auth: { username: 'api', password: 'secret' },
+            http_headers: { 'x-request-id': 'request-1' },
+            use_multipart_params: true,
+            use_multipart_params_auto: false,
+        });
+        expect(request.abort_signal).toBeInstanceOf(AbortSignal);
+        expect(request.abort_signal).not.toBe(controller.signal);
+        controller.abort();
+        expect(request.abort_signal?.aborted).toBe(true);
+    });
+
+    it.each([
+        ['', {}, 'sql must be a non-empty string'],
+        ['select 1', { timeoutMs: 0 }, 'timeoutMs must be a positive safe integer'],
+        ['select 1', { queryId: ' ' }, 'queryId must be a non-empty string'],
+        ['select 1', { database: ' ' }, 'database must be a non-empty string or null'],
+        ['select 1', { role: [] }, 'role must contain at least one role'],
+        ['select 1', { auth: { username: 'api' } }, 'auth.password must be a string'],
+        ['select 1', { auth: { access_token: '', username: 'api' } }, 'auth.access_token must be a non-empty string'],
+        ['select 1', { auth: { access_token: 'token', username: 'api' } }, 'JWT auth cannot be combined'],
+        ['select 1', { auth: null }, 'auth must be an object'],
+        ['select 1', { httpHeaders: { good: 'bad\nvalue' } }, 'must be a single-line string'],
+        ['select 1', { httpHeaders: { ' ': 'value' } }, 'invalid header name'],
+        ['select 1', { httpHeaders: [] }, 'httpHeaders must be an object'],
+        ['select 1', { abortSignal: {} }, 'abortSignal must be an AbortSignal'],
+        ['select 1', { queryParams: [] }, 'queryParams must be an object'],
+        ['select 1', { clickHouseSettings: [] }, 'clickHouseSettings must be an object'],
+    ] as const)('rejects malformed requests %#', async (sql, options, message) => {
+        const service = new ClickHouseService({});
+        await expect(service.command(sql, options as never)).rejects.toThrow(message);
+    });
+
+    it('preserves the compatibility insert helper and exposes insert results', async () => {
+        const client = createMockClient();
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({});
 
         await service.insertJsonEachRow('events', []);
-        await service.insertJsonEachRow('events', [{ id: 1, name: 'created' }]);
+        await service.insertJsonEachRow(' events ', [{ id: 1, name: 'created' }]);
+        await expect(service.insert('events', [])).resolves.toMatchObject({
+            executed: true,
+            query_id: 'insert-id',
+        });
 
-        expect(client.insert).toHaveBeenCalledTimes(1);
-        expect(client.insert).toHaveBeenCalledWith(
+        expect(client.insert).toHaveBeenCalledTimes(2);
+        expect(client.insert).toHaveBeenNthCalledWith(
+            1,
             expect.objectContaining({
                 table: 'events',
                 values: [{ id: 1, name: 'created' }],
@@ -95,43 +215,307 @@ describe('clickhouse service', () => {
         );
     });
 
-    it('creates and reuses clients for explicit database overrides', async () => {
+    it.each([
+        [' ', []],
+        ['events\nDROP TABLE users', []],
+        ['events', {}],
+    ])('rejects unsafe insert input %#', async (table, rows) => {
+        const service = new ClickHouseService({});
+        await expect(service.insertJsonEachRow(table, rows as never)).rejects.toBeInstanceOf(ClickHouseRequestError);
+    });
+
+    it('single-flights concurrent database client creation', async () => {
         const defaultClient = createMockClient();
         const analyticsClient = createMockClient();
         mockedCreateClient.mockReturnValueOnce(defaultClient as never).mockReturnValueOnce(analyticsClient as never);
-        const service = new ClickHouseService({ url: 'http://clickhouse:8123', database: 'default' });
+        const service = new ClickHouseService({ database: 'default' });
 
-        await service.command('optimize table events', { database: 'analytics' });
-        await service.command('optimize table visits', { database: 'analytics' });
+        await Promise.all([
+            service.command('optimize table events', { database: 'analytics' }),
+            service.command('optimize table visits', { database: 'analytics' }),
+        ]);
 
         expect(mockedCreateClient).toHaveBeenCalledTimes(2);
-        expect(mockedCreateClient).toHaveBeenLastCalledWith(expect.objectContaining({ database: 'analytics' }));
         expect(analyticsClient.command).toHaveBeenCalledTimes(2);
+        await service.command('optimize table cached', { database: 'analytics', role: ' reader ' });
+        expect(analyticsClient.command).toHaveBeenLastCalledWith(expect.objectContaining({ role: 'reader' }));
+        expect(service.getStats()).toMatchObject({
+            activeOperations: 0,
+            cachedDatabaseClients: 1,
+            databases: ['default', 'analytics'],
+            closing: false,
+        });
     });
 
-    it('closes all created clients on module destroy', async () => {
+    it('evicts the least recently used idle database client at the configured bound', async () => {
         const defaultClient = createMockClient();
+        const analyticsClient = createMockClient();
+        const reportingClient = createMockClient();
+        mockedCreateClient
+            .mockReturnValueOnce(defaultClient as never)
+            .mockReturnValueOnce(analyticsClient as never)
+            .mockReturnValueOnce(reportingClient as never);
+        const service = new ClickHouseService({ maxDatabaseClients: 1 });
+
+        await service.command('select 1', { database: 'analytics' });
+        await service.command('select 1', { database: 'reporting' });
+
+        expect(analyticsClient.close).toHaveBeenCalledTimes(1);
+        expect(reportingClient.command).toHaveBeenCalledTimes(1);
+        expect(service.getStats().databases).toEqual(['default', 'reporting']);
+    });
+
+    it('rejects pool growth while every override client is busy and recovers after release', async () => {
+        const defaultClient = createMockClient();
+        const analyticsClient = createMockClient();
+        const reportingClient = createMockClient();
+        mockedCreateClient
+            .mockReturnValueOnce(defaultClient as never)
+            .mockReturnValueOnce(analyticsClient as never)
+            .mockReturnValueOnce(reportingClient as never);
+        const service = new ClickHouseService({ maxDatabaseClients: 1 });
+        const gate = deferred<void>();
+        const entered = deferred<void>();
+        const held = service.withClient(
+            async () => {
+                entered.resolve();
+                await gate.promise;
+            },
+            { database: 'analytics' },
+        );
+        await entered.promise;
+
+        await expect(service.command('select 1', { database: 'reporting' })).rejects.toBeInstanceOf(
+            ClickHouseClientPoolExhaustedError,
+        );
+        expect(mockedCreateClient).toHaveBeenCalledTimes(2);
+
+        gate.resolve();
+        await held;
+        await service.command('select 1', { database: 'reporting' });
+        expect(analyticsClient.close).toHaveBeenCalledTimes(1);
+        expect(reportingClient.command).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the pool closed to growth when an evicted client fails to close', async () => {
+        const defaultClient = createMockClient();
+        const analyticsClient = createMockClient({
+            close: jest.fn().mockRejectedValue(new Error('socket close failed')),
+        });
+        mockedCreateClient.mockReturnValueOnce(defaultClient as never).mockReturnValueOnce(analyticsClient as never);
+        const service = new ClickHouseService({ maxDatabaseClients: 1 });
+        await service.command('select 1', { database: 'analytics' });
+
+        await expect(service.command('select 1', { database: 'reporting' })).rejects.toMatchObject({
+            code: 'CLICKHOUSE_CLIENT_POOL_EXHAUSTED',
+            cause: expect.objectContaining({ message: 'socket close failed' }),
+        });
+        await expect(service.command('select 1', { database: 'warehouse' })).rejects.toBeInstanceOf(
+            ClickHouseClientPoolExhaustedError,
+        );
+        expect(mockedCreateClient).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows pool recovery after a timed-out eviction eventually closes', async () => {
+        const closeGate = deferred<void>();
+        const defaultClient = createMockClient();
+        const analyticsClient = createMockClient({ close: jest.fn(() => closeGate.promise) });
+        const reportingClient = createMockClient();
+        mockedCreateClient
+            .mockReturnValueOnce(defaultClient as never)
+            .mockReturnValueOnce(analyticsClient as never)
+            .mockReturnValueOnce(reportingClient as never);
+        const service = new ClickHouseService({ maxDatabaseClients: 1, requestTimeoutMs: 10 });
+        await service.command('select 1', { database: 'analytics' });
+
+        await expect(service.command('select 1', { database: 'reporting' })).rejects.toMatchObject({
+            code: 'CLICKHOUSE_CLIENT_POOL_EXHAUSTED',
+        });
+        closeGate.resolve();
+        await closeGate.promise;
+        await Promise.resolve();
+
+        await service.command('select 1', { database: 'reporting' });
+        expect(reportingClient.command).toHaveBeenCalledTimes(1);
+    });
+
+    it('releases a client lease when advanced SDK work fails', async () => {
+        const analyticsClient = createMockClient();
+        mockedCreateClient
+            .mockImplementationOnce(() => createMockClient() as never)
+            .mockReturnValueOnce(analyticsClient as never);
+        const service = new ClickHouseService({ maxDatabaseClients: 1 });
+
+        await expect(
+            service.withClient(
+                () => {
+                    throw new Error('consumer failed');
+                },
+                { database: 'analytics' },
+            ),
+        ).rejects.toThrow('consumer failed');
+        await expect(service.withClient(null as never)).rejects.toThrow('callback must be a function');
+        expect(service.getStats().activeOperations).toBe(0);
+    });
+
+    it('routes null database overrides to the configured root database', async () => {
+        const analyticsClient = createMockClient();
         const rootClient = createMockClient();
-        mockedCreateClient.mockReturnValueOnce(defaultClient as never).mockReturnValueOnce(rootClient as never);
-        const service = new ClickHouseService({ url: 'http://clickhouse:8123', database: 'default' });
+        mockedCreateClient.mockReturnValueOnce(analyticsClient as never).mockReturnValueOnce(rootClient as never);
+        const service = new ClickHouseService({ database: 'analytics', rootDatabase: 'system' });
 
-        await service.command('create database analytics', { database: null });
-        await service.onModuleDestroy();
+        await service.command('show databases', { database: null });
 
+        expect(mockedCreateClient).toHaveBeenLastCalledWith(expect.objectContaining({ database: 'system' }));
+        expect(rootClient.command).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns structured authenticated health results and keeps ping compatible', async () => {
+        const client = createMockClient();
+        client.ping
+            .mockResolvedValueOnce({ success: true })
+            .mockResolvedValueOnce({ success: false, error: new Error('not authorized') })
+            .mockRejectedValueOnce(new Error('network down'));
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({ database: 'analytics', pingTimeoutMs: 50 });
+
+        await expect(service.healthCheck()).resolves.toMatchObject({
+            healthy: true,
+            database: 'analytics',
+        });
+        await expect(service.ping()).resolves.toBe(false);
+        await expect(service.healthCheck()).resolves.toMatchObject({
+            healthy: false,
+            error: 'network down',
+        });
+        expect(client.ping).toHaveBeenCalledWith(
+            expect.objectContaining({ select: true, abort_signal: expect.any(AbortSignal) }),
+        );
+    });
+
+    it('turns invalid or closed health probes into unhealthy results', async () => {
+        const service = new ClickHouseService({});
+
+        await expect(service.healthCheck({ database: ' ' })).resolves.toMatchObject({ healthy: false });
+        await service.close();
+        await expect(service.healthCheck()).resolves.toMatchObject({
+            healthy: false,
+            error: expect.stringContaining('closing or already closed'),
+        });
+    });
+
+    it('waits for active work, closes once, and rejects new work after shutdown starts', async () => {
+        const client = createMockClient();
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({ shutdownTimeoutMs: 250 });
+        const gate = deferred<void>();
+        const entered = deferred<void>();
+        const operation = service.withClient(async () => {
+            entered.resolve();
+            await gate.promise;
+        });
+        await entered.promise;
+
+        const closePromise = service.close();
+        expect(service.close()).toBe(closePromise);
+        expect(client.close).not.toHaveBeenCalled();
+        await expect(service.command('select 1')).rejects.toBeInstanceOf(ClickHouseServiceClosedError);
+
+        gate.resolve();
+        await operation;
+        await closePromise;
+        expect(client.close).toHaveBeenCalledTimes(1);
+        expect(service.getStats().closing).toBe(true);
+    });
+
+    it('tracks an operation before its asynchronous client acquisition yields', async () => {
+        const client = createMockClient();
+        const commandGate = deferred<void>();
+        client.command.mockImplementationOnce(async () => {
+            await commandGate.promise;
+            return { query_id: 'command-id' };
+        });
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({ shutdownTimeoutMs: 250 });
+
+        const operation = service.command('optimize table events');
+        const closePromise = service.close();
+        await Promise.resolve();
+        expect(client.close).not.toHaveBeenCalled();
+
+        commandGate.resolve();
+        await operation;
+        await closePromise;
+        expect(client.command).toHaveBeenCalledTimes(1);
+        expect(client.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('attempts every client close and preserves all shutdown failures', async () => {
+        const defaultClient = createMockClient({
+            close: jest.fn().mockRejectedValue(new Error('default close failed')),
+        });
+        const analyticsClient = createMockClient({
+            close: jest.fn().mockRejectedValue(new Error('analytics close failed')),
+        });
+        mockedCreateClient.mockReturnValueOnce(defaultClient as never).mockReturnValueOnce(analyticsClient as never);
+        const service = new ClickHouseService({});
+        await service.command('select 1', { database: 'analytics' });
+
+        await expect(service.close()).rejects.toMatchObject({
+            code: 'CLICKHOUSE_SHUTDOWN_ERROR',
+            errors: expect.arrayContaining([expect.any(Error), expect.any(Error)]),
+        });
         expect(defaultClient.close).toHaveBeenCalledTimes(1);
-        expect(rootClient.close).toHaveBeenCalledTimes(1);
+        expect(analyticsClient.close).toHaveBeenCalledTimes(1);
+        expect(ClickHouseShutdownError).toBeInstanceOf(Function);
+    });
+
+    it('bounds shutdown even when the first-party client close never settles', async () => {
+        const client = createMockClient({ close: jest.fn(() => new Promise<void>(() => undefined)) });
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({ shutdownTimeoutMs: 10 });
+        const startedAt = Date.now();
+
+        await expect(service.close()).rejects.toMatchObject({ code: 'CLICKHOUSE_SHUTDOWN_ERROR' });
+        expect(Date.now() - startedAt).toBeLessThan(250);
+        expect(client.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('bounds waiting for active operations and exposes the Nest destroy hook', async () => {
+        const client = createMockClient();
+        mockedCreateClient.mockReturnValue(client as never);
+        const service = new ClickHouseService({ shutdownTimeoutMs: 10 });
+        const gate = deferred<void>();
+        const operation = service.withClient(() => gate.promise);
+
+        await expect(service.onModuleDestroy()).rejects.toMatchObject({ code: 'CLICKHOUSE_SHUTDOWN_ERROR' });
+        expect(client.close).toHaveBeenCalledTimes(1);
+        gate.resolve();
+        await operation;
     });
 });
 
-function createMockClient() {
+function createMockClient(overrides: Record<string, unknown> = {}) {
     return {
-        command: jest.fn().mockResolvedValue(undefined),
+        command: jest.fn().mockResolvedValue({ query_id: 'command-id' }),
         query: jest.fn().mockResolvedValue({
             json: jest.fn().mockResolvedValue({ data: [{ id: 1 }] }),
             text: jest.fn().mockResolvedValue('query-result'),
+            close: jest.fn(),
         }),
-        insert: jest.fn().mockResolvedValue(undefined),
+        insert: jest.fn().mockResolvedValue({ executed: true, query_id: 'insert-id' }),
         ping: jest.fn().mockResolvedValue({ success: true }),
         close: jest.fn().mockResolvedValue(undefined),
+        ...overrides,
     };
+}
+
+function deferred<T>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
 }

--- a/packages/clickhouse/src/clickhouse-options.ts
+++ b/packages/clickhouse/src/clickhouse-options.ts
@@ -1,0 +1,223 @@
+import type { ClickHouseClientConfigOptions } from '@clickhouse/client';
+import { ClickHouseConfigurationError, type ClickHouseModuleOptions } from './clickhouse.types';
+
+const DEFAULT_URL = 'http://localhost:8123';
+const DEFAULT_DATABASE = 'default';
+const DEFAULT_APPLICATION = '@a3s-lab/clickhouse';
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+const DEFAULT_PING_TIMEOUT_MS = 2_000;
+const DEFAULT_SHUTDOWN_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_DATABASE_CLIENTS = 16;
+
+export interface NormalizedClickHouseModuleOptions {
+    clientOptions: ClickHouseClientConfigOptions;
+    database: string;
+    rootDatabase: string;
+    requestTimeoutMs: number;
+    pingTimeoutMs: number;
+    shutdownTimeoutMs: number;
+    maxDatabaseClients: number;
+}
+
+export function createClickHouseClientOptions(input: ClickHouseModuleOptions = {}): ClickHouseClientConfigOptions {
+    return { ...normalizeClickHouseModuleOptions(input).clientOptions };
+}
+
+export function normalizeClickHouseModuleOptions(
+    input: ClickHouseModuleOptions = {},
+): NormalizedClickHouseModuleOptions {
+    ensureObject(input, 'ClickHouse module options');
+    const advancedValue: unknown = input.clientOptions ?? {};
+    ensureObject(advancedValue, 'clientOptions');
+    const advanced = advancedValue as ClickHouseClientConfigOptions;
+
+    if (advanced.host !== undefined && (input.url !== undefined || advanced.url !== undefined)) {
+        throw new ClickHouseConfigurationError('clientOptions.host cannot be combined with url');
+    }
+
+    const url = normalizeUrl(input.url ?? advanced.url ?? advanced.host ?? DEFAULT_URL);
+    const database = normalizeRequiredString(input.database ?? advanced.database ?? DEFAULT_DATABASE, 'database');
+    const rootDatabase = normalizeRequiredString(input.rootDatabase ?? DEFAULT_DATABASE, 'rootDatabase');
+    const requestTimeoutMs = positiveInteger(
+        input.requestTimeoutMs ?? advanced.request_timeout ?? DEFAULT_REQUEST_TIMEOUT_MS,
+        'requestTimeoutMs',
+    );
+    const pingTimeoutMs = positiveInteger(input.pingTimeoutMs ?? DEFAULT_PING_TIMEOUT_MS, 'pingTimeoutMs');
+    const shutdownTimeoutMs = positiveInteger(
+        input.shutdownTimeoutMs ?? DEFAULT_SHUTDOWN_TIMEOUT_MS,
+        'shutdownTimeoutMs',
+    );
+    const maxDatabaseClients = nonNegativeInteger(
+        input.maxDatabaseClients ?? DEFAULT_MAX_DATABASE_CLIENTS,
+        'maxDatabaseClients',
+    );
+    const maxOpenConnections = optionalPositiveInteger(
+        input.maxOpenConnections ?? advanced.max_open_connections,
+        'maxOpenConnections',
+    );
+    const application = normalizeRequiredString(
+        input.application ?? advanced.application ?? DEFAULT_APPLICATION,
+        'application',
+    );
+    const username = optionalNonEmptyString(input.username ?? advanced.username, 'username');
+    const password = optionalString(input.password ?? advanced.password, 'password');
+    const accessToken = optionalNonEmptyString(input.accessToken ?? advanced.access_token, 'accessToken');
+
+    if (accessToken !== undefined && (username !== undefined || password !== undefined || hasUrlCredentials(url))) {
+        throw new ClickHouseConfigurationError('accessToken cannot be combined with username/password authentication');
+    }
+
+    const pathname = optionalNonEmptyString(input.pathname ?? advanced.pathname, 'pathname');
+    const sessionId = optionalNonEmptyString(input.sessionId ?? advanced.session_id, 'sessionId');
+    const role = normalizeRole(input.role ?? advanced.role);
+    const httpHeaders = normalizeHeaders(input.httpHeaders ?? advanced.http_headers);
+
+    const clientOptions: ClickHouseClientConfigOptions = {
+        ...advanced,
+        url,
+        database,
+        request_timeout: requestTimeoutMs,
+        application,
+    };
+    delete clientOptions.host;
+    assign(clientOptions, 'username', username);
+    assign(clientOptions, 'password', password);
+    assign(clientOptions, 'access_token', accessToken);
+    assign(clientOptions, 'pathname', pathname);
+    assign(clientOptions, 'max_open_connections', maxOpenConnections);
+    assign(clientOptions, 'compression', input.compression ?? advanced.compression);
+    assign(clientOptions, 'keep_alive', input.keepAlive ?? advanced.keep_alive);
+    assign(clientOptions, 'tls', input.tls ?? advanced.tls);
+    assign(clientOptions, 'clickhouse_settings', input.clickHouseSettings ?? advanced.clickhouse_settings);
+    assign(clientOptions, 'http_headers', httpHeaders);
+    assign(clientOptions, 'session_id', sessionId);
+    assign(clientOptions, 'role', role);
+    assign(clientOptions, 'use_multipart_params', input.useMultipartParams ?? advanced.use_multipart_params);
+    assign(
+        clientOptions,
+        'use_multipart_params_auto',
+        input.useMultipartParamsAuto ?? advanced.use_multipart_params_auto,
+    );
+
+    return {
+        clientOptions,
+        database,
+        rootDatabase,
+        requestTimeoutMs,
+        pingTimeoutMs,
+        shutdownTimeoutMs,
+        maxDatabaseClients,
+    };
+}
+
+function normalizeUrl(value: string | URL): string {
+    let url: URL;
+    try {
+        const source = value instanceof URL ? value.toString() : normalizeRequiredString(value, 'url');
+        url = new URL(source);
+    } catch (error) {
+        if (error instanceof ClickHouseConfigurationError) {
+            throw error;
+        }
+        throw new ClickHouseConfigurationError('url must be a valid HTTP(S) URL', error);
+    }
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        throw new ClickHouseConfigurationError('url must use the http: or https: protocol');
+    }
+    if (url.hash) {
+        throw new ClickHouseConfigurationError('url must not contain a fragment');
+    }
+    if (/^\/+$/u.test(url.pathname)) {
+        url.pathname = '/';
+    }
+    const serialized = url.toString();
+    return url.pathname === '/' ? serialized.replace(/\/(?=[?#]|$)/, '') : serialized;
+}
+
+function hasUrlCredentials(url: string): boolean {
+    const parsed = new URL(url);
+    return parsed.username.length > 0 || parsed.password.length > 0;
+}
+
+function normalizeHeaders(value: Record<string, string> | undefined): Record<string, string> | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    ensureObject(value, 'httpHeaders');
+    const headers: Record<string, string> = {};
+    for (const [name, headerValue] of Object.entries(value)) {
+        const normalizedName = name.trim();
+        if (!normalizedName || /[\r\n]/.test(normalizedName)) {
+            throw new ClickHouseConfigurationError('httpHeaders contains an invalid header name');
+        }
+        if (typeof headerValue !== 'string' || /[\r\n]/.test(headerValue)) {
+            throw new ClickHouseConfigurationError(`httpHeaders.${normalizedName} must be a single-line string`);
+        }
+        headers[normalizedName] = headerValue;
+    }
+    return headers;
+}
+
+function normalizeRole(value: string | string[] | undefined): string | string[] | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            throw new ClickHouseConfigurationError('role must contain at least one role');
+        }
+        return value.map((role, index) => normalizeRequiredString(role, `role[${index}]`));
+    }
+    return normalizeRequiredString(value, 'role');
+}
+
+function normalizeRequiredString(value: unknown, name: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new ClickHouseConfigurationError(`${name} must be a non-empty string`);
+    }
+    return value.trim();
+}
+
+function optionalNonEmptyString(value: unknown, name: string): string | undefined {
+    return value === undefined ? undefined : normalizeRequiredString(value, name);
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value !== 'string') {
+        throw new ClickHouseConfigurationError(`${name} must be a string`);
+    }
+    return value;
+}
+
+function positiveInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new ClickHouseConfigurationError(`${name} must be a positive safe integer`);
+    }
+    return value as number;
+}
+
+function optionalPositiveInteger(value: unknown, name: string): number | undefined {
+    return value === undefined ? undefined : positiveInteger(value, name);
+}
+
+function nonNegativeInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) < 0) {
+        throw new ClickHouseConfigurationError(`${name} must be a non-negative safe integer`);
+    }
+    return value as number;
+}
+
+function ensureObject(value: unknown, name: string): void {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new ClickHouseConfigurationError(`${name} must be an object`);
+    }
+}
+
+function assign<T extends object, K extends keyof T>(target: T, key: K, value: T[K] | undefined): void {
+    if (value !== undefined) {
+        target[key] = value;
+    }
+}

--- a/packages/clickhouse/src/clickhouse-request.ts
+++ b/packages/clickhouse/src/clickhouse-request.ts
@@ -1,0 +1,289 @@
+import type { BaseQueryParams, DataFormat } from '@clickhouse/client';
+import { ClickHouseRequestError, type ClickHouseRequestOptions } from './clickhouse.types';
+
+interface SqlToken {
+    value: string;
+    start: number;
+    end: number;
+    identifier: boolean;
+}
+
+const RESULT_STATEMENTS = new Set(['SELECT', 'WITH', 'SHOW', 'DESCRIBE', 'DESC', 'EXPLAIN', 'EXISTS']);
+const SUPPORTED_FORMATS = [
+    'JSONObjectEachRow',
+    'JSON',
+    'JSONStrings',
+    'JSONCompact',
+    'JSONCompactStrings',
+    'JSONColumnsWithMetadata',
+    'JSONEachRow',
+    'JSONStringsEachRow',
+    'JSONCompactEachRow',
+    'JSONCompactStringsEachRow',
+    'JSONCompactEachRowWithNames',
+    'JSONCompactEachRowWithNamesAndTypes',
+    'JSONCompactStringsEachRowWithNames',
+    'JSONCompactStringsEachRowWithNamesAndTypes',
+    'JSONEachRowWithProgress',
+    'CSV',
+    'CSVWithNames',
+    'CSVWithNamesAndTypes',
+    'TabSeparated',
+    'TabSeparatedRaw',
+    'TabSeparatedWithNames',
+    'TabSeparatedWithNamesAndTypes',
+    'CustomSeparated',
+    'CustomSeparatedWithNames',
+    'CustomSeparatedWithNamesAndTypes',
+    'Parquet',
+] as const satisfies readonly DataFormat[];
+const FORMATS = new Map<string, DataFormat>(SUPPORTED_FORMATS.map(format => [format.toLowerCase(), format]));
+
+export function createClickHouseQueryOptions(
+    options: ClickHouseRequestOptions,
+    defaultTimeoutMs: number,
+): BaseQueryParams {
+    assertClickHouseRequestOptions(options);
+    const timeoutMs = positiveInteger(options.timeoutMs ?? defaultTimeoutMs, 'timeoutMs');
+    const queryId = optionalString(options.queryId, 'queryId');
+    const sessionId = optionalString(options.sessionId, 'sessionId');
+    const role = normalizeRole(options.role);
+    const httpHeaders = normalizeHeaders(options.httpHeaders);
+    validateAuth(options.auth);
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const abortSignal = options.abortSignal ? AbortSignal.any([options.abortSignal, timeoutSignal]) : timeoutSignal;
+    return {
+        query_id: queryId,
+        clickhouse_settings: options.clickHouseSettings,
+        query_params: options.queryParams,
+        abort_signal: abortSignal,
+        session_id: sessionId,
+        role,
+        auth: options.auth,
+        http_headers: httpHeaders,
+        use_multipart_params: options.useMultipartParams,
+        use_multipart_params_auto: options.useMultipartParamsAuto,
+    };
+}
+
+export function splitTrailingClickHouseFormat(
+    sql: string,
+    fallback: DataFormat,
+): { query: string; format: DataFormat } {
+    const query = normalizeClickHouseSql(sql);
+    const tokens = tokenizeSql(query);
+    while (tokens.at(-1)?.value === ';') {
+        tokens.pop();
+    }
+    if (tokens.length === 0) {
+        throw new ClickHouseRequestError('sql must contain a statement');
+    }
+    const formatName = tokens.at(-1);
+    const formatKeyword = tokens.at(-2);
+    if (!formatName || !formatKeyword || formatKeyword.value.toUpperCase() !== 'FORMAT') {
+        return { query: query.slice(0, tokens.at(-1)!.end).trim(), format: fallback };
+    }
+    if (!formatName.identifier) {
+        throw new ClickHouseRequestError('FORMAT must be followed by a supported format name');
+    }
+    const format = FORMATS.get(formatName.value.toLowerCase());
+    if (!format) {
+        throw new ClickHouseRequestError(`Unsupported ClickHouse response format '${formatName.value}'`);
+    }
+    const withoutFormat = query.slice(0, formatKeyword.start).trim().replace(/;+$/, '').trim();
+    if (!withoutFormat) {
+        throw new ClickHouseRequestError('SQL before FORMAT must not be empty');
+    }
+    return { query: withoutFormat, format };
+}
+
+export function expectsClickHouseResult(sql: string): boolean {
+    const firstKeyword = tokenizeSql(sql)
+        .find(token => token.identifier)
+        ?.value.toUpperCase();
+    return firstKeyword ? RESULT_STATEMENTS.has(firstKeyword) : false;
+}
+
+export function normalizeClickHouseSql(sql: string): string {
+    if (typeof sql !== 'string' || sql.trim().length === 0) {
+        throw new ClickHouseRequestError('sql must be a non-empty string');
+    }
+    return sql.trim();
+}
+
+export function normalizeClickHouseTable(table: string): string {
+    if (typeof table !== 'string' || table.trim().length === 0 || /[\r\n\0]/.test(table)) {
+        throw new ClickHouseRequestError('table must be a non-empty single-line identifier or expression');
+    }
+    return table.trim();
+}
+
+export function resolveClickHouseDatabase(
+    database: string | null | undefined,
+    defaultDatabase: string,
+    rootDatabase: string,
+): string {
+    if (database === undefined) {
+        return defaultDatabase;
+    }
+    if (database === null) {
+        return rootDatabase;
+    }
+    if (typeof database !== 'string' || database.trim().length === 0) {
+        throw new ClickHouseRequestError('database must be a non-empty string or null');
+    }
+    return database.trim();
+}
+
+export function assertClickHouseRequestOptions(options: ClickHouseRequestOptions): void {
+    if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+        throw new ClickHouseRequestError('request options must be an object');
+    }
+    if (options.abortSignal !== undefined && !(options.abortSignal instanceof AbortSignal)) {
+        throw new ClickHouseRequestError('abortSignal must be an AbortSignal');
+    }
+    if (options.queryParams !== undefined && !isRecord(options.queryParams)) {
+        throw new ClickHouseRequestError('queryParams must be an object');
+    }
+    if (options.clickHouseSettings !== undefined && !isRecord(options.clickHouseSettings)) {
+        throw new ClickHouseRequestError('clickHouseSettings must be an object');
+    }
+}
+
+function validateAuth(auth: ClickHouseRequestOptions['auth']): void {
+    if (auth === undefined) {
+        return;
+    }
+    if (!isRecord(auth)) {
+        throw new ClickHouseRequestError('auth must be an object');
+    }
+    if ('access_token' in auth) {
+        optionalString(auth.access_token, 'auth.access_token');
+        if ('username' in auth || 'password' in auth) {
+            throw new ClickHouseRequestError('JWT auth cannot be combined with username/password');
+        }
+        return;
+    }
+    requiredString(auth.username, 'auth.username');
+    if (typeof auth.password !== 'string') {
+        throw new ClickHouseRequestError('auth.password must be a string');
+    }
+}
+
+function normalizeRole(role: ClickHouseRequestOptions['role']): string | string[] | undefined {
+    if (role === undefined) {
+        return undefined;
+    }
+    if (Array.isArray(role)) {
+        if (role.length === 0) {
+            throw new ClickHouseRequestError('role must contain at least one role');
+        }
+        return role.map((value, index) => requiredString(value, `role[${index}]`));
+    }
+    return requiredString(role, 'role');
+}
+
+function normalizeHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    if (headers === undefined) {
+        return undefined;
+    }
+    if (!isRecord(headers)) {
+        throw new ClickHouseRequestError('httpHeaders must be an object');
+    }
+    const normalized: Record<string, string> = {};
+    for (const [name, value] of Object.entries(headers)) {
+        const normalizedName = name.trim();
+        if (!normalizedName || /[\r\n]/.test(normalizedName)) {
+            throw new ClickHouseRequestError('httpHeaders contains an invalid header name');
+        }
+        if (typeof value !== 'string' || /[\r\n]/.test(value)) {
+            throw new ClickHouseRequestError(`httpHeaders.${normalizedName} must be a single-line string`);
+        }
+        normalized[normalizedName] = value;
+    }
+    return normalized;
+}
+
+function tokenizeSql(sql: string): SqlToken[] {
+    const tokens: SqlToken[] = [];
+    let index = 0;
+    while (index < sql.length) {
+        const char = sql[index];
+        const next = sql[index + 1];
+        if (/\s/.test(char)) {
+            index += 1;
+            continue;
+        }
+        if ((char === '-' && next === '-') || char === '#') {
+            index += char === '#' ? 1 : 2;
+            while (index < sql.length && sql[index] !== '\n') {
+                index += 1;
+            }
+            continue;
+        }
+        if (char === '/' && next === '*') {
+            index += 2;
+            while (index < sql.length && !(sql[index] === '*' && sql[index + 1] === '/')) {
+                index += 1;
+            }
+            index = Math.min(sql.length, index + 2);
+            continue;
+        }
+        if (char === "'" || char === '"' || char === '`') {
+            const quote = char;
+            const start = index;
+            index += 1;
+            while (index < sql.length) {
+                if (sql[index] === '\\') {
+                    index += 2;
+                    continue;
+                }
+                if (sql[index] === quote) {
+                    if (sql[index + 1] === quote) {
+                        index += 2;
+                        continue;
+                    }
+                    index += 1;
+                    break;
+                }
+                index += 1;
+            }
+            tokens.push({ value: sql.slice(start, index), start, end: index, identifier: false });
+            continue;
+        }
+        if (/[A-Za-z_]/.test(char)) {
+            const start = index;
+            index += 1;
+            while (index < sql.length && /[A-Za-z0-9_]/.test(sql[index])) {
+                index += 1;
+            }
+            tokens.push({ value: sql.slice(start, index), start, end: index, identifier: true });
+            continue;
+        }
+        tokens.push({ value: char, start: index, end: index + 1, identifier: false });
+        index += 1;
+    }
+    return tokens;
+}
+
+function requiredString(value: unknown, name: string): string {
+    if (typeof value !== 'string' || value.trim().length === 0) {
+        throw new ClickHouseRequestError(`${name} must be a non-empty string`);
+    }
+    return value.trim();
+}
+
+function optionalString(value: unknown, name: string): string | undefined {
+    return value === undefined ? undefined : requiredString(value, name);
+}
+
+function positiveInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new ClickHouseRequestError(`${name} must be a positive safe integer`);
+    }
+    return value as number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/clickhouse/src/clickhouse.service.ts
+++ b/packages/clickhouse/src/clickhouse.service.ts
@@ -1,59 +1,121 @@
-import { type ClickHouseClient, type DataFormat, createClient } from '@clickhouse/client';
-import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import {
+    type ClickHouseClient,
+    type ClickHouseClientConfigOptions,
+    type CommandResult,
+    createClient,
+    type InsertResult,
+} from '@clickhouse/client';
+import { Inject, Injectable, Logger, type OnModuleDestroy } from '@nestjs/common';
 import {
     CLICKHOUSE_OPTIONS_TOKEN,
+    ClickHouseClientPoolExhaustedError,
+    type ClickHouseHealthResult,
     type ClickHouseJsonResponse,
     type ClickHouseModuleOptions,
+    ClickHouseRequestError,
     type ClickHouseRequestOptions,
+    ClickHouseServiceClosedError,
+    type ClickHouseServiceStats,
+    ClickHouseShutdownError,
 } from './clickhouse.types';
+import { type NormalizedClickHouseModuleOptions, normalizeClickHouseModuleOptions } from './clickhouse-options';
+import {
+    assertClickHouseRequestOptions,
+    createClickHouseQueryOptions,
+    expectsClickHouseResult,
+    normalizeClickHouseSql,
+    normalizeClickHouseTable,
+    resolveClickHouseDatabase,
+    splitTrailingClickHouseFormat,
+} from './clickhouse-request';
+
+interface ClientEntry {
+    client: ClickHouseClient;
+    database: string;
+    active: number;
+    lastUsed: number;
+    closing: boolean;
+    reserved: boolean;
+    closeTask?: Promise<void>;
+}
+
+interface ClientLease {
+    client: ClickHouseClient;
+    release: () => void;
+}
+
+interface TaskSettlement {
+    timedOut: boolean;
+    errors: unknown[];
+}
 
 @Injectable()
 export class ClickHouseService implements OnModuleDestroy {
     private readonly logger = new Logger(ClickHouseService.name);
-    private readonly client: ClickHouseClient;
-    private rootClient?: ClickHouseClient;
-    private readonly clientsByDatabase = new Map<string, ClickHouseClient>();
+    private readonly options: NormalizedClickHouseModuleOptions;
+    private readonly defaultEntry: ClientEntry;
+    private readonly clientsByDatabase = new Map<string, ClientEntry>();
+    private readonly pendingClients = new Map<string, Promise<ClientEntry>>();
+    private readonly activeOperations = new Set<Promise<unknown>>();
+    private poolTail: Promise<void> = Promise.resolve();
+    private closePromise: Promise<void> | null = null;
+    private shuttingDown = false;
+    private sequence = 0;
 
-    constructor(@Inject(CLICKHOUSE_OPTIONS_TOKEN) private readonly options: ClickHouseModuleOptions) {
-        this.client = this.createClient(options.database);
-        if (options.database) {
-            this.clientsByDatabase.set(options.database, this.client);
-        }
+    constructor(@Inject(CLICKHOUSE_OPTIONS_TOKEN) options: ClickHouseModuleOptions) {
+        this.options = normalizeClickHouseModuleOptions(options);
+        this.defaultEntry = this.createEntry(this.options.database);
     }
 
     async execute(sql: string, options: ClickHouseRequestOptions = {}): Promise<string> {
-        if (this.expectsResult(sql)) {
-            return this.queryText(sql, options);
+        const query = normalizeClickHouseSql(sql);
+        if (expectsClickHouseResult(query)) {
+            return this.queryText(query, options);
         }
-        await this.command(sql, options);
+        await this.command(query, options);
         return '';
     }
 
-    async command(sql: string, options: ClickHouseRequestOptions = {}): Promise<void> {
-        await this.getClient(options).command({
-            query: sql,
-            ...this.toQueryOptions(options),
-        });
+    async command(sql: string, options: ClickHouseRequestOptions = {}): Promise<CommandResult> {
+        const query = normalizeClickHouseSql(sql);
+        const queryOptions = createClickHouseQueryOptions(options, this.options.requestTimeoutMs);
+        return this.withClient(
+            client =>
+                client.command({
+                    query,
+                    ...queryOptions,
+                }),
+            options,
+        );
     }
 
     async queryJson<T>(sql: string, options: ClickHouseRequestOptions = {}): Promise<ClickHouseJsonResponse<T>> {
-        const { query, format } = this.stripTrailingFormat(sql, 'JSON');
-        const resultSet = await this.getClient(options).query({
-            query,
-            format,
-            ...this.toQueryOptions(options),
-        });
-        return (await resultSet.json<T>()) as ClickHouseJsonResponse<T>;
+        const { query, format } = splitTrailingClickHouseFormat(sql, 'JSON');
+        if (format !== 'JSON') {
+            throw new ClickHouseRequestError('queryJson only supports the JSON response format');
+        }
+        const queryOptions = createClickHouseQueryOptions(options, this.options.requestTimeoutMs);
+        return this.withClient(async client => {
+            const resultSet = await client.query({
+                query,
+                format: 'JSON',
+                ...queryOptions,
+            });
+            return (await resultSet.json<T>()) as ClickHouseJsonResponse<T>;
+        }, options);
     }
 
     async queryText(sql: string, options: ClickHouseRequestOptions = {}): Promise<string> {
-        const { query, format } = this.stripTrailingFormat(sql, 'TabSeparated');
-        const resultSet = await this.getClient(options).query({
-            query,
-            format,
-            ...this.toQueryOptions(options),
-        });
-        return resultSet.text();
+        const { query, format } = splitTrailingClickHouseFormat(sql, 'TabSeparated');
+        const queryOptions = createClickHouseQueryOptions(options, this.options.requestTimeoutMs);
+        return this.withClient(async client => {
+            const resultSet = await client.query({
+                query,
+                format,
+                ...queryOptions,
+            });
+            return resultSet.text();
+        }, options);
     }
 
     async insertJsonEachRow<T extends Record<string, unknown>>(
@@ -61,100 +123,349 @@ export class ClickHouseService implements OnModuleDestroy {
         rows: readonly T[],
         options: ClickHouseRequestOptions = {},
     ): Promise<void> {
+        const normalizedTable = normalizeClickHouseTable(table);
+        if (!Array.isArray(rows)) {
+            throw new ClickHouseRequestError('rows must be an array');
+        }
         if (rows.length === 0) {
             return;
         }
-        await this.getClient(options).insert({
-            table,
-            values: rows,
-            format: 'JSONEachRow',
-            ...this.toQueryOptions(options),
-        });
+        const queryOptions = createClickHouseQueryOptions(options, this.options.requestTimeoutMs);
+        await this.withClient(
+            client =>
+                client.insert({
+                    table: normalizedTable,
+                    values: rows,
+                    format: 'JSONEachRow',
+                    ...queryOptions,
+                }),
+            options,
+        );
+    }
+
+    async insert<T extends Record<string, unknown>>(
+        table: string,
+        rows: readonly T[],
+        options: ClickHouseRequestOptions = {},
+    ): Promise<InsertResult> {
+        const normalizedTable = normalizeClickHouseTable(table);
+        if (!Array.isArray(rows)) {
+            throw new ClickHouseRequestError('rows must be an array');
+        }
+        const queryOptions = createClickHouseQueryOptions(options, this.options.requestTimeoutMs);
+        return this.withClient(
+            client =>
+                client.insert({
+                    table: normalizedTable,
+                    values: rows,
+                    format: 'JSONEachRow',
+                    ...queryOptions,
+                }),
+            options,
+        );
+    }
+
+    /**
+     * Runs advanced first-party SDK work while preserving database-pool ownership and shutdown tracking.
+     * Any returned streams must be fully consumed inside the callback.
+     */
+    async withClient<T>(
+        callback: (client: ClickHouseClient) => T | Promise<T>,
+        options: ClickHouseRequestOptions = {},
+    ): Promise<T> {
+        if (typeof callback !== 'function') {
+            throw new ClickHouseRequestError('callback must be a function');
+        }
+        assertClickHouseRequestOptions(options);
+        const operation = this.runWithClient(callback, options.database);
+        this.activeOperations.add(operation);
+        try {
+            return await operation;
+        } finally {
+            this.activeOperations.delete(operation);
+        }
+    }
+
+    private async runWithClient<T>(
+        callback: (client: ClickHouseClient) => T | Promise<T>,
+        database: string | null | undefined,
+    ): Promise<T> {
+        const lease = await this.acquireClient(database);
+        try {
+            return await callback(lease.client);
+        } finally {
+            lease.release();
+        }
+    }
+
+    async healthCheck(options: ClickHouseRequestOptions = {}): Promise<ClickHouseHealthResult> {
+        const startedAt = Date.now();
+        let database: string;
+        try {
+            assertClickHouseRequestOptions(options);
+            database = resolveClickHouseDatabase(options.database, this.options.database, this.options.rootDatabase);
+        } catch (error) {
+            return {
+                healthy: false,
+                database: this.options.database,
+                latencyMs: Date.now() - startedAt,
+                error: this.errorMessage(error),
+            };
+        }
+
+        try {
+            const base = createClickHouseQueryOptions(
+                {
+                    ...options,
+                    timeoutMs: options.timeoutMs ?? this.options.pingTimeoutMs,
+                },
+                this.options.pingTimeoutMs,
+            );
+            const { query_params: _queryParams, ...pingOptions } = base;
+            const result = await this.withClient(client => client.ping({ select: true, ...pingOptions }), options);
+            return {
+                healthy: result.success,
+                database,
+                latencyMs: Date.now() - startedAt,
+                ...(result.success ? {} : { error: result.error.message }),
+            };
+        } catch (error) {
+            const message = this.errorMessage(error);
+            this.logger.warn(`ClickHouse health check failed: ${message}`);
+            return {
+                healthy: false,
+                database,
+                latencyMs: Date.now() - startedAt,
+                error: message,
+            };
+        }
     }
 
     async ping(): Promise<boolean> {
-        try {
-            const result = await this.client.ping({ select: true, abort_signal: AbortSignal.timeout(2000) });
-            return result.success;
-        } catch (error) {
-            this.logger.warn(`ClickHouse ping failed: ${error instanceof Error ? error.message : String(error)}`);
-            return false;
-        }
+        return (await this.healthCheck()).healthy;
+    }
+
+    getStats(): ClickHouseServiceStats {
+        return {
+            activeOperations: this.activeOperations.size,
+            cachedDatabaseClients: this.clientsByDatabase.size,
+            databases: [this.options.database, ...this.clientsByDatabase.keys()],
+            closing: this.shuttingDown,
+        };
+    }
+
+    close(): Promise<void> {
+        this.shuttingDown = true;
+        this.closePromise ??= this.performClose();
+        return this.closePromise;
     }
 
     async onModuleDestroy(): Promise<void> {
-        const clients = new Set<ClickHouseClient>([
-            this.client,
-            ...(this.rootClient ? [this.rootClient] : []),
-            ...this.clientsByDatabase.values(),
-        ]);
-        await Promise.all([...clients].map(client => client.close()));
+        await this.close();
     }
 
-    private createClient(database?: string | null): ClickHouseClient {
-        return createClient({
-            url: this.normalizeBaseUrl(this.options.url || 'http://localhost:8123'),
-            username: this.options.username,
-            password: this.options.password,
-            database: database ?? undefined,
-            request_timeout: this.options.requestTimeoutMs ?? 10000,
-            max_open_connections: this.options.maxOpenConnections,
-            application: this.options.application ?? '@a3s-lab/clickhouse',
-            compression: this.options.compression,
+    private async performClose(): Promise<void> {
+        const deadline = Date.now() + this.options.shutdownTimeoutMs;
+        const errors: unknown[] = [];
+        const pending = await this.settleTasks([...this.pendingClients.values(), ...this.activeOperations], deadline);
+        if (pending.timedOut) {
+            errors.push(new Error('Timed out waiting for active ClickHouse operations'));
+        }
+
+        const entries = [this.defaultEntry, ...this.clientsByDatabase.values()];
+        this.clientsByDatabase.clear();
+        const closeTasks = entries.map(entry => this.startClientClose(entry));
+        const closed = await this.settleTasks(closeTasks, deadline);
+        errors.push(...closed.errors);
+        if (closed.timedOut) {
+            errors.push(new Error('Timed out closing ClickHouse clients'));
+        }
+
+        if (errors.length > 0) {
+            throw new ClickHouseShutdownError(errors);
+        }
+        this.logger.log('ClickHouse clients closed');
+    }
+
+    private async acquireClient(databaseOverride: string | null | undefined): Promise<ClientLease> {
+        this.assertRunning();
+        const database = resolveClickHouseDatabase(databaseOverride, this.options.database, this.options.rootDatabase);
+        let entry: ClientEntry;
+        if (database === this.options.database) {
+            entry = this.defaultEntry;
+        } else {
+            const cached = this.clientsByDatabase.get(database);
+            if (cached && !cached.closing) {
+                entry = cached;
+            } else {
+                entry = await this.getOrCreateDatabaseClient(database);
+                this.assertRunning();
+            }
+        }
+        if (entry.closing) {
+            throw new ClickHouseServiceClosedError();
+        }
+        if (entry.reserved) {
+            entry.reserved = false;
+        } else {
+            entry.active += 1;
+        }
+        entry.lastUsed = ++this.sequence;
+        let released = false;
+        return {
+            client: entry.client,
+            release: () => {
+                if (!released) {
+                    released = true;
+                    entry.active = Math.max(0, entry.active - 1);
+                    entry.lastUsed = ++this.sequence;
+                }
+            },
+        };
+    }
+
+    private getOrCreateDatabaseClient(database: string): Promise<ClientEntry> {
+        const current = this.pendingClients.get(database);
+        if (current) {
+            return current;
+        }
+        const pending = this.createDatabaseClient(database).finally(() => {
+            if (this.pendingClients.get(database) === pending) {
+                this.pendingClients.delete(database);
+            }
+        });
+        this.pendingClients.set(database, pending);
+        return pending;
+    }
+
+    private createDatabaseClient(database: string): Promise<ClientEntry> {
+        return this.withPoolLock(async () => {
+            this.assertRunning();
+            const existing = this.clientsByDatabase.get(database);
+            if (existing && !existing.closing) {
+                return existing;
+            }
+
+            if (this.clientsByDatabase.size >= this.options.maxDatabaseClients) {
+                const victim = [...this.clientsByDatabase.values()]
+                    .filter(entry => entry.active === 0 && !entry.closing)
+                    .sort((left, right) => left.lastUsed - right.lastUsed)[0];
+                if (!victim) {
+                    throw new ClickHouseClientPoolExhaustedError(this.options.maxDatabaseClients);
+                }
+                await this.closeEvictedClient(victim);
+                this.assertRunning();
+            }
+
+            const entry = this.createEntry(database, true);
+            this.clientsByDatabase.set(database, entry);
+            return entry;
         });
     }
 
-    private getClient(options: ClickHouseRequestOptions): ClickHouseClient {
-        if (options.database === null) {
-            return this.getRootClient();
+    private async closeEvictedClient(entry: ClientEntry): Promise<void> {
+        const task = this.startClientClose(entry);
+        const settled = await this.settleTasks([task], Date.now() + this.options.requestTimeoutMs);
+        if (settled.timedOut) {
+            this.logger.warn(`Timed out closing evicted ClickHouse client for database '${entry.database}'`);
+            void task.then(
+                () => {
+                    if (this.clientsByDatabase.get(entry.database) === entry) {
+                        this.clientsByDatabase.delete(entry.database);
+                    }
+                },
+                () => undefined,
+            );
+            throw new ClickHouseClientPoolExhaustedError(
+                this.options.maxDatabaseClients,
+                `evicted client for database '${entry.database}' did not close before the timeout`,
+            );
         }
-        const database = options.database?.trim();
-        if (!database || database === this.options.database) {
-            return this.client;
+        for (const error of settled.errors) {
+            this.logger.warn(
+                `Failed closing evicted ClickHouse client for database '${entry.database}': ${this.errorMessage(error)}`,
+            );
+            throw new ClickHouseClientPoolExhaustedError(
+                this.options.maxDatabaseClients,
+                `evicted client for database '${entry.database}' failed to close`,
+                error,
+            );
         }
-        const cached = this.clientsByDatabase.get(database);
-        if (cached) {
-            return cached;
-        }
-        const client = this.createClient(database);
-        this.clientsByDatabase.set(database, client);
-        return client;
+        this.clientsByDatabase.delete(entry.database);
     }
 
-    private getRootClient(): ClickHouseClient {
-        if (!this.rootClient) {
-            this.rootClient = this.createClient(null);
-        }
-        return this.rootClient;
-    }
-
-    private toQueryOptions(options: ClickHouseRequestOptions) {
+    private createEntry(database: string, reserved = false): ClientEntry {
+        const clientOptions: ClickHouseClientConfigOptions = {
+            ...this.options.clientOptions,
+            database,
+        };
         return {
-            query_id: options.queryId,
-            clickhouse_settings: options.clickHouseSettings,
-            query_params: options.queryParams,
-            abort_signal: AbortSignal.timeout(options.timeoutMs ?? this.options.requestTimeoutMs ?? 10000),
+            client: createClient(clientOptions),
+            database,
+            active: reserved ? 1 : 0,
+            lastUsed: ++this.sequence,
+            closing: false,
+            reserved,
         };
     }
 
-    private stripTrailingFormat(sql: string, fallback: DataFormat): { query: string; format: DataFormat } {
-        const trimmed = sql.trim().replace(/;+$/, '');
-        const match = trimmed.match(/\s+FORMAT\s+([A-Za-z0-9_]+)\s*$/i);
-        if (!match) {
-            return { query: trimmed, format: fallback };
+    private startClientClose(entry: ClientEntry): Promise<void> {
+        entry.closing = true;
+        entry.closeTask ??= Promise.resolve().then(() => entry.client.close());
+        return entry.closeTask;
+    }
+
+    private async withPoolLock<T>(callback: () => Promise<T>): Promise<T> {
+        const previous = this.poolTail;
+        let release!: () => void;
+        this.poolTail = new Promise<void>(resolve => {
+            release = resolve;
+        });
+        await previous;
+        try {
+            return await callback();
+        } finally {
+            release();
+        }
+    }
+
+    private async settleTasks(tasks: readonly Promise<unknown>[], deadline: number): Promise<TaskSettlement> {
+        if (tasks.length === 0) {
+            return { timedOut: false, errors: [] };
+        }
+        const settled = Promise.allSettled(tasks);
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) {
+            return { timedOut: true, errors: [] };
+        }
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const result = await Promise.race([
+            settled.then(values => ({ values })),
+            new Promise<{ timeout: true }>(resolve => {
+                timer = setTimeout(() => resolve({ timeout: true }), remaining);
+            }),
+        ]);
+        if (timer) {
+            clearTimeout(timer);
+        }
+        if ('timeout' in result) {
+            return { timedOut: true, errors: [] };
         }
         return {
-            query: trimmed.slice(0, match.index).trim(),
-            format: match[1] as DataFormat,
+            timedOut: false,
+            errors: result.values
+                .filter((value): value is PromiseRejectedResult => value.status === 'rejected')
+                .map(value => value.reason),
         };
     }
 
-    private expectsResult(sql: string): boolean {
-        return /^\s*(SELECT|WITH|SHOW|DESCRIBE|DESC|EXPLAIN)\b/i.test(sql);
+    private assertRunning(): void {
+        if (this.shuttingDown) {
+            throw new ClickHouseServiceClosedError();
+        }
     }
 
-    private normalizeBaseUrl(url: string): string {
-        const trimmed = url.trim().replace(/\/+$/, '');
-        return trimmed || 'http://localhost:8123';
+    private errorMessage(error: unknown): string {
+        return error instanceof Error ? error.message : String(error);
     }
 }

--- a/packages/clickhouse/src/clickhouse.types.ts
+++ b/packages/clickhouse/src/clickhouse.types.ts
@@ -1,22 +1,59 @@
-import type { ClickHouseSettings } from '@clickhouse/client';
+import type {
+    BaseQueryParams,
+    ClickHouseAuth,
+    ClickHouseClient,
+    ClickHouseClientConfigOptions,
+    ClickHouseSettings,
+    CommandResult,
+    DataFormat,
+    InsertResult,
+} from '@clickhouse/client';
 import type { DynamicModule } from '@nestjs/common';
 
 export const CLICKHOUSE_OPTIONS_TOKEN = 'CLICKHOUSE_OPTIONS';
 
-export type { ClickHouseSettings };
+export type {
+    ClickHouseAuth,
+    ClickHouseClient,
+    ClickHouseClientConfigOptions,
+    ClickHouseSettings,
+    CommandResult,
+    DataFormat,
+    InsertResult,
+};
 
 export interface ClickHouseModuleOptions {
-    url: string;
+    /** ClickHouse HTTP(S) endpoint. Defaults to http://localhost:8123. */
+    url?: string | URL;
     username?: string;
     password?: string;
+    /** ClickHouse Cloud JWT. Mutually exclusive with username/password authentication. */
+    accessToken?: string;
     database?: string;
+    /** Database used when a request explicitly sets database: null. Defaults to default. */
+    rootDatabase?: string;
     requestTimeoutMs?: number;
+    pingTimeoutMs?: number;
+    shutdownTimeoutMs?: number;
     maxOpenConnections?: number;
+    /** Maximum cached database override clients, excluding the configured default client. */
+    maxDatabaseClients?: number;
     application?: string;
-    compression?: {
-        request?: boolean;
-        response?: boolean;
-    };
+    pathname?: string;
+    compression?: ClickHouseClientConfigOptions['compression'];
+    keepAlive?: ClickHouseClientConfigOptions['keep_alive'];
+    tls?: ClickHouseClientConfigOptions['tls'];
+    clickHouseSettings?: ClickHouseSettings;
+    httpHeaders?: Record<string, string>;
+    sessionId?: string;
+    role?: string | string[];
+    useMultipartParams?: boolean;
+    useMultipartParamsAuto?: boolean;
+    /**
+     * Advanced first-party client options. Named convenience fields above take precedence.
+     * Lifecycle-only options are never forwarded to the client.
+     */
+    clientOptions?: ClickHouseClientConfigOptions;
 }
 
 export interface ClickHouseAsyncOptions {
@@ -43,4 +80,82 @@ export interface ClickHouseRequestOptions {
     database?: string | null;
     queryParams?: Record<string, unknown>;
     timeoutMs?: number;
+    abortSignal?: AbortSignal;
+    sessionId?: string;
+    role?: string | string[];
+    auth?: BaseQueryParams['auth'];
+    httpHeaders?: Record<string, string>;
+    useMultipartParams?: boolean;
+    useMultipartParamsAuto?: boolean;
+}
+
+export interface ClickHouseHealthResult {
+    healthy: boolean;
+    database: string;
+    latencyMs: number;
+    error?: string;
+}
+
+export interface ClickHouseServiceStats {
+    activeOperations: number;
+    cachedDatabaseClients: number;
+    databases: string[];
+    closing: boolean;
+}
+
+export class ClickHousePackageError extends Error {
+    constructor(
+        message: string,
+        public readonly code: string,
+        public readonly statusCode: number,
+        options?: ErrorOptions,
+    ) {
+        super(message, options);
+        this.name = 'ClickHousePackageError';
+    }
+}
+
+export class ClickHouseConfigurationError extends ClickHousePackageError {
+    constructor(message: string, cause?: unknown) {
+        super(message, 'CLICKHOUSE_CONFIGURATION_ERROR', 500, cause === undefined ? undefined : { cause });
+        this.name = 'ClickHouseConfigurationError';
+    }
+}
+
+export class ClickHouseRequestError extends ClickHousePackageError {
+    constructor(message: string) {
+        super(message, 'CLICKHOUSE_REQUEST_ERROR', 400);
+        this.name = 'ClickHouseRequestError';
+    }
+}
+
+export class ClickHouseServiceClosedError extends ClickHousePackageError {
+    constructor() {
+        super('ClickHouse service is closing or already closed', 'CLICKHOUSE_SERVICE_CLOSED', 503);
+        this.name = 'ClickHouseServiceClosedError';
+    }
+}
+
+export class ClickHouseClientPoolExhaustedError extends ClickHousePackageError {
+    constructor(maxDatabaseClients: number, detail?: string, cause?: unknown) {
+        super(
+            `ClickHouse database client pool cannot allocate another override client (capacity ${maxDatabaseClients})${detail ? `: ${detail}` : ''}`,
+            'CLICKHOUSE_CLIENT_POOL_EXHAUSTED',
+            503,
+            cause === undefined ? undefined : { cause },
+        );
+        this.name = 'ClickHouseClientPoolExhaustedError';
+    }
+}
+
+export class ClickHouseShutdownError extends ClickHousePackageError {
+    constructor(public readonly errors: readonly unknown[]) {
+        super(
+            `ClickHouse shutdown completed with ${errors.length} error${errors.length === 1 ? '' : 's'}`,
+            'CLICKHOUSE_SHUTDOWN_ERROR',
+            500,
+            { cause: new AggregateError(errors, 'ClickHouse shutdown errors') },
+        );
+        this.name = 'ClickHouseShutdownError';
+    }
 }

--- a/packages/clickhouse/src/index.ts
+++ b/packages/clickhouse/src/index.ts
@@ -1,3 +1,4 @@
-export * from './clickhouse.types';
-export * from './clickhouse.service';
 export * from './clickhouse.module';
+export * from './clickhouse.service';
+export * from './clickhouse.types';
+export { createClickHouseClientOptions } from './clickhouse-options';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,7 +218,7 @@ importers:
   packages/clickhouse:
     dependencies:
       '@clickhouse/client':
-        specifier: ^1.18.5
+        specifier: ^1.22.0
         version: 1.22.0
     devDependencies:
       '@nestjs/common':

--- a/scripts/smoke-core-install.mjs
+++ b/scripts/smoke-core-install.mjs
@@ -154,7 +154,14 @@ import { BullMQModule } from '@a3s-lab/bullmq';
 import { NatsModule } from '@a3s-lab/nats';
 import { RustFSModule } from '@a3s-lab/rustfs';
 import { EtcdModule } from '@a3s-lab/etcd';
-import { CLICKHOUSE_OPTIONS_TOKEN, ClickHouseModule } from '@a3s-lab/clickhouse';
+import {
+    CLICKHOUSE_OPTIONS_TOKEN,
+    ClickHouseClientPoolExhaustedError,
+    type ClickHouseHealthResult,
+    ClickHouseModule,
+    type ClickHouseRequestOptions,
+    createClickHouseClientOptions,
+} from '@a3s-lab/clickhouse';
 import { MigrationModule, NON_TRANSACTIONAL_MIGRATION_NAME } from '@a3s-lab/migrations';
 import { FileUploadModule, getExtension } from '@a3s-lab/files';
 import {
@@ -179,6 +186,21 @@ const logger = new LoggerServiceImpl({ json: true });
 const retry = new RetryService();
 const pool = createPostgresPoolConfig({ host: 'localhost', port: '5432' });
 const redis = createRedissonModuleOptions({ host: 'localhost', port: '6379' });
+const clickhouseClient = createClickHouseClientOptions({
+    url: 'https://clickhouse.test:8443',
+    database: 'analytics',
+    requestTimeoutMs: 2_000,
+});
+const clickhouseRequest: ClickHouseRequestOptions = {
+    database: 'reporting',
+    queryParams: { tenant: 'a3s' },
+    timeoutMs: 1_000,
+};
+const clickhouseHealth: ClickHouseHealthResult = {
+    healthy: true,
+    database: 'analytics',
+    latencyMs: 1,
+};
 const provider = createNestCqrsDomainEventPublisherProvider();
 const sandboxConnection = createA3SBoxConnectionConfig({
     apiUrl: 'https://api.box.test',
@@ -211,6 +233,9 @@ void logger;
 void retry;
 void pool;
 void redis;
+void clickhouseClient;
+void clickhouseRequest;
+void clickhouseHealth;
 void provider;
 void moduleRefs;
 void serviceRefs;
@@ -218,6 +243,7 @@ void Public;
 void StatusCode;
 void DEFAULT_HISTOGRAM_BUCKETS;
 void CLICKHOUSE_OPTIONS_TOKEN;
+void ClickHouseClientPoolExhaustedError;
 void NON_TRANSACTIONAL_MIGRATION_NAME;
 
 const extension: string = getExtension('file.txt');
@@ -253,7 +279,13 @@ const expectedExports = {
     '@a3s-lab/nats': ['NatsModule', 'NatsServiceImpl'],
     '@a3s-lab/rustfs': ['RustFSModule', 'RustFSServiceImpl'],
     '@a3s-lab/etcd': ['EtcdModule', 'EtcdService'],
-    '@a3s-lab/clickhouse': ['CLICKHOUSE_OPTIONS_TOKEN', 'ClickHouseModule', 'ClickHouseService'],
+    '@a3s-lab/clickhouse': [
+        'CLICKHOUSE_OPTIONS_TOKEN',
+        'ClickHouseClientPoolExhaustedError',
+        'ClickHouseModule',
+        'ClickHouseService',
+        'createClickHouseClientOptions',
+    ],
     '@a3s-lab/migrations': ['MigrationModule', 'createFileMigrationProvider'],
     '@a3s-lab/files': ['FileUploadModule', 'FileUploadService', 'getExtension'],
     '@a3s-lab/sandbox': ['SandboxModule', 'SandboxService', 'createA3SBoxConnectionConfig'],


### PR DESCRIPTION
## Summary
- validate and normalize first-party ClickHouse options, including JWT/basic auth conflicts, TLS/advanced SDK configuration, and a verified `@clickhouse/client` 1.22 capability floor
- add request cancellation, typed command/insert results, authenticated health reports, service stats, and lifecycle-owned advanced client access
- bound database overrides with race-safe single-flight creation and LRU eviction that fails closed when clients are busy or cannot close
- make shutdown idempotent, deadline-bounded, operation-aware, and aggregate all client close failures
- expand package/root architecture documentation, changeset, tests, and packed-consumer type/runtime smoke coverage

## Verification
- `pnpm release:check`
- `pnpm smoke:core-install`
- `pnpm audit:prod`
- `pnpm exec changeset status --since=origin/main`
- `pnpm --filter @a3s-lab/clickhouse exec jest --coverage --runInBand --silent` (66 tests; 97.95% statements, 94.61% branches)