### PR TITLE
fix: harden BullMQ lifecycle and queue semantics

### DIFF
--- a/.changeset/quiet-workers-close.md
+++ b/.changeset/quiet-workers-close.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/bullmq": patch
+---
+
+Preserve queue-level job defaults, expose first-party BullMQ option and processor types, support multiple managed workers, add bounded health and shutdown lifecycles, make destructive queue cleanup explicit, and validate public configuration and request boundaries.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/kysely` | NestJS Kysely module, query logging, and PostgreSQL option builders. |
 | `@a3s-lab/redisson` | NestJS Redisson module, Redis service helpers, single-node Redis option builders, and public Redis/Redisson API re-exports. |
 | `@a3s-lab/resilience` | Retry, circuit breaker, cache, rate limiting, distributed lock decorators, services, guards, and interceptors. |
-| `@a3s-lab/bullmq` | NestJS BullMQ module, queue service helpers, worker lifecycle, queue metrics, and cleanup helpers. |
+| `@a3s-lab/bullmq` | Lifecycle-safe NestJS BullMQ module with SDK-typed options, multi-worker management, queue metrics, health checks, bounded shutdown, and explicit cleanup helpers. |
 | `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
@@ -176,6 +176,8 @@ an `NPM_TOKEN` secret with access to the `@a3s-lab` scope.
 - HTTP metrics use route templates rather than raw URLs. Histogram memory is constant per series, and counters, gauges,
   and histograms cap label cardinality with an explicit overflow series.
 - Startup database migrations remain disabled in every environment unless the application explicitly opts in.
+- BullMQ preserves queue-level retry defaults, rejects new work during teardown, closes owned workers before queues under
+  one total timeout, and labels job-removal operations as destructive rather than implying that `drain` processes jobs.
 
 ## Design Boundaries
 

--- a/docs/framework-core.md
+++ b/docs/framework-core.md
@@ -15,7 +15,7 @@ Nestify separates reusable backend API capabilities from the sample application.
 | `@a3s-lab/resilience` | Retry, circuit breaker, cache, rate limiting, distributed lock decorators, services, guards, and interceptors. |
 | `@a3s-lab/kysely` | NestJS Kysely module, query logging, and PostgreSQL option builders for API database wiring. |
 | `@a3s-lab/redisson` | NestJS Redisson module, Redis service helpers, and single-node Redis option builders. |
-| `@a3s-lab/bullmq` | NestJS BullMQ module, queue service helpers, worker lifecycle, and queue metrics for background tasks. |
+| `@a3s-lab/bullmq` | Lifecycle-safe NestJS BullMQ module with SDK-typed options, multi-worker management, queue metrics, health checks, bounded shutdown, and explicit cleanup operations. |
 | `@a3s-lab/nats` | NestJS NATS module, publish/subscribe, request/reply, JetStream helpers, connection state, and lifecycle cleanup. |
 | `@a3s-lab/rustfs` | NestJS S3-compatible object storage module, bucket operations, object operations, presigned URLs, multipart uploads, and health checks. |
 | `@a3s-lab/etcd` | NestJS etcd module, key-value operations, JSON config helpers, local caching, watches, leases, compare-and-set, and health checks. |
@@ -133,7 +133,7 @@ The framework core is covered by package tests for:
 - Resilience module registration and interceptor metadata execution
 - Kysely PostgreSQL option builders and module registration
 - Redisson Redis option builders and module registration
-- BullMQ queue creation, worker lifecycle, metrics, and module registration
+- BullMQ option validation, queue defaults, multiple managed workers, cancellation-aware processors, metrics, health checks, destructive cleanup semantics, and bounded failure-safe shutdown
 - NATS module registration, publish/request encoding, subscriptions, JetStream publishing, and lifecycle cleanup
 - RustFS client registration, bucket/object commands, presigned URLs, multipart uploads, error mapping, and health checks
 - Etcd client registration, key-value operations, config cache, watches, leases, compare-and-set, health checks, and lifecycle cleanup

--- a/packages/bullmq/README.md
+++ b/packages/bullmq/README.md
@@ -1,6 +1,6 @@
 # @a3s-lab/bullmq
 
-NestJS module and service helpers for BullMQ-backed task queues.
+Lifecycle-safe NestJS integration for BullMQ queues, workers, queue events, metrics, health checks, and administrative operations.
 
 ## Install
 
@@ -10,57 +10,149 @@ pnpm add @a3s-lab/bullmq @nestjs/common bullmq
 
 ## Use
 
+Register a connection configuration or an existing BullMQ-compatible ioredis client. Queue, worker, and queue-event settings use the first-party BullMQ SDK types.
+
 ```ts
-import { BullMQModule } from '@a3s-lab/bullmq';
+import { Module } from '@nestjs/common';
+import { BullMQModule, createBullMQModuleOptions } from '@a3s-lab/bullmq';
 
 @Module({
     imports: [
-        BullMQModule.register({
-            connection: {
-                host: 'localhost',
-                port: 6379,
-            },
-            defaultJobOptions: {
-                attempts: 3,
-                backoff: { type: 'exponential', delay: 1000 },
-                removeOnComplete: true,
-            },
-        }),
+        BullMQModule.register(
+            createBullMQModuleOptions({
+                connection: {
+                    host: 'localhost',
+                    port: 6379,
+                },
+                prefix: 'orders',
+                defaultJobOptions: {
+                    attempts: 3,
+                    backoff: { type: 'exponential', delay: 1_000 },
+                    removeOnComplete: true,
+                },
+                workerOptions: {
+                    concurrency: 4,
+                },
+                shutdownTimeoutMs: 10_000,
+            }),
+        ),
     ],
 })
 export class AppModule {}
 ```
 
-Inject the service to add jobs and create workers:
+Async registration requires a factory, so a module cannot silently start without options:
+
+```ts
+BullMQModule.registerAsync({
+    inject: [ConfigService],
+    useFactory: (config: ConfigService) => ({
+        connection: {
+            host: config.getOrThrow('REDIS_HOST'),
+            port: config.getOrThrow('REDIS_PORT'),
+        },
+    }),
+});
+```
+
+### Add jobs
+
+`addJob` forwards explicit `JobsOptions` unchanged. When the options argument is omitted, BullMQ applies the queue's `defaultJobOptions`; the service does not inject a hidden retry policy.
 
 ```ts
 import { Injectable } from '@nestjs/common';
 import { BullMQService } from '@a3s-lab/bullmq';
 
+interface RebuildSearchIndex {
+    tenantId: string;
+}
+
 @Injectable()
-export class TaskService {
+export class SearchJobs {
     constructor(private readonly queues: BullMQService) {}
 
-    async enqueue(data: Record<string, unknown>) {
-        await this.queues.addJob('tasks', 'process', data);
+    enqueue(data: RebuildSearchIndex) {
+        return this.queues.addJob('search', 'rebuild-index', data);
     }
 
-    startWorker() {
-        this.queues.createWorker('tasks', async job => {
-            await processTask(job.data);
-            return { success: true };
-        });
+    enqueueUrgent(data: RebuildSearchIndex) {
+        return this.queues.addJob('search', 'rebuild-index', data, { priority: 1 });
     }
 }
 ```
 
+### Run workers
+
+Processors return their result directly, matching BullMQ's `Processor` contract. The lock token and `AbortSignal` are forwarded so application code can cooperate with cancellation. A worker id is local to this service; distinct ids allow multiple workers for the same queue.
+
+```ts
+interface RebuildResult {
+    indexed: number;
+}
+
+const primary = queues.createWorker<RebuildSearchIndex, RebuildResult>(
+    'search',
+    async (job, _token, signal) => {
+        const indexed = await rebuildIndex(job.data.tenantId, { signal });
+        return { indexed };
+    },
+    { id: 'search-primary', concurrency: 8 },
+);
+
+const lowPriority = queues.createWorker<RebuildSearchIndex, RebuildResult>(
+    'search',
+    async job => ({ indexed: await rebuildIndex(job.data.tenantId) }),
+    { id: 'search-low-priority', concurrency: 2 },
+);
+```
+
+Calling `createWorker` again with the same id and queue returns the existing worker. Reusing an id for a different queue throws `BullMQWorkerConflictError`. Use `getWorker(id)` or `closeWorker(id, force)` for explicit worker management.
+
+### Observe health and queue state
+
+```ts
+const metrics = await queues.getQueueMetrics('search');
+const health = await queues.healthCheck('search');
+const events = queues.getQueueEvents('search');
+
+events.on('failed', ({ jobId, failedReason }) => {
+    reportFailure(jobId, failedReason);
+});
+```
+
+`healthCheck` bounds `Queue.waitUntilReady()` with `healthTimeoutMs` and returns `{ healthy, queue, latencyMs, error? }`. Queue and QueueEvents error listeners are installed before the resources are returned.
+
+### Administrative operations
+
+The service exposes `pauseQueue`, `resumeQueue`, `cleanQueue`, `getJob`, and atomic `removeJob` helpers. Destructive operations are named and documented explicitly:
+
+```ts
+// Removes waiting jobs. It does not process them.
+await queues.removeWaitingJobs('search');
+
+// Also remove delayed jobs.
+await queues.removeWaitingJobs('search', true);
+
+// Remove at most 500 failed jobs older than one day.
+await queues.cleanQueue('search', 86_400_000, 'failed', 500);
+```
+
+`drainQueue` remains as a deprecated compatibility alias for `removeWaitingJobs`.
+
+### Shutdown behavior
+
+The service rejects new work as soon as shutdown begins, waits for already-started service operations, closes workers before QueueEvents and Queue instances, attempts every resource even when one close fails, and uses one total `shutdownTimeoutMs` budget. Repeated `close()` and Nest `onModuleDestroy()` calls share the same promise. By default, workers receive a force-close request if graceful shutdown exhausts the budget.
+
+Shutdown failures are reported as `BullMQShutdownError` with an `errors` array and aggregate cause instead of being lost after the first failure.
+
 ## Exports
 
-- `BullMQModule`
-- `BullMQService`
-- Queue, worker, job, metrics, and module option types
-- Configurable module definition helpers
+- `BullMQModule`, `BullMQService`, and module tokens
+- `createBullMQModuleOptions`, `normalizeBullMQModuleOptions`, and normalized option types
+- BullMQ-derived connection, queue, worker, queue-event, job, and processor types
+- Queue metrics, health, service stats, cleanup status, and managed worker option types
+- Structured configuration, request, lifecycle, worker-conflict, and shutdown errors
 
 ## Notes
 
-The package owns generic queue registration, worker lifecycle, queue metrics, and cleanup helpers. Applications still own queue names, job payloads, retry policy, and worker business logic.
+The package owns resources created through `BullMQService` and closes them during Nest module teardown. Applications own queue names, payload schemas, retry policy, processor business logic, and authorization around destructive administrative methods. A raw Queue or Worker returned by the service must not be used after shutdown starts.

--- a/packages/bullmq/package.json
+++ b/packages/bullmq/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@a3s-lab/bullmq",
     "version": "0.0.1",
-    "description": "NestJS module and service helpers for BullMQ task queues",
+    "description": "Lifecycle-safe NestJS integration for BullMQ task queues",
     "author": "A3S Lab",
     "license": "MIT",
     "homepage": "https://github.com/A3S-Lab/nestify/tree/main/packages/bullmq#readme",
@@ -48,7 +48,7 @@
         "prepublishOnly": "pnpm run build"
     },
     "dependencies": {
-        "bullmq": "^5.0.0"
+        "bullmq": "^5.79.1"
     },
     "devDependencies": {
         "@nestjs/common": "^11.1.28",

--- a/packages/bullmq/src/__tests__/bullmq-options.spec.ts
+++ b/packages/bullmq/src/__tests__/bullmq-options.spec.ts
@@ -1,0 +1,167 @@
+import {
+    BullMQConfigurationError,
+    type BullMQModuleOptions,
+    BullMQPackageError,
+    BullMQRequestError,
+    BullMQServiceClosedError,
+    BullMQShutdownError,
+    BullMQWorkerConflictError,
+} from '../bullmq.types';
+import {
+    createBullMQModuleOptions,
+    DEFAULT_BULLMQ_HEALTH_TIMEOUT_MS,
+    DEFAULT_BULLMQ_SHUTDOWN_TIMEOUT_MS,
+    normalizeBullMQModuleOptions,
+} from '../bullmq-options';
+
+describe('BullMQ options', () => {
+    it('normalizes defaults while preserving the connection object', () => {
+        const connection = { host: 'redis', port: 6379 };
+        const options = normalizeBullMQModuleOptions({ connection });
+
+        expect(options).toEqual({
+            connection,
+            defaultJobOptions: undefined,
+            prefix: undefined,
+            queueOptions: {},
+            workerOptions: {},
+            queueEventsOptions: {},
+            shutdownTimeoutMs: DEFAULT_BULLMQ_SHUTDOWN_TIMEOUT_MS,
+            healthTimeoutMs: DEFAULT_BULLMQ_HEALTH_TIMEOUT_MS,
+            forceWorkerCloseOnTimeout: true,
+        });
+        expect(options.connection).toBe(connection);
+    });
+
+    it('accepts explicitly undefined optional Redis connection fields', () => {
+        expect(
+            normalizeBullMQModuleOptions({
+                connection: { host: undefined, port: undefined, db: undefined },
+            }).connection,
+        ).toEqual({ host: undefined, port: undefined, db: undefined });
+    });
+
+    it('copies first-party option groups and applies lifecycle settings', () => {
+        const defaultJobOptions = { attempts: 3 };
+        const queueOptions = { skipVersionCheck: true };
+        const workerOptions = { concurrency: 4 };
+        const queueEventsOptions = { autorun: false };
+        const normalized = normalizeBullMQModuleOptions({
+            connection: { host: 'redis', port: 6380, db: 2 },
+            prefix: 'app',
+            defaultJobOptions,
+            queueOptions,
+            workerOptions,
+            queueEventsOptions,
+            shutdownTimeoutMs: 5_000,
+            healthTimeoutMs: 500,
+            forceWorkerCloseOnTimeout: false,
+        });
+
+        expect(normalized).toMatchObject({
+            prefix: 'app',
+            shutdownTimeoutMs: 5_000,
+            healthTimeoutMs: 500,
+            forceWorkerCloseOnTimeout: false,
+        });
+        expect(normalized.defaultJobOptions).toEqual(defaultJobOptions);
+        expect(normalized.defaultJobOptions).not.toBe(defaultJobOptions);
+        expect(normalized.queueOptions).not.toBe(queueOptions);
+        expect(normalized.workerOptions).not.toBe(workerOptions);
+        expect(normalized.queueEventsOptions).not.toBe(queueEventsOptions);
+    });
+
+    it('creates validated public module options without empty advanced groups', () => {
+        const connection = { host: 'redis', port: 6379 };
+        expect(createBullMQModuleOptions({ connection })).toEqual({
+            connection,
+            shutdownTimeoutMs: DEFAULT_BULLMQ_SHUTDOWN_TIMEOUT_MS,
+            healthTimeoutMs: DEFAULT_BULLMQ_HEALTH_TIMEOUT_MS,
+            forceWorkerCloseOnTimeout: true,
+        });
+
+        expect(
+            createBullMQModuleOptions({
+                connection,
+                prefix: 'app',
+                defaultJobOptions: { attempts: 2 },
+                queueOptions: { skipWaitingForReady: true },
+                workerOptions: { concurrency: 2 },
+                queueEventsOptions: { autorun: false },
+            }),
+        ).toMatchObject({
+            prefix: 'app',
+            defaultJobOptions: { attempts: 2 },
+            queueOptions: { skipWaitingForReady: true },
+            workerOptions: { concurrency: 2 },
+            queueEventsOptions: { autorun: false },
+        });
+    });
+
+    it.each([
+        [null, 'BullMQ module options must be an object'],
+        [[], 'BullMQ module options must be an object'],
+        [{}, 'connection must be a BullMQ connection object or Redis client'],
+        [{ connection: 'redis://localhost' }, 'connection must be a BullMQ connection object or Redis client'],
+        [{ connection: { host: '', port: 6379 } }, 'connection.host must be a non-empty single-line string'],
+        [{ connection: { host: 'redis', port: 0 } }, 'connection.port must be a positive safe integer'],
+        [{ connection: { host: 'redis', port: 6379, db: -1 } }, 'connection.db must be a non-negative safe integer'],
+    ])('rejects invalid module or connection input %#', (input, message) => {
+        expect(() => normalizeBullMQModuleOptions(input as BullMQModuleOptions)).toThrow(message as string);
+    });
+
+    it.each([
+        [{ prefix: '\n' }, 'prefix must be a non-empty single-line string'],
+        [{ shutdownTimeoutMs: 0 }, 'shutdownTimeoutMs must be a positive safe integer'],
+        [{ healthTimeoutMs: 1.5 }, 'healthTimeoutMs must be a positive safe integer'],
+        [{ forceWorkerCloseOnTimeout: 'yes' }, 'forceWorkerCloseOnTimeout must be a boolean'],
+        [{ defaultJobOptions: [] }, 'defaultJobOptions must be an object'],
+        [{ queueOptions: null }, 'queueOptions must be an object'],
+        [{ workerOptions: { concurrency: 0 } }, 'workerOptions.concurrency must be a positive safe integer'],
+        [
+            { queueEventsOptions: { blockingTimeout: 0 } },
+            'queueEventsOptions.blockingTimeout must be a positive safe integer',
+        ],
+    ])('rejects invalid option input %#', (overrides, message) => {
+        expect(() =>
+            normalizeBullMQModuleOptions({
+                connection: { host: 'redis', port: 6379 },
+                ...overrides,
+            } as BullMQModuleOptions),
+        ).toThrow(message as string);
+    });
+
+    it.each([
+        ['queueOptions', 'connection'],
+        ['queueOptions', 'defaultJobOptions'],
+        ['queueOptions', 'prefix'],
+        ['workerOptions', 'connection'],
+        ['workerOptions', 'prefix'],
+        ['queueEventsOptions', 'connection'],
+        ['queueEventsOptions', 'prefix'],
+    ])('rejects module-owned %s.%s fields at runtime', (group, field) => {
+        expect(() =>
+            normalizeBullMQModuleOptions({
+                connection: { host: 'redis', port: 6379 },
+                [group]: { [field]: 'unexpected' },
+            } as unknown as BullMQModuleOptions),
+        ).toThrow(`${group}.${field} is managed by the module`);
+    });
+
+    it('exposes stable structured package errors', () => {
+        const cause = new Error('cause');
+        const configuration = new BullMQConfigurationError('bad config', cause);
+        const request = new BullMQRequestError('bad request');
+        const closed = new BullMQServiceClosedError();
+        const conflict = new BullMQWorkerConflictError('worker', 'first', 'second');
+        const shutdown = new BullMQShutdownError([cause]);
+
+        expect(configuration).toBeInstanceOf(BullMQPackageError);
+        expect(configuration).toMatchObject({ code: 'BULLMQ_CONFIGURATION_ERROR', statusCode: 500, cause });
+        expect(request).toMatchObject({ code: 'BULLMQ_REQUEST_ERROR', statusCode: 400 });
+        expect(closed).toMatchObject({ code: 'BULLMQ_SERVICE_CLOSED', statusCode: 503 });
+        expect(conflict).toMatchObject({ code: 'BULLMQ_WORKER_CONFLICT', statusCode: 409 });
+        expect(shutdown).toMatchObject({ code: 'BULLMQ_SHUTDOWN_ERROR', errors: [cause] });
+        expect(shutdown.cause).toBeInstanceOf(AggregateError);
+    });
+});

--- a/packages/bullmq/src/__tests__/index.spec.ts
+++ b/packages/bullmq/src/__tests__/index.spec.ts
@@ -1,6 +1,14 @@
-import { BULLMQ_OPTIONS_TOKEN } from '../bullmq.module-definition';
+import { Logger } from '@nestjs/common';
 import { BullMQModule } from '../bullmq.module';
+import { BULLMQ_OPTIONS_TOKEN } from '../bullmq.module-definition';
 import { BullMQService } from '../bullmq.service';
+import {
+    type BullMQModuleOptions,
+    BullMQRequestError,
+    BullMQServiceClosedError,
+    BullMQShutdownError,
+    BullMQWorkerConflictError,
+} from '../bullmq.types';
 
 const mockQueueInstances: Array<Record<string, any>> = [];
 const mockWorkerInstances: Array<Record<string, any>> = [];
@@ -11,7 +19,13 @@ jest.mock('bullmq', () => ({
         const queue = {
             name,
             options,
-            add: jest.fn(async (jobName, data, jobOptions) => ({ id: 'job-1', name: jobName, data, opts: jobOptions })),
+            on: jest.fn(),
+            add: jest.fn(async (jobName, data, jobOptions) => ({
+                id: 'job-1',
+                name: jobName,
+                data,
+                opts: jobOptions,
+            })),
             getWaitingCount: jest.fn(async () => 1),
             getActiveCount: jest.fn(async () => 2),
             getCompletedCount: jest.fn(async () => 3),
@@ -21,7 +35,9 @@ jest.mock('bullmq', () => ({
             resume: jest.fn(async () => undefined),
             drain: jest.fn(async () => undefined),
             clean: jest.fn(async () => ['job-1']),
-            getJob: jest.fn(async (id: string) => ({ id, remove: jest.fn(async () => undefined) })),
+            remove: jest.fn(async () => 1),
+            getJob: jest.fn(async (id: string) => ({ id })),
+            waitUntilReady: jest.fn(async () => ({ status: 'ready' })),
             close: jest.fn(async () => undefined),
         };
         mockQueueInstances.push(queue);
@@ -42,6 +58,7 @@ jest.mock('bullmq', () => ({
         const events = {
             name,
             options,
+            on: jest.fn(),
             close: jest.fn(async () => undefined),
         };
         mockQueueEventInstances.push(events);
@@ -50,6 +67,13 @@ jest.mock('bullmq', () => ({
 }));
 
 describe('bullmq package', () => {
+    beforeAll(() => {
+        jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+        jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
+        jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+    });
+
     beforeEach(() => {
         jest.clearAllMocks();
         mockQueueInstances.length = 0;
@@ -57,11 +81,17 @@ describe('bullmq package', () => {
         mockQueueEventInstances.length = 0;
     });
 
+    afterAll(() => {
+        jest.restoreAllMocks();
+    });
+
     it('exports static and async Nest module registrations', () => {
         const options = { connection: { host: 'localhost', port: 6379 } };
         const staticModule = BullMQModule.register(options);
+        const factory = () => options;
         const asyncModule = BullMQModule.registerAsync({
-            useFactory: () => options,
+            imports: [],
+            useFactory: factory,
             inject: [],
         });
 
@@ -72,74 +102,162 @@ describe('bullmq package', () => {
                 BullMQService,
             ]),
         );
+        expect(asyncModule.imports).toEqual([]);
         expect(asyncModule.providers).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ provide: BULLMQ_OPTIONS_TOKEN, useFactory: expect.any(Function) }),
+                expect.objectContaining({ provide: BULLMQ_OPTIONS_TOKEN, useFactory: factory, inject: [] }),
                 BullMQService,
             ]),
         );
     });
 
-    it('creates queues with connection, defaults, and prefix', async () => {
-        const service = new BullMQService({
-            connection: { host: 'cache', port: 6380 },
-            defaultJobOptions: { attempts: 2 },
+    it('creates and caches queues with advanced options and an error listener', () => {
+        const service = createService({
             prefix: 'api',
+            defaultJobOptions: { attempts: 2 },
+            queueOptions: { skipVersionCheck: true },
         });
 
         const queue = service.getQueue('tasks') as any;
-        const sameQueue = service.getQueue('tasks');
-        const job = await service.addJob('tasks', 'process', { resourceId: 'resource-1' });
-
-        expect(sameQueue).toBe(queue);
+        expect(service.getQueue('tasks')).toBe(queue);
         expect(queue.options).toEqual({
-            connection: { host: 'cache', port: 6380 },
+            connection: { host: 'cache', port: 6379 },
             defaultJobOptions: { attempts: 2 },
             prefix: 'api',
+            skipVersionCheck: true,
         });
-        expect(queue.add).toHaveBeenCalledWith(
-            'process',
-            { resourceId: 'resource-1' },
-            expect.objectContaining({
-                attempts: 3,
-                backoff: { type: 'exponential', delay: 1000 },
-            }),
-        );
-        expect(job).toMatchObject({ id: 'job-1', name: 'process' });
+        expect(queue.on).toHaveBeenCalledWith('error', expect.any(Function));
+        expect(service.getStats()).toMatchObject({ queues: 1, closing: false });
     });
 
-    it('creates workers, wraps processors, and reuses existing workers', async () => {
-        const service = new BullMQService({
-            connection: { host: 'cache', port: 6379 },
+    it('preserves queue-level defaults when job options are omitted', async () => {
+        const service = createService({ defaultJobOptions: { attempts: 7 } });
+
+        const job = await service.addJob('tasks', 'process', { resourceId: 'resource-1' });
+        const queue = mockQueueInstances[0];
+
+        expect(queue.add).toHaveBeenCalledWith('process', { resourceId: 'resource-1' }, undefined);
+        expect(job).toMatchObject({ id: 'job-1', name: 'process' });
+        expect(service.getStats().activeOperations).toBe(0);
+    });
+
+    it('passes explicit SDK job options and builds delayed and repeatable jobs', async () => {
+        const service = createService();
+        await service.addJob('tasks', 'direct', { ok: true }, { attempts: 4, priority: 2 });
+        await service.addDelayedJob('tasks', 'later', { ok: true }, 500);
+        await service.addRepeatableJob('tasks', 'scheduled', { ok: true }, '*/5 * * * *');
+
+        const add = mockQueueInstances[0].add;
+        expect(add).toHaveBeenNthCalledWith(1, 'direct', { ok: true }, { attempts: 4, priority: 2 });
+        expect(add).toHaveBeenNthCalledWith(2, 'later', { ok: true }, { delay: 500 });
+        expect(add).toHaveBeenNthCalledWith(3, 'scheduled', { ok: true }, { repeat: { pattern: '*/5 * * * *' } });
+    });
+
+    it('validates queue, job, repeat, delay, and job option inputs', async () => {
+        const service = createService();
+
+        expect(() => service.getQueue('bad:name')).toThrow(BullMQRequestError);
+        expect(() => service.getQueue(' tasks ')).toThrow(BullMQRequestError);
+        await expect(service.addJob('tasks', '' as string, {}, undefined)).rejects.toBeInstanceOf(BullMQRequestError);
+        await expect(service.addJob('tasks', 'job', {}, null as never)).rejects.toBeInstanceOf(BullMQRequestError);
+        expect(() => service.addDelayedJob('tasks', 'job', {}, -1)).toThrow(BullMQRequestError);
+        expect(() => service.addRepeatableJob('tasks', 'job', {}, '\n')).toThrow(BullMQRequestError);
+    });
+
+    it('returns processor results directly and forwards BullMQ cancellation arguments', async () => {
+        const service = createService({
             prefix: 'api',
+            workerOptions: { concurrency: 2, autorun: false },
         });
+        const processor = jest.fn(async (_job, token?: string, signal?: AbortSignal) => ({
+            token,
+            aborted: signal?.aborted,
+        }));
+        const worker = service.createWorker('tasks', processor, { id: 'primary', concurrency: 5 }) as any;
+        const signal = new AbortController().signal;
+        const job = { name: 'process', data: { ok: true } };
 
-        const worker = service.createWorker('tasks', async job => ({ success: true, data: job.data }), {
-            concurrency: 5,
-        }) as any;
-        const sameWorker = service.createWorker('tasks', async () => ({ success: true }));
-        const result = await mockWorkerInstances[0].processor({ name: 'process', data: { ok: true } });
-
-        expect(sameWorker).toBe(worker);
+        await expect(worker.processor(job, 'lock-token', signal)).resolves.toEqual({
+            token: 'lock-token',
+            aborted: false,
+        });
+        expect(processor).toHaveBeenCalledWith(job, 'lock-token', signal);
         expect(worker.options).toEqual({
-            connection: { host: 'cache', port: 6379 },
+            autorun: false,
             concurrency: 5,
+            connection: { host: 'cache', port: 6379 },
             prefix: 'api',
         });
         expect(worker.on).toHaveBeenCalledWith('completed', expect.any(Function));
         expect(worker.on).toHaveBeenCalledWith('failed', expect.any(Function));
-        expect(result).toEqual({ success: true, data: { ok: true } });
+        expect(worker.on).toHaveBeenCalledWith('error', expect.any(Function));
     });
 
-    it('reports metrics and closes managed resources', async () => {
-        const service = new BullMQService({
+    it('allows multiple worker ids, reuses an id, and rejects cross-queue conflicts', () => {
+        const service = createService();
+        const first = service.createWorker('tasks', async () => 'first', { id: 'worker-a' });
+        const second = service.createWorker('tasks', async () => 'second', { id: 'worker-b' });
+
+        expect(second).not.toBe(first);
+        expect(service.createWorker('tasks', async () => 'ignored', { id: 'worker-a' })).toBe(first);
+        expect(service.getWorker('worker-b')).toBe(second);
+        expect(() => service.createWorker('other', async () => 'bad', { id: 'worker-a' })).toThrow(
+            BullMQWorkerConflictError,
+        );
+        expect(service.getStats().workers).toBe(2);
+    });
+
+    it('logs and rethrows processor failures', async () => {
+        const service = createService();
+        const failure = new Error('processor failed');
+        const worker = service.createWorker('tasks', async () => {
+            throw failure;
+        }) as any;
+
+        await expect(worker.processor({ name: 'process' })).rejects.toBe(failure);
+        expect(Logger.prototype.error).toHaveBeenCalledWith(expect.stringContaining('processor failed'));
+    });
+
+    it('validates worker inputs and closes individual workers', async () => {
+        const service = createService();
+        expect(() => service.createWorker('tasks', null as never)).toThrow(BullMQRequestError);
+        expect(() => service.createWorker('tasks', async () => undefined, { concurrency: 0 })).toThrow(
+            BullMQRequestError,
+        );
+        expect(() =>
+            service.createWorker('tasks', async () => undefined, {
+                connection: { host: 'other', port: 6379 },
+            } as never),
+        ).toThrow('worker options.connection is managed by the service');
+        expect(() => service.getWorker(' worker ')).toThrow(BullMQRequestError);
+
+        const worker = service.createWorker('tasks', async () => undefined, { id: 'worker-a' }) as any;
+        await expect(service.closeWorker('missing')).resolves.toBe(false);
+        await expect(service.closeWorker('worker-a', true)).resolves.toBe(true);
+        expect(worker.close).toHaveBeenCalledWith(true);
+        expect(service.getWorker('worker-a')).toBeUndefined();
+        await expect(service.closeWorker('missing', 'yes' as never)).rejects.toBeInstanceOf(BullMQRequestError);
+    });
+
+    it('creates and caches queue events with advanced options', () => {
+        const service = createService({
+            prefix: 'api',
+            queueEventsOptions: { autorun: false, blockingTimeout: 2_000 },
+        });
+        const events = service.getQueueEvents('tasks') as any;
+
+        expect(service.getQueueEvents('tasks')).toBe(events);
+        expect(events.options).toEqual({
+            autorun: false,
+            blockingTimeout: 2_000,
             connection: { host: 'cache', port: 6379 },
             prefix: 'api',
         });
+        expect(events.on).toHaveBeenCalledWith('error', expect.any(Function));
+    });
 
-        const queue = service.getQueue('tasks') as any;
-        const events = service.getQueueEvents('tasks') as any;
-        const worker = service.createWorker('tasks', async () => ({ success: true })) as any;
+    it('reports metrics and controls queue state', async () => {
+        const service = createService();
 
         await expect(service.getQueueMetrics('tasks')).resolves.toEqual({
             waiting: 1,
@@ -148,12 +266,164 @@ describe('bullmq package', () => {
             failed: 4,
             delayed: 5,
         });
-        expect(events.options).toEqual({ connection: { host: 'cache', port: 6379 }, prefix: 'api' });
+        await service.pauseQueue('tasks');
+        await service.resumeQueue('tasks');
 
-        await service.onModuleDestroy();
+        expect(mockQueueInstances[0].pause).toHaveBeenCalledTimes(1);
+        expect(mockQueueInstances[0].resume).toHaveBeenCalledTimes(1);
+    });
 
-        expect(worker.close).toHaveBeenCalled();
-        expect(queue.close).toHaveBeenCalled();
-        expect(events.close).toHaveBeenCalled();
+    it('makes destructive drain semantics explicit and validates cleanup', async () => {
+        const service = createService();
+
+        await service.removeWaitingJobs('tasks');
+        await service.drainQueue('tasks', true);
+        await expect(service.cleanQueue('tasks', 0, 'failed', 25)).resolves.toEqual(['job-1']);
+
+        const queue = mockQueueInstances[0];
+        expect(queue.drain).toHaveBeenNthCalledWith(1, false);
+        expect(queue.drain).toHaveBeenNthCalledWith(2, true);
+        expect(queue.clean).toHaveBeenCalledWith(0, 25, 'failed');
+        await expect(service.removeWaitingJobs('tasks', 'yes' as never)).rejects.toBeInstanceOf(BullMQRequestError);
+        await expect(service.cleanQueue('tasks', -1)).rejects.toBeInstanceOf(BullMQRequestError);
+        await expect(service.cleanQueue('tasks', 0, 'unknown' as never)).rejects.toBeInstanceOf(BullMQRequestError);
+        await expect(service.cleanQueue('tasks', 0, 'completed', 0)).rejects.toBeInstanceOf(BullMQRequestError);
+    });
+
+    it('gets and atomically removes jobs', async () => {
+        const service = createService();
+
+        await expect(service.getJob('tasks', 'job-1')).resolves.toEqual({ id: 'job-1' });
+        await expect(service.removeJob('tasks', 'job-1', { removeChildren: true })).resolves.toBe(true);
+        mockQueueInstances[0].remove.mockResolvedValueOnce(0);
+        await expect(service.removeJob('tasks', 'missing')).resolves.toBe(false);
+        expect(mockQueueInstances[0].remove).toHaveBeenCalledWith('job-1', { removeChildren: true });
+        await expect(service.removeJob('tasks', '', {})).rejects.toBeInstanceOf(BullMQRequestError);
+        await expect(service.removeJob('tasks', 'job', { removeChildren: 'yes' } as never)).rejects.toBeInstanceOf(
+            BullMQRequestError,
+        );
+    });
+
+    it('reports healthy and failed readiness checks', async () => {
+        const service = createService();
+        await expect(service.healthCheck('health')).resolves.toMatchObject({ healthy: true, queue: 'health' });
+
+        mockQueueInstances[0].waitUntilReady.mockRejectedValueOnce(new Error('redis unavailable'));
+        await expect(service.healthCheck('health')).resolves.toMatchObject({
+            healthy: false,
+            queue: 'health',
+            error: 'redis unavailable',
+        });
+    });
+
+    it('bounds readiness checks with a timeout', async () => {
+        jest.useFakeTimers();
+        try {
+            const service = createService({ healthTimeoutMs: 25 });
+            await expect(service.healthCheck('health')).resolves.toMatchObject({ healthy: true });
+            const stalledQueue = service.getQueue('other') as any;
+            stalledQueue.waitUntilReady.mockReturnValueOnce(new Promise(() => undefined));
+            const secondCheck = service.healthCheck('other');
+
+            await jest.advanceTimersByTimeAsync(25);
+            await expect(secondCheck).resolves.toMatchObject({
+                healthy: false,
+                error: 'Connection readiness timed out after 25ms',
+            });
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('waits for in-flight operations before idempotently closing all resource groups', async () => {
+        const service = createService();
+        service.getQueueEvents('tasks');
+        service.createWorker('tasks', async () => undefined);
+        const queue = service.getQueue('tasks') as any;
+        const deferred = createDeferred<unknown>();
+        queue.add.mockReturnValueOnce(deferred.promise);
+        const operation = service.addJob('tasks', 'process', {});
+
+        const firstClose = service.close();
+        const secondClose = service.close();
+        expect(secondClose).toBe(firstClose);
+        expect(queue.close).not.toHaveBeenCalled();
+        expect(() => service.getQueue('other')).toThrow(BullMQServiceClosedError);
+
+        deferred.resolve({ id: 'job-1', name: 'process' });
+        await operation;
+        await firstClose;
+
+        expect(mockWorkerInstances[0].close).toHaveBeenCalledWith(false);
+        expect(mockQueueEventInstances[0].close).toHaveBeenCalledTimes(1);
+        expect(queue.close).toHaveBeenCalledTimes(1);
+        expect(service.getStats()).toEqual({
+            queues: 0,
+            workers: 0,
+            queueEvents: 0,
+            activeOperations: 0,
+            closing: true,
+        });
+        await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+    });
+
+    it('attempts every resource close and aggregates failures', async () => {
+        const service = createService();
+        const firstQueue = service.getQueue('first') as any;
+        const secondQueue = service.getQueue('second') as any;
+        const events = service.getQueueEvents('first') as any;
+        const worker = service.createWorker('first', async () => undefined) as any;
+        worker.close.mockRejectedValueOnce(new Error('worker close failed'));
+        firstQueue.close.mockRejectedValueOnce(new Error('queue close failed'));
+
+        await expect(service.close()).rejects.toMatchObject({
+            name: 'BullMQShutdownError',
+            errors: expect.arrayContaining([expect.any(Error), expect.any(Error)]),
+        });
+        expect(events.close).toHaveBeenCalledTimes(1);
+        expect(secondQueue.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('force-closes workers when graceful shutdown exceeds the total budget', async () => {
+        jest.useFakeTimers();
+        try {
+            const service = createService({ shutdownTimeoutMs: 20 });
+            const worker = service.createWorker('tasks', async () => undefined) as any;
+            worker.close.mockImplementation((force?: boolean) =>
+                force ? Promise.resolve() : new Promise(() => undefined),
+            );
+
+            const closing = expect(service.close()).rejects.toBeInstanceOf(BullMQShutdownError);
+            await jest.advanceTimersByTimeAsync(20);
+            await jest.runAllTimersAsync();
+
+            await closing;
+            expect(worker.close).toHaveBeenCalledWith(false);
+            expect(worker.close).toHaveBeenCalledWith(true);
+            expect(mockQueueInstances).toHaveLength(0);
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });
+
+function createService(overrides: Partial<BullMQModuleOptions> = {}): BullMQService {
+    return new BullMQService({
+        connection: { host: 'cache', port: 6379 },
+        ...overrides,
+    });
+}
+
+function createDeferred<T>(): {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+    reject: (reason: unknown) => void;
+} {
+    let resolve!: (value: T) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+}

--- a/packages/bullmq/src/bullmq-options.ts
+++ b/packages/bullmq/src/bullmq-options.ts
@@ -1,0 +1,166 @@
+import type { ConnectionOptions, DefaultJobOptions } from 'bullmq';
+import {
+    BullMQConfigurationError,
+    type BullMQModuleOptions,
+    type BullMQQueueEventsOptions,
+    type BullMQQueueOptions,
+    type BullMQWorkerDefaults,
+} from './bullmq.types';
+
+export const DEFAULT_BULLMQ_SHUTDOWN_TIMEOUT_MS = 10_000;
+export const DEFAULT_BULLMQ_HEALTH_TIMEOUT_MS = 2_000;
+
+export interface NormalizedBullMQModuleOptions {
+    connection: ConnectionOptions;
+    defaultJobOptions?: DefaultJobOptions;
+    prefix?: string;
+    queueOptions: BullMQQueueOptions;
+    workerOptions: BullMQWorkerDefaults;
+    queueEventsOptions: BullMQQueueEventsOptions;
+    shutdownTimeoutMs: number;
+    healthTimeoutMs: number;
+    forceWorkerCloseOnTimeout: boolean;
+}
+
+export function createBullMQModuleOptions(input: BullMQModuleOptions): BullMQModuleOptions {
+    const normalized = normalizeBullMQModuleOptions(input);
+    return {
+        connection: normalized.connection,
+        ...(normalized.defaultJobOptions && {
+            defaultJobOptions: normalized.defaultJobOptions,
+        }),
+        ...(normalized.prefix && { prefix: normalized.prefix }),
+        ...(Object.keys(normalized.queueOptions).length > 0 && {
+            queueOptions: normalized.queueOptions,
+        }),
+        ...(Object.keys(normalized.workerOptions).length > 0 && {
+            workerOptions: normalized.workerOptions,
+        }),
+        ...(Object.keys(normalized.queueEventsOptions).length > 0 && {
+            queueEventsOptions: normalized.queueEventsOptions,
+        }),
+        shutdownTimeoutMs: normalized.shutdownTimeoutMs,
+        healthTimeoutMs: normalized.healthTimeoutMs,
+        forceWorkerCloseOnTimeout: normalized.forceWorkerCloseOnTimeout,
+    };
+}
+
+export function normalizeBullMQModuleOptions(input: BullMQModuleOptions): NormalizedBullMQModuleOptions {
+    ensureObject(input, 'BullMQ module options');
+    const connection = validateConnection(input.connection);
+    const prefix = optionalSingleLineString(input.prefix, 'prefix');
+    const defaultJobOptions =
+        input.defaultJobOptions === undefined
+            ? undefined
+            : optionalOptions<DefaultJobOptions>(input.defaultJobOptions, 'defaultJobOptions');
+    const queueOptions = optionalOptions<BullMQQueueOptions>(input.queueOptions, 'queueOptions');
+    const workerOptions = optionalOptions<BullMQWorkerDefaults>(input.workerOptions, 'workerOptions');
+    const queueEventsOptions = optionalOptions<BullMQQueueEventsOptions>(
+        input.queueEventsOptions,
+        'queueEventsOptions',
+    );
+
+    rejectOwnedFields(queueOptions, 'queueOptions', ['connection', 'defaultJobOptions', 'prefix']);
+    rejectOwnedFields(workerOptions, 'workerOptions', ['connection', 'prefix']);
+    rejectOwnedFields(queueEventsOptions, 'queueEventsOptions', ['connection', 'prefix']);
+    if (workerOptions.concurrency !== undefined) {
+        positiveInteger(workerOptions.concurrency, 'workerOptions.concurrency');
+    }
+    if (queueEventsOptions.blockingTimeout !== undefined) {
+        positiveInteger(queueEventsOptions.blockingTimeout, 'queueEventsOptions.blockingTimeout');
+    }
+
+    return {
+        connection,
+        defaultJobOptions,
+        prefix,
+        queueOptions,
+        workerOptions,
+        queueEventsOptions,
+        shutdownTimeoutMs: positiveInteger(
+            input.shutdownTimeoutMs ?? DEFAULT_BULLMQ_SHUTDOWN_TIMEOUT_MS,
+            'shutdownTimeoutMs',
+        ),
+        healthTimeoutMs: positiveInteger(input.healthTimeoutMs ?? DEFAULT_BULLMQ_HEALTH_TIMEOUT_MS, 'healthTimeoutMs'),
+        forceWorkerCloseOnTimeout: optionalBoolean(input.forceWorkerCloseOnTimeout, 'forceWorkerCloseOnTimeout', true),
+    };
+}
+
+function validateConnection(value: unknown): ConnectionOptions {
+    if ((typeof value !== 'object' && typeof value !== 'function') || value === null) {
+        throw new BullMQConfigurationError('connection must be a BullMQ connection object or Redis client');
+    }
+
+    const connection = value as Record<string, unknown>;
+    if (hasOwn(connection, 'host')) {
+        optionalSingleLineString(connection.host, 'connection.host');
+    }
+    if (hasOwn(connection, 'port') && connection.port !== undefined) {
+        positiveInteger(connection.port, 'connection.port');
+    }
+    if (hasOwn(connection, 'db') && connection.db !== undefined) {
+        nonNegativeInteger(connection.db, 'connection.db');
+    }
+
+    return value as ConnectionOptions;
+}
+
+function optionalOptions<T extends object>(value: unknown, name: string): T {
+    if (value === undefined) {
+        return {} as T;
+    }
+    ensureObject(value, name);
+    return { ...(value as T) };
+}
+
+function rejectOwnedFields(value: object, name: string, fields: readonly string[]): void {
+    for (const field of fields) {
+        if (hasOwn(value, field)) {
+            throw new BullMQConfigurationError(`${name}.${field} is managed by the module`);
+        }
+    }
+}
+
+function optionalSingleLineString(value: unknown, name: string): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value !== 'string' || value.trim().length === 0 || /[\r\n]/u.test(value)) {
+        throw new BullMQConfigurationError(`${name} must be a non-empty single-line string`);
+    }
+    return value;
+}
+
+function optionalBoolean(value: unknown, name: string, fallback: boolean): boolean {
+    if (value === undefined) {
+        return fallback;
+    }
+    if (typeof value !== 'boolean') {
+        throw new BullMQConfigurationError(`${name} must be a boolean`);
+    }
+    return value;
+}
+
+function positiveInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new BullMQConfigurationError(`${name} must be a positive safe integer`);
+    }
+    return value as number;
+}
+
+function nonNegativeInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) < 0) {
+        throw new BullMQConfigurationError(`${name} must be a non-negative safe integer`);
+    }
+    return value as number;
+}
+
+function ensureObject(value: unknown, name: string): asserts value is object {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new BullMQConfigurationError(`${name} must be an object`);
+    }
+}
+
+function hasOwn(value: object, key: string): boolean {
+    return Object.getOwnPropertyDescriptor(value, key) !== undefined;
+}

--- a/packages/bullmq/src/bullmq.module.ts
+++ b/packages/bullmq/src/bullmq.module.ts
@@ -2,17 +2,10 @@
 // BullMQ Module - Distributed task queue
 // ============================================================================
 
-import {
-    Module,
-    Global,
-    type DynamicModule,
-    type FactoryProvider,
-    type ModuleMetadata,
-    type Provider,
-} from '@nestjs/common';
-import type { BullMQModuleOptions } from './bullmq.types';
+import { type DynamicModule, Global, Module, type Provider } from '@nestjs/common';
 import { BULLMQ_OPTIONS_TOKEN } from './bullmq.module-definition';
 import { BullMQService } from './bullmq.service';
+import type { BullMQAsyncOptions, BullMQModuleOptions } from './bullmq.types';
 
 @Global()
 @Module({})
@@ -37,20 +30,14 @@ export class BullMQModule {
     /**
      * Register BullMQ module asynchronously (for ConfigService-based config)
      */
-    static registerAsync(options: {
-        imports?: ModuleMetadata['imports'];
-        useFactory?: (...args: unknown[]) => Promise<BullMQModuleOptions> | BullMQModuleOptions;
-        inject?: FactoryProvider['inject'];
-    }): DynamicModule {
-        const asyncProviders: Provider[] = [];
-
-        if (options.useFactory) {
-            asyncProviders.push({
+    static registerAsync(options: BullMQAsyncOptions): DynamicModule {
+        const asyncProviders: Provider[] = [
+            {
                 provide: BULLMQ_OPTIONS_TOKEN,
                 useFactory: options.useFactory,
                 inject: options.inject ?? [],
-            });
-        }
+            },
+        ];
 
         return {
             module: BullMQModule,

--- a/packages/bullmq/src/bullmq.service.ts
+++ b/packages/bullmq/src/bullmq.service.ts
@@ -1,283 +1,566 @@
-// ============================================================================
-// BullMQ Service - Queue management and job processing
-// ============================================================================
-
-import { Inject, Injectable, OnModuleDestroy, Logger } from '@nestjs/common';
-import { Queue, Worker, QueueEvents, type Job } from 'bullmq';
-import type { BullMQModuleOptions } from './bullmq.types';
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import {
+    type Job,
+    type JobsOptions,
+    Queue,
+    QueueEvents,
+    type QueueEventsOptions,
+    type QueueOptions,
+    Worker,
+    type WorkerOptions,
+} from 'bullmq';
 import { BULLMQ_OPTIONS_TOKEN } from './bullmq.module-definition';
+import {
+    type BullMQCleanStatus,
+    type BullMQHealthResult,
+    type BullMQModuleOptions,
+    BullMQRequestError,
+    BullMQServiceClosedError,
+    type BullMQServiceStats,
+    BullMQShutdownError,
+    BullMQWorkerConflictError,
+    type BullMQWorkerOptions,
+    type JobData,
+    type JobProcessor,
+    type QueueMetrics,
+} from './bullmq.types';
+import { type NormalizedBullMQModuleOptions, normalizeBullMQModuleOptions } from './bullmq-options';
 
-export interface JobData {
-    [key: string]: unknown;
+interface ManagedWorker {
+    queueName: string;
+    worker: Worker;
 }
 
-export interface JobResult {
-    success: boolean;
-    data?: unknown;
-    error?: string;
+interface ShutdownAction {
+    label: string;
+    run: () => Promise<unknown>;
 }
 
-export type JobProcessor<T extends JobData = JobData> = (job: Job<T>) => Promise<JobResult>;
+type SettleResult<T> =
+    | { status: 'fulfilled'; value: T }
+    | { status: 'rejected'; reason: unknown }
+    | { status: 'timeout' };
 
-/**
- * Queue metrics for monitoring
- */
-export interface QueueMetrics {
-    waiting: number;
-    active: number;
-    completed: number;
-    failed: number;
-    delayed: number;
-}
+const CLEAN_STATUSES: ReadonlySet<BullMQCleanStatus> = new Set([
+    'active',
+    'completed',
+    'delayed',
+    'failed',
+    'paused',
+    'prioritized',
+    'wait',
+    'waiting',
+]);
 
 @Injectable()
 export class BullMQService implements OnModuleDestroy {
-    private readonly queues: Map<string, Queue> = new Map();
-    private readonly workers: Map<string, Worker> = new Map();
-    private readonly queueEvents: Map<string, QueueEvents> = new Map();
+    private readonly queues = new Map<string, Queue>();
+    private readonly workers = new Map<string, ManagedWorker>();
+    private readonly queueEvents = new Map<string, QueueEvents>();
+    private readonly inFlightOperations = new Set<Promise<unknown>>();
     private readonly logger = new Logger(BullMQService.name);
+    private readonly options: NormalizedBullMQModuleOptions;
+    private closing = false;
+    private closePromise?: Promise<void>;
 
-    constructor(@Inject(BULLMQ_OPTIONS_TOKEN) private readonly options: BullMQModuleOptions) {}
+    constructor(@Inject(BULLMQ_OPTIONS_TOKEN) options: BullMQModuleOptions) {
+        this.options = normalizeBullMQModuleOptions(options);
+    }
 
-    /**
-     * Get or create a queue
-     */
-    getQueue(name: string): Queue {
-        if (this.queues.has(name)) {
-            return this.queues.get(name)!;
+    /** Get or create an owned Queue instance. */
+    getQueue<DataType = JobData, ResultType = unknown, NameType extends string = string>(
+        name: string,
+    ): Queue<DataType, ResultType, NameType> {
+        this.assertRunning();
+        const queueName = validateQueueName(name);
+        const existing = this.queues.get(queueName);
+        if (existing) {
+            return existing as Queue<DataType, ResultType, NameType>;
         }
 
-        const queue = new Queue(name, {
+        const queueOptions: QueueOptions = {
+            ...this.options.queueOptions,
             connection: this.options.connection,
-            defaultJobOptions: this.options.defaultJobOptions,
-            prefix: this.options.prefix,
-        });
-
-        this.queues.set(name, queue);
-        this.logger.log(`Queue '${name}' created`);
-
+            ...(this.options.defaultJobOptions && {
+                defaultJobOptions: this.options.defaultJobOptions,
+            }),
+            ...(this.options.prefix && { prefix: this.options.prefix }),
+        };
+        const queue = new Queue<DataType, ResultType, NameType>(queueName, queueOptions);
+        queue.on('error', error => this.logger.error(`Queue '${queueName}' error: ${errorMessage(error)}`));
+        this.queues.set(queueName, queue);
+        this.logger.log(`Queue '${queueName}' created`);
         return queue;
     }
 
-    /**
-     * Add a job to a queue
-     */
-    async addJob<T extends JobData>(
+    /** Add a job without overriding Queue.defaultJobOptions when options are omitted. */
+    addJob<DataType = JobData, ResultType = unknown, NameType extends string = string>(
         queueName: string,
-        jobName: string,
-        data: T,
-        options?: {
-            priority?: number;
-            attempts?: number;
-            backoff?: { type: 'exponential' | 'fixed'; delay: number };
-            delay?: number;
-            repeat?: { pattern: string } | { endDate: Date };
-        },
-    ): Promise<Job> {
-        const queue = this.getQueue(queueName);
-
-        const job = await queue.add(jobName, data, {
-            priority: options?.priority,
-            attempts: options?.attempts ?? 3,
-            backoff: options?.backoff ?? { type: 'exponential', delay: 1000 },
-            delay: options?.delay,
-            repeat: options?.repeat,
-        });
-
-        this.logger.debug(`Job '${jobName}' added to queue '${queueName}'`);
-        return job;
-    }
-
-    /**
-     * Add a delayed job (runs after delay)
-     */
-    async addDelayedJob<T extends JobData>(queueName: string, jobName: string, data: T, delayMs: number): Promise<Job> {
-        return this.addJob(queueName, jobName, data, { delay: delayMs });
-    }
-
-    /**
-     * Add a repeatable job (cron-like)
-     */
-    async addRepeatableJob<T extends JobData>(
-        queueName: string,
-        jobName: string,
-        data: T,
-        pattern: string, // e.g., '*/5 * * * *'
-    ): Promise<Job> {
-        return this.addJob(queueName, jobName, data, {
-            repeat: { pattern },
+        jobName: NameType,
+        data: DataType,
+        options?: JobsOptions,
+    ): Promise<Job<DataType, ResultType, NameType>> {
+        return this.runOperation(async () => {
+            const name = validateJobName(jobName);
+            validateOptionalObject(options, 'job options');
+            const queue = this.getQueue<DataType, ResultType, NameType>(queueName);
+            const add = queue.add.bind(queue) as unknown as (
+                jobName: NameType,
+                jobData: DataType,
+                jobOptions?: JobsOptions,
+            ) => Promise<Job<DataType, ResultType, NameType>>;
+            const job = await add(name, data, options);
+            this.logger.debug(`Job '${name}' added to queue '${queue.name}'`);
+            return job;
         });
     }
 
-    /**
-     * Create a worker for a queue
-     */
-    createWorker<T extends JobData = JobData>(
+    addDelayedJob<DataType = JobData, ResultType = unknown, NameType extends string = string>(
         queueName: string,
-        processor: JobProcessor<T>,
-        options?: { concurrency?: number },
-    ): Worker {
-        if (this.workers.has(queueName)) {
-            this.logger.warn(`Worker for queue '${queueName}' already exists`);
-            return this.workers.get(queueName)!;
+        jobName: NameType,
+        data: DataType,
+        delayMs: number,
+    ): Promise<Job<DataType, ResultType, NameType>> {
+        nonNegativeInteger(delayMs, 'delayMs');
+        return this.addJob<DataType, ResultType, NameType>(queueName, jobName, data, { delay: delayMs });
+    }
+
+    addRepeatableJob<DataType = JobData, ResultType = unknown, NameType extends string = string>(
+        queueName: string,
+        jobName: NameType,
+        data: DataType,
+        pattern: string,
+    ): Promise<Job<DataType, ResultType, NameType>> {
+        const repeatPattern = validateSingleLineString(pattern, 'repeat pattern');
+        return this.addJob<DataType, ResultType, NameType>(queueName, jobName, data, {
+            repeat: { pattern: repeatPattern },
+        });
+    }
+
+    /** Create or retrieve a managed worker. Supply a distinct id for multiple workers on one queue. */
+    createWorker<DataType = JobData, ResultType = unknown, NameType extends string = string>(
+        queueName: string,
+        processor: JobProcessor<DataType, ResultType, NameType>,
+        options: BullMQWorkerOptions = {},
+    ): Worker<DataType, ResultType, NameType> {
+        this.assertRunning();
+        const name = validateQueueName(queueName);
+        if (typeof processor !== 'function') {
+            throw new BullMQRequestError('processor must be a function');
+        }
+        validateOptionalObject(options, 'worker options');
+        rejectWorkerOwnedOptions(options);
+        const { id, ...overrides } = options;
+        const workerId = validateSingleLineString(id ?? name, 'worker id');
+        const existing = this.workers.get(workerId);
+        if (existing) {
+            if (existing.queueName !== name) {
+                throw new BullMQWorkerConflictError(workerId, existing.queueName, name);
+            }
+            this.logger.warn(`Worker '${workerId}' for queue '${name}' already exists`);
+            return existing.worker as Worker<DataType, ResultType, NameType>;
         }
 
-        const worker = new Worker<T>(
-            queueName,
-            async job => {
-                this.logger.debug(`Processing job '${job.name}' in queue '${queueName}'`);
+        const workerOptions: WorkerOptions = {
+            ...this.options.workerOptions,
+            ...overrides,
+            connection: this.options.connection,
+            ...(this.options.prefix && { prefix: this.options.prefix }),
+        };
+        if (workerOptions.concurrency !== undefined) {
+            positiveInteger(workerOptions.concurrency, 'worker concurrency');
+        }
+
+        const worker = new Worker<DataType, ResultType, NameType>(
+            name,
+            async (job, token, signal) => {
+                this.logger.debug(`Processing job '${job.name}' in queue '${name}'`);
                 try {
-                    const result = await processor(job);
-                    if (!result.success) {
-                        throw new Error(result.error);
-                    }
-                    return result;
+                    return await processor(job, token, signal);
                 } catch (error) {
-                    const message = error instanceof Error ? error.message : String(error);
-                    this.logger.error(`Job '${job.name}' failed: ${message}`);
+                    this.logger.error(`Job '${job.name}' failed: ${errorMessage(error)}`);
                     throw error;
                 }
             },
-            {
-                connection: this.options.connection,
-                concurrency: options?.concurrency ?? 1,
-                prefix: this.options.prefix,
-            },
+            workerOptions,
         );
-
-        worker.on('completed', job => {
-            this.logger.debug(`Job '${job.name}' completed`);
-        });
-
-        worker.on('failed', (job, error) => {
-            this.logger.error(`Job '${job?.name}' failed: ${error.message}`);
-        });
-
-        this.workers.set(queueName, worker);
-        this.logger.log(`Worker for queue '${queueName}' created`);
-
+        worker.on('completed', job => this.logger.debug(`Job '${job.name}' completed`));
+        worker.on('failed', (job, error) =>
+            this.logger.error(`Job '${job?.name ?? 'unknown'}' failed: ${errorMessage(error)}`),
+        );
+        worker.on('error', error => this.logger.error(`Worker '${workerId}' error: ${errorMessage(error)}`));
+        this.workers.set(workerId, { queueName: name, worker });
+        this.logger.log(`Worker '${workerId}' for queue '${name}' created`);
         return worker;
     }
 
-    /**
-     * Get queue events for monitoring
-     */
+    getWorker<DataType = JobData, ResultType = unknown, NameType extends string = string>(
+        workerId: string,
+    ): Worker<DataType, ResultType, NameType> | undefined {
+        this.assertRunning();
+        const id = validateSingleLineString(workerId, 'worker id');
+        return this.workers.get(id)?.worker as Worker<DataType, ResultType, NameType> | undefined;
+    }
+
+    closeWorker(workerId: string, force = false): Promise<boolean> {
+        return this.runOperation(async () => {
+            const id = validateSingleLineString(workerId, 'worker id');
+            if (typeof force !== 'boolean') {
+                throw new BullMQRequestError('force must be a boolean');
+            }
+            const managed = this.workers.get(id);
+            if (!managed) {
+                return false;
+            }
+            await managed.worker.close(force);
+            if (this.workers.get(id) === managed) {
+                this.workers.delete(id);
+            }
+            this.logger.debug(`Worker '${id}' closed`);
+            return true;
+        });
+    }
+
+    /** Get or create the single owned QueueEvents instance for a queue. */
     getQueueEvents(queueName: string): QueueEvents {
-        if (this.queueEvents.has(queueName)) {
-            return this.queueEvents.get(queueName)!;
+        this.assertRunning();
+        const name = validateQueueName(queueName);
+        const existing = this.queueEvents.get(name);
+        if (existing) {
+            return existing;
         }
 
-        const events = new QueueEvents(queueName, {
+        const eventOptions: QueueEventsOptions = {
+            ...this.options.queueEventsOptions,
             connection: this.options.connection,
-            prefix: this.options.prefix,
-        });
-
-        this.queueEvents.set(queueName, events);
+            ...(this.options.prefix && { prefix: this.options.prefix }),
+        };
+        const events = new QueueEvents(name, eventOptions);
+        events.on('error', error => this.logger.error(`QueueEvents '${name}' error: ${errorMessage(error)}`));
+        this.queueEvents.set(name, events);
         return events;
     }
 
-    /**
-     * Get queue metrics
-     */
-    async getQueueMetrics(queueName: string): Promise<QueueMetrics> {
-        const queue = this.getQueue(queueName);
-
-        const [waiting, active, completed, failed, delayed] = await Promise.all([
-            queue.getWaitingCount(),
-            queue.getActiveCount(),
-            queue.getCompletedCount(),
-            queue.getFailedCount(),
-            queue.getDelayedCount(),
-        ]);
-
-        return { waiting, active, completed, failed, delayed };
+    getQueueMetrics(queueName: string): Promise<QueueMetrics> {
+        return this.runOperation(async () => {
+            const queue = this.getQueue(queueName);
+            const [waiting, active, completed, failed, delayed] = await Promise.all([
+                queue.getWaitingCount(),
+                queue.getActiveCount(),
+                queue.getCompletedCount(),
+                queue.getFailedCount(),
+                queue.getDelayedCount(),
+            ]);
+            return { waiting, active, completed, failed, delayed };
+        });
     }
 
-    /**
-     * Pause a queue
-     */
-    async pauseQueue(queueName: string): Promise<void> {
-        const queue = this.getQueue(queueName);
-        await queue.pause();
-        this.logger.log(`Queue '${queueName}' paused`);
+    pauseQueue(queueName: string): Promise<void> {
+        return this.runOperation(async () => {
+            const queue = this.getQueue(queueName);
+            await queue.pause();
+            this.logger.log(`Queue '${queue.name}' paused`);
+        });
     }
 
-    /**
-     * Resume a queue
-     */
-    async resumeQueue(queueName: string): Promise<void> {
-        const queue = this.getQueue(queueName);
-        await queue.resume();
-        this.logger.log(`Queue '${queueName}' resumed`);
+    resumeQueue(queueName: string): Promise<void> {
+        return this.runOperation(async () => {
+            const queue = this.getQueue(queueName);
+            await queue.resume();
+            this.logger.log(`Queue '${queue.name}' resumed`);
+        });
     }
 
-    /**
-     * Drain a queue (process all waiting jobs)
-     */
-    async drainQueue(queueName: string): Promise<void> {
-        const queue = this.getQueue(queueName);
-        await queue.drain();
-        this.logger.log(`Queue '${queueName}' drained`);
+    /** Remove waiting jobs. Delayed jobs are retained unless includeDelayed is true. */
+    removeWaitingJobs(queueName: string, includeDelayed = false): Promise<void> {
+        return this.runOperation(async () => {
+            if (typeof includeDelayed !== 'boolean') {
+                throw new BullMQRequestError('includeDelayed must be a boolean');
+            }
+            const queue = this.getQueue(queueName);
+            await queue.drain(includeDelayed);
+            this.logger.log(
+                `Waiting jobs removed from queue '${queue.name}'${includeDelayed ? ', including delayed jobs' : ''}`,
+            );
+        });
     }
 
-    /**
-     * Clean a queue (remove old jobs)
-     */
-    async cleanQueue(
+    /** @deprecated Use removeWaitingJobs; BullMQ drain removes jobs instead of processing them. */
+    drainQueue(queueName: string, includeDelayed = false): Promise<void> {
+        return this.removeWaitingJobs(queueName, includeDelayed);
+    }
+
+    cleanQueue(
         queueName: string,
-        grace: number = 24 * 60 * 60 * 1000, // 24 hours
-        status?: 'completed' | 'failed',
+        grace = 24 * 60 * 60 * 1000,
+        status: BullMQCleanStatus = 'completed',
+        limit = 100,
     ): Promise<string[]> {
-        const queue = this.getQueue(queueName);
-        return queue.clean(grace, 100, status ?? 'completed');
+        return this.runOperation(async () => {
+            nonNegativeInteger(grace, 'grace');
+            positiveInteger(limit, 'limit');
+            if (!CLEAN_STATUSES.has(status)) {
+                throw new BullMQRequestError(`Unsupported clean status: ${String(status)}`);
+            }
+            return this.getQueue(queueName).clean(grace, limit, status);
+        });
     }
 
-    /**
-     * Remove a specific job
-     */
-    async removeJob(queueName: string, jobId: string): Promise<void> {
-        const queue = this.getQueue(queueName);
-        const job = await queue.getJob(jobId);
-        if (job) {
-            await job.remove();
-        }
+    removeJob(queueName: string, jobId: string, options?: { removeChildren?: boolean }): Promise<boolean> {
+        return this.runOperation(async () => {
+            const id = validateSingleLineString(jobId, 'job id');
+            validateOptionalObject(options, 'remove options');
+            if (options?.removeChildren !== undefined && typeof options.removeChildren !== 'boolean') {
+                throw new BullMQRequestError('removeChildren must be a boolean');
+            }
+            const removed = await this.getQueue(queueName).remove(id, options);
+            return removed > 0;
+        });
     }
 
-    /**
-     * Get a job by ID
-     */
-    async getJob(queueName: string, jobId: string): Promise<Job | undefined> {
-        const queue = this.getQueue(queueName);
-        return queue.getJob(jobId);
+    getJob<DataType = JobData, ResultType = unknown, NameType extends string = string>(
+        queueName: string,
+        jobId: string,
+    ): Promise<Job<DataType, ResultType, NameType> | undefined> {
+        return this.runOperation(async () => {
+            const id = validateSingleLineString(jobId, 'job id');
+            const queue = this.getQueue<DataType, ResultType, NameType>(queueName);
+            return (await queue.getJob(id)) as Job<DataType, ResultType, NameType> | undefined;
+        });
     }
 
-    /**
-     * Close all queues and workers
-     */
-    async onModuleDestroy(): Promise<void> {
-        this.logger.log('Closing BullMQ connections...');
+    healthCheck(queueName = 'bullmq-health'): Promise<BullMQHealthResult> {
+        return this.runOperation(async () => {
+            const queue = this.getQueue(validateQueueName(queueName));
+            const startedAt = Date.now();
+            const result = await settleWithin(queue.waitUntilReady(), this.options.healthTimeoutMs);
+            const latencyMs = Date.now() - startedAt;
+            if (result.status === 'fulfilled') {
+                return { healthy: true, queue: queue.name, latencyMs };
+            }
+            const error =
+                result.status === 'timeout'
+                    ? `Connection readiness timed out after ${this.options.healthTimeoutMs}ms`
+                    : errorMessage(result.reason);
+            return { healthy: false, queue: queue.name, latencyMs, error };
+        });
+    }
 
-        // Close all workers
-        for (const [name, worker] of this.workers) {
-            await worker.close();
-            this.logger.debug(`Worker '${name}' closed`);
+    getStats(): BullMQServiceStats {
+        return {
+            queues: this.queues.size,
+            workers: this.workers.size,
+            queueEvents: this.queueEvents.size,
+            activeOperations: this.inFlightOperations.size,
+            closing: this.closing,
+        };
+    }
+
+    close(): Promise<void> {
+        if (!this.closePromise) {
+            this.closing = true;
+            this.closePromise = this.closeResources();
+        }
+        return this.closePromise;
+    }
+
+    onModuleDestroy(): Promise<void> {
+        return this.close();
+    }
+
+    private async closeResources(): Promise<void> {
+        const errors: unknown[] = [];
+        const deadline = Date.now() + this.options.shutdownTimeoutMs;
+        this.logger.log('Closing BullMQ resources...');
+
+        await this.waitForOperations(deadline, errors);
+        const workerActions = [...this.workers].map<ShutdownAction>(([id, managed]) => ({
+            label: `worker '${id}'`,
+            run: () => managed.worker.close(false),
+        }));
+        const workersClosed = await this.runShutdownActions(workerActions, deadline, errors, 'closing workers');
+        if (!workersClosed && this.options.forceWorkerCloseOnTimeout) {
+            const forceActions = [...this.workers].map<ShutdownAction>(([id, managed]) => ({
+                label: `worker '${id}' force close`,
+                run: () => managed.worker.close(true),
+            }));
+            await this.runShutdownActions(forceActions, deadline, errors, 'force-closing workers');
         }
 
-        // Close all queues
-        for (const [name, queue] of this.queues) {
-            await queue.close();
-            this.logger.debug(`Queue '${name}' closed`);
-        }
+        await this.runShutdownActions(
+            [...this.queueEvents].map<ShutdownAction>(([name, events]) => ({
+                label: `QueueEvents '${name}'`,
+                run: () => events.close(),
+            })),
+            deadline,
+            errors,
+            'closing queue event listeners',
+        );
+        await this.runShutdownActions(
+            [...this.queues].map<ShutdownAction>(([name, queue]) => ({
+                label: `queue '${name}'`,
+                run: () => queue.close(),
+            })),
+            deadline,
+            errors,
+            'closing queues',
+        );
 
-        // Close all queue events
-        for (const [, events] of this.queueEvents) {
-            await events.close();
-        }
-
-        this.queues.clear();
         this.workers.clear();
         this.queueEvents.clear();
-
-        this.logger.log('BullMQ connections closed');
+        this.queues.clear();
+        if (errors.length > 0) {
+            this.logger.error(`BullMQ shutdown completed with ${errors.length} error(s)`);
+            throw new BullMQShutdownError(errors);
+        }
+        this.logger.log('BullMQ resources closed');
     }
+
+    private async waitForOperations(deadline: number, errors: unknown[]): Promise<void> {
+        const operations = [...this.inFlightOperations];
+        if (operations.length === 0) {
+            return;
+        }
+        const result = await settleWithin(Promise.allSettled(operations), remainingMs(deadline));
+        if (result.status === 'timeout') {
+            errors.push(new Error(`Timed out waiting for ${operations.length} BullMQ operation(s)`));
+        } else if (result.status === 'rejected') {
+            errors.push(
+                new Error('Failed while waiting for BullMQ operations', {
+                    cause: result.reason,
+                }),
+            );
+        }
+    }
+
+    private async runShutdownActions(
+        actions: ShutdownAction[],
+        deadline: number,
+        errors: unknown[],
+        phase: string,
+    ): Promise<boolean> {
+        if (actions.length === 0) {
+            return true;
+        }
+        const result = await settleWithin(
+            Promise.allSettled(actions.map(action => invoke(action.run))),
+            remainingMs(deadline),
+        );
+        if (result.status === 'timeout') {
+            errors.push(new Error(`Timed out ${phase} after ${this.options.shutdownTimeoutMs}ms total shutdown time`));
+            return false;
+        }
+        if (result.status === 'rejected') {
+            errors.push(new Error(`Failed ${phase}`, { cause: result.reason }));
+            return false;
+        }
+        result.value.forEach((settlement, index) => {
+            if (settlement.status === 'rejected') {
+                errors.push(
+                    new Error(`Failed to close ${actions[index].label}`, {
+                        cause: settlement.reason,
+                    }),
+                );
+            }
+        });
+        return true;
+    }
+
+    private runOperation<T>(operation: () => Promise<T>): Promise<T> {
+        this.assertRunning();
+        const task = invoke(operation);
+        this.inFlightOperations.add(task);
+        void task.then(
+            () => this.inFlightOperations.delete(task),
+            () => this.inFlightOperations.delete(task),
+        );
+        return task;
+    }
+
+    private assertRunning(): void {
+        if (this.closing) {
+            throw new BullMQServiceClosedError();
+        }
+    }
+}
+
+function validateQueueName(value: unknown): string {
+    const name = validateSingleLineString(value, 'queue name');
+    if (name.includes(':')) {
+        throw new BullMQRequestError('queue name cannot contain :');
+    }
+    return name;
+}
+
+function validateJobName<NameType extends string>(value: NameType): NameType {
+    validateSingleLineString(value, 'job name');
+    return value;
+}
+
+function validateSingleLineString(value: unknown, name: string): string {
+    if (typeof value !== 'string' || value.length === 0 || value.trim() !== value || /[\r\n]/u.test(value)) {
+        throw new BullMQRequestError(`${name} must be a non-empty, trimmed, single-line string`);
+    }
+    return value;
+}
+
+function validateOptionalObject(value: unknown, name: string): void {
+    if (value !== undefined && (typeof value !== 'object' || value === null || Array.isArray(value))) {
+        throw new BullMQRequestError(`${name} must be an object`);
+    }
+}
+
+function rejectWorkerOwnedOptions(options: object): void {
+    for (const field of ['connection', 'prefix']) {
+        if (Object.getOwnPropertyDescriptor(options, field) !== undefined) {
+            throw new BullMQRequestError(`worker options.${field} is managed by the service`);
+        }
+    }
+}
+
+function positiveInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new BullMQRequestError(`${name} must be a positive safe integer`);
+    }
+    return value as number;
+}
+
+function nonNegativeInteger(value: unknown, name: string): number {
+    if (!Number.isSafeInteger(value) || (value as number) < 0) {
+        throw new BullMQRequestError(`${name} must be a non-negative safe integer`);
+    }
+    return value as number;
+}
+
+function remainingMs(deadline: number): number {
+    return Math.max(0, deadline - Date.now());
+}
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function invoke<T>(operation: () => Promise<T>): Promise<T> {
+    try {
+        return operation();
+    } catch (error) {
+        return Promise.reject(error);
+    }
+}
+
+function settleWithin<T>(promise: Promise<T>, timeoutMs: number): Promise<SettleResult<T>> {
+    return new Promise(resolve => {
+        let completed = false;
+        const finish = (result: SettleResult<T>) => {
+            if (completed) return;
+            completed = true;
+            clearTimeout(timer);
+            resolve(result);
+        };
+        const timer = setTimeout(() => finish({ status: 'timeout' }), Math.max(0, timeoutMs));
+        void promise.then(
+            value => finish({ status: 'fulfilled', value }),
+            reason => finish({ status: 'rejected', reason }),
+        );
+    });
 }

--- a/packages/bullmq/src/bullmq.types.ts
+++ b/packages/bullmq/src/bullmq.types.ts
@@ -1,29 +1,174 @@
-// ============================================================================
-// BullMQ Module Options
-// ============================================================================
+import type { DynamicModule, FactoryProvider } from '@nestjs/common';
+import type {
+    ConnectionOptions,
+    DefaultJobOptions,
+    Job,
+    JobsOptions,
+    Processor,
+    Queue,
+    QueueEvents,
+    QueueEventsOptions,
+    QueueOptions,
+    Worker,
+    WorkerOptions,
+} from 'bullmq';
+
+export type {
+    ConnectionOptions,
+    DefaultJobOptions,
+    Job,
+    JobsOptions,
+    Processor,
+    Queue,
+    QueueEvents,
+    QueueEventsOptions,
+    QueueOptions,
+    Worker,
+    WorkerOptions,
+};
+
+export type BullMQQueueOptions = Omit<QueueOptions, 'connection' | 'defaultJobOptions' | 'prefix'>;
+export type BullMQWorkerDefaults = Omit<WorkerOptions, 'connection' | 'prefix'>;
+export type BullMQQueueEventsOptions = Omit<QueueEventsOptions, 'connection' | 'prefix'>;
+
+export interface BullMQWorkerOptions extends BullMQWorkerDefaults {
+    /** Stable local identifier. Different ids allow multiple workers for one queue. */
+    id?: string;
+}
 
 export interface BullMQModuleOptions {
-    /** Redis connection URL */
-    connection: {
-        host: string;
-        port: number;
-        password?: string;
-        db?: number;
-    };
-    /** Default job options */
-    defaultJobOptions?: {
-        attempts?: number;
-        backoff?: {
-            type: 'exponential' | 'fixed';
-            delay?: number;
-        };
-        removeOnComplete?: boolean | number;
-        removeOnFail?: boolean | number;
-    };
-    /** Queue prefixes */
+    /** A BullMQ connection configuration or an existing compatible ioredis client. */
+    connection: ConnectionOptions;
+    /** Default options inherited by jobs which do not override them. */
+    defaultJobOptions?: DefaultJobOptions;
+    /** Prefix shared by every resource owned by this module. */
     prefix?: string;
+    /** Advanced first-party Queue options, excluding module-owned fields. */
+    queueOptions?: BullMQQueueOptions;
+    /** Advanced first-party Worker defaults, excluding module-owned fields. */
+    workerOptions?: BullMQWorkerDefaults;
+    /** Advanced first-party QueueEvents defaults, excluding module-owned fields. */
+    queueEventsOptions?: BullMQQueueEventsOptions;
+    /** Total graceful shutdown budget. Defaults to 10 seconds. */
+    shutdownTimeoutMs?: number;
+    /** Connection readiness budget used by healthCheck. Defaults to 2 seconds. */
+    healthTimeoutMs?: number;
+    /** Force-close workers if graceful shutdown exhausts the budget. Defaults to true. */
+    forceWorkerCloseOnTimeout?: boolean;
+}
+
+export interface BullMQAsyncOptions {
+    imports?: DynamicModule['imports'];
+    useFactory: (...args: unknown[]) => BullMQModuleOptions | Promise<BullMQModuleOptions>;
+    inject?: FactoryProvider['inject'];
 }
 
 export interface BullMQOptionsFactory {
-    createBullMQOptions(): Promise<BullMQModuleOptions> | BullMQModuleOptions;
+    createBullMQOptions(): BullMQModuleOptions | Promise<BullMQModuleOptions>;
+}
+
+export interface JobData {
+    [key: string]: unknown;
+}
+
+/** @deprecated Processors can return their result directly. */
+export interface JobResult {
+    success: boolean;
+    data?: unknown;
+    error?: string;
+}
+
+export type JobProcessor<DataType = JobData, ResultType = unknown, NameType extends string = string> = Processor<
+    DataType,
+    ResultType,
+    NameType
+>;
+
+export type BullMQCleanStatus =
+    | 'active'
+    | 'completed'
+    | 'delayed'
+    | 'failed'
+    | 'paused'
+    | 'prioritized'
+    | 'wait'
+    | 'waiting';
+
+export interface QueueMetrics {
+    waiting: number;
+    active: number;
+    completed: number;
+    failed: number;
+    delayed: number;
+}
+
+export interface BullMQHealthResult {
+    healthy: boolean;
+    queue: string;
+    latencyMs: number;
+    error?: string;
+}
+
+export interface BullMQServiceStats {
+    queues: number;
+    workers: number;
+    queueEvents: number;
+    activeOperations: number;
+    closing: boolean;
+}
+
+export class BullMQPackageError extends Error {
+    constructor(
+        message: string,
+        public readonly code: string,
+        public readonly statusCode: number,
+        options?: ErrorOptions,
+    ) {
+        super(message, options);
+        this.name = 'BullMQPackageError';
+    }
+}
+
+export class BullMQConfigurationError extends BullMQPackageError {
+    constructor(message: string, cause?: unknown) {
+        super(message, 'BULLMQ_CONFIGURATION_ERROR', 500, cause === undefined ? undefined : { cause });
+        this.name = 'BullMQConfigurationError';
+    }
+}
+
+export class BullMQRequestError extends BullMQPackageError {
+    constructor(message: string) {
+        super(message, 'BULLMQ_REQUEST_ERROR', 400);
+        this.name = 'BullMQRequestError';
+    }
+}
+
+export class BullMQServiceClosedError extends BullMQPackageError {
+    constructor() {
+        super('BullMQ service is closing or already closed', 'BULLMQ_SERVICE_CLOSED', 503);
+        this.name = 'BullMQServiceClosedError';
+    }
+}
+
+export class BullMQWorkerConflictError extends BullMQPackageError {
+    constructor(workerId: string, existingQueue: string, requestedQueue: string) {
+        super(
+            `Worker '${workerId}' already belongs to queue '${existingQueue}', not '${requestedQueue}'`,
+            'BULLMQ_WORKER_CONFLICT',
+            409,
+        );
+        this.name = 'BullMQWorkerConflictError';
+    }
+}
+
+export class BullMQShutdownError extends BullMQPackageError {
+    constructor(public readonly errors: readonly unknown[]) {
+        super(
+            `BullMQ shutdown completed with ${errors.length} error${errors.length === 1 ? '' : 's'}`,
+            'BULLMQ_SHUTDOWN_ERROR',
+            500,
+            { cause: new AggregateError(errors, 'BullMQ shutdown errors') },
+        );
+        this.name = 'BullMQShutdownError';
+    }
 }

--- a/packages/bullmq/src/index.ts
+++ b/packages/bullmq/src/index.ts
@@ -1,4 +1,5 @@
 export * from './bullmq.module';
+export * from './bullmq.module-definition';
 export * from './bullmq.service';
 export * from './bullmq.types';
-export * from './bullmq.module-definition';
+export * from './bullmq-options';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,7 +187,7 @@ importers:
   packages/bullmq:
     dependencies:
       bullmq:
-        specifier: ^5.0.0
+        specifier: ^5.79.1
         version: 5.79.1
     devDependencies:
       '@nestjs/common':

--- a/scripts/smoke-core-install.mjs
+++ b/scripts/smoke-core-install.mjs
@@ -150,7 +150,13 @@ import { LoggerServiceImpl } from '@a3s-lab/logger';
 import { ResilienceModule, RetryService } from '@a3s-lab/resilience';
 import { KyselyModule, createPostgresPoolConfig } from '@a3s-lab/kysely';
 import { RedissonModule, createRedissonModuleOptions } from '@a3s-lab/redisson';
-import { BullMQModule } from '@a3s-lab/bullmq';
+import {
+    BullMQModule,
+    BullMQService,
+    createBullMQModuleOptions,
+    type BullMQHealthResult,
+    type BullMQWorkerOptions,
+} from '@a3s-lab/bullmq';
 import { NatsModule } from '@a3s-lab/nats';
 import { RustFSModule } from '@a3s-lab/rustfs';
 import { EtcdModule } from '@a3s-lab/etcd';
@@ -179,6 +185,12 @@ const logger = new LoggerServiceImpl({ json: true });
 const retry = new RetryService();
 const pool = createPostgresPoolConfig({ host: 'localhost', port: '5432' });
 const redis = createRedissonModuleOptions({ host: 'localhost', port: '6379' });
+const bullmq = createBullMQModuleOptions({
+    connection: { host: 'localhost', port: 6379 },
+    workerOptions: { concurrency: 2 },
+});
+const bullmqWorker: BullMQWorkerOptions = { id: 'smoke-worker', concurrency: 1 };
+const bullmqHealth: BullMQHealthResult = { healthy: true, queue: 'smoke', latencyMs: 0 };
 const provider = createNestCqrsDomainEventPublisherProvider();
 const sandboxConnection = createA3SBoxConnectionConfig({
     apiUrl: 'https://api.box.test',
@@ -199,7 +211,7 @@ const moduleRefs = [
     FileUploadModule,
     SandboxModule,
 ];
-const serviceRefs = [AiService, SandboxService];
+const serviceRefs = [AiService, BullMQService, SandboxService];
 
 void event;
 void envelope;
@@ -211,6 +223,9 @@ void logger;
 void retry;
 void pool;
 void redis;
+void bullmq;
+void bullmqWorker;
+void bullmqHealth;
 void provider;
 void moduleRefs;
 void serviceRefs;
@@ -249,7 +264,13 @@ const expectedExports = {
     '@a3s-lab/resilience': ['RetryService', 'ResilienceModule', 'CacheService'],
     '@a3s-lab/kysely': ['KyselyModule', 'createPostgresPoolConfig'],
     '@a3s-lab/redisson': ['RedissonModule', 'createRedissonModuleOptions'],
-    '@a3s-lab/bullmq': ['BullMQModule', 'BullMQService'],
+    '@a3s-lab/bullmq': [
+        'BullMQModule',
+        'BullMQService',
+        'createBullMQModuleOptions',
+        'BullMQServiceClosedError',
+        'BullMQShutdownError',
+    ],
     '@a3s-lab/nats': ['NatsModule', 'NatsServiceImpl'],
     '@a3s-lab/rustfs': ['RustFSModule', 'RustFSServiceImpl'],
     '@a3s-lab/etcd': ['EtcdModule', 'EtcdService'],


### PR DESCRIPTION
## Summary
- preserve BullMQ queue-level job defaults and expose first-party SDK option/processor types
- support multiple managed workers, cancellation-aware processors, health checks, and bounded failure-safe shutdown
- clarify destructive queue cleanup semantics and expand package/root documentation plus packed-consumer smoke coverage

## Verification
- `pnpm release:check`
- `pnpm smoke:core-install`
- `pnpm audit:prod`
- `pnpm changeset status --since=origin/main`
- `pnpm --filter @a3s-lab/bullmq exec jest --coverage --runInBand --silent` (45 tests; 96.72% statements, 91.4% branches)
- `pnpm install --frozen-lockfile --offline --ignore-scripts`