### PR TITLE
feat(sandbox): harden lifecycle and connection boundaries

### DIFF
--- a/.changeset/calm-sandboxes-close.md
+++ b/.changeset/calm-sandboxes-close.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/sandbox": minor
+---
+
+Harden A3S Box connection validation and add scope-aware, bounded, observable sandbox shutdown with retryable cleanup ownership.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run NestJS module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
 | `@a3s-lab/ai` | NestJS integration for the A3S coding-agent runtime through `@a3s-lab/code`, with injectable configuration and lifecycle-safe agent access. |
-| `@a3s-lab/sandbox` | NestJS integration for A3S Box sandbox and code-interpreter workflows through the lazily loaded first-party `@a3s-lab/box` TypeScript SDK. |
+| `@a3s-lab/sandbox` | NestJS integration for the first-party `@a3s-lab/box` SDK with native instances, guarded connection configuration, managed scopes, and bounded observable shutdown. |
 
 The shared package list is dependency-ordered in `scripts/core-packages.mjs`. Build, test, pack, smoke install, and publish rehearsal commands all use that same list.
 
@@ -176,6 +176,8 @@ an `NPM_TOKEN` secret with access to the `@a3s-lab` scope.
 - HTTP metrics use route templates rather than raw URLs. Histogram memory is constant per series, and counters, gauges,
   and histograms cap label cardinality with an explicit overflow series.
 - Startup database migrations remain disabled in every environment unless the application explicitly opts in.
+- Sandbox shutdown rejects new work, drains complete managed callback and connection scopes, applies a 30-second
+  default bound, settles every owned instance, and reports final cleanup failures without discarding retry ownership.
 
 ## Design Boundaries
 

--- a/docs/framework-core.md
+++ b/docs/framework-core.md
@@ -23,7 +23,7 @@ Nestify separates reusable backend API capabilities from the sample application.
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
 | `@a3s-lab/ai` | NestJS module and service integration for the A3S coding-agent runtime provided by `@a3s-lab/code`. |
-| `@a3s-lab/sandbox` | NestJS module, service, and connection helpers that lazily load the first-party `@a3s-lab/box` TypeScript SDK. |
+| `@a3s-lab/sandbox` | NestJS module and lifecycle service for native first-party `@a3s-lab/box` sandboxes, with guarded connection configuration and bounded cleanup. |
 
 Each package has a package-level README with install notes, import examples, exported capabilities, and boundary notes:
 
@@ -63,6 +63,8 @@ The NestJS integration packages accept NestJS 10 and 11 peers. Workspace builds,
   excess labels aggregate into a fixed overflow series, and HTTP paths come only from route templates or a fixed
   unmatched label.
 - Automatic migrations are fail-closed and require an explicit module or environment opt-in in production.
+- Sandbox instances created by the service remain owned until release or successful cleanup. Shutdown is idempotent,
+  drains complete managed scopes before final cleanup, is bounded by default, and exposes unrecovered failures.
 
 ## Sample API Wiring
 
@@ -141,7 +143,8 @@ The framework core is covered by package tests for:
 - Migration provider wrapping and module registration
 - File upload validation, storage key handling, module registration, and upload interceptors
 - AI module registration, injected runtime access, session delegation, and lifecycle cleanup
-- Sandbox connection configuration, module registration, lazy SDK access, operation delegation, and lifecycle cleanup
+- Sandbox connection hardening, module registration, validated lazy SDK access, native operation delegation, managed
+  callback/connect concurrency, bounded shutdown, cleanup aggregation, and retryable ownership
 
 Run:
 

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -36,6 +36,8 @@ import { SandboxModule } from '@a3s-lab/sandbox';
             defaultTemplate: 'code-interpreter-v1',
             defaultTimeoutMs: 60_000,
             killOnShutdown: true,
+            shutdownTimeoutMs: 30_000,
+            cleanupFailurePolicy: 'throw',
         }),
     ],
 })
@@ -44,7 +46,8 @@ export class AppModule {}
 
 `registerAsync` accepts the usual Nest factory, class, and existing-provider forms. Modules are non-global by default;
 set `isGlobal: true` explicitly if one application-wide service is intended. Module-owned connection fields override
-per-call SDK options, and `validateApiKey` is always `false` for A3S credentials.
+per-call SDK options, `validateApiKey` is always `false` for A3S credentials, and caller option objects are copied and
+frozen before delegation. Operation and shutdown timeouts must be positive safe integers.
 
 The Nest wrapper and `createA3SBoxConnectionConfig()` do not read or rewrite `E2B_*` variables. A3S Box 3.0.11,
 however, re-exports compatibility classes backed by its pinned transport, which can still consult ambient `E2B_*`
@@ -52,7 +55,8 @@ values for unspecified transport fields. For strict A3S-only routing, start the 
 the wrapper cannot override every inherited transport field until the first-party SDK removes that fallback.
 
 `createA3SBoxConnectionConfig()` exposes the same endpoint validation and `api.<domain>` derivation rules without
-loading the ESM SDK:
+loading the ESM SDK. It trims endpoint fields, accepts only absolute HTTP(S) URLs without embedded credentials,
+rejects control-plane query strings/fragments, validates explicit host/port domains, and returns a frozen object:
 
 ```ts
 import { createA3SBoxConnectionConfig } from '@a3s-lab/sandbox';
@@ -92,18 +96,29 @@ when the call does not provide one.
 - `SandboxModule` and its sync/async registration option types
 - `SandboxService`
 - `createA3SBoxConnectionConfig()`
+- `DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS`
+- Typed configuration, SDK, closed-service, shutdown-timeout, and aggregate-cleanup errors
 - Native A3S Box sandbox, code-interpreter, connection, and operation types
 
 ## Notes
 
 `create()` and `createCodeInterpreter()` create owned instances. `withSandbox()` and `withCodeInterpreter()` always
-attempt to kill those instances after the callback. `connect()` and `connectCodeInterpreter()` return unowned instances
-and are never killed automatically. Use `release(instance)` to transfer ownership or `kill(instance)` for idempotent
-service-managed cleanup. On Nest shutdown, the service waits for in-flight creates and explicit kills, and all remaining
-owned instances are killed with settled-result semantics unless `killOnShutdown` is false. An instance whose creation
-finishes only after shutdown begins is killed before the rejected create operation settles, so it cannot leak. Both SDK
-entrypoints are loaded only when their first operation runs, so requiring this CommonJS package root does not
-synchronously load the SDK's ESM modules.
+attempt to kill those instances after the complete callback scope. `connect()` and `connectCodeInterpreter()` return
+unowned instances and are never killed automatically, but an already-started connection is still drained during
+shutdown. Use `release(instance)` to transfer ownership or `kill(instance)` for idempotent service-managed cleanup.
+
+`shutdown()` is public, idempotent, and also backs Nest's `onModuleDestroy()`. Once it starts, the service rejects new
+operations. Shutdown first drains managed callbacks, creates, connects, and explicit kills for up to
+`shutdownTimeoutMs` (30 seconds by default), then settles cleanup for every remaining owned instance. Late creates are
+killed before their rejected operation settles. A final kill failure preserves service ownership so callers can retry
+`kill(instance)` explicitly. If a late create cannot be cleaned up, its `SandboxServiceClosedError` also exposes the
+native object as `unreleasedInstance` so the caller retains a recovery path. By default, timeout and final cleanup
+failures are exposed together as `SandboxCleanupError`; set `cleanupFailurePolicy: 'ignore'` only when best-effort
+shutdown is intentional.
+
+Both SDK entrypoints are loaded only when their first operation runs, validated before use, cached after success, and
+retried after load failure. Requiring this CommonJS package root therefore does not synchronously load the SDK's ESM
+modules.
 
 A3S Box 3.0.11 production-tests a useful E2B-compatible subset: create/connect/get/list, timeout and kill,
 memory-preserving pause/connect-resume, current metrics and logs, foreground/background commands, stdin, PTY,

--- a/packages/sandbox/src/__tests__/sandbox.connection.spec.ts
+++ b/packages/sandbox/src/__tests__/sandbox.connection.spec.ts
@@ -6,9 +6,27 @@ const invalidConnections: Array<[A3SConnectionOptions, string]> = [
     [{ apiUrl: '' }, 'apiUrl cannot be empty'],
     [{ apiUrl: 'box.test' }, 'absolute HTTP or HTTPS URL'],
     [{ apiUrl: 'ftp://api.box.test' }, 'absolute HTTP or HTTPS URL'],
+    [{ apiUrl: 'https://user:secret@api.box.test' }, 'apiUrl cannot contain embedded credentials'],
+    [{ apiUrl: 'https://api.box.test?tenant=one' }, 'apiUrl cannot contain a query string or fragment'],
+    [{ apiUrl: 'https://api.box.test#fragment' }, 'apiUrl cannot contain a query string or fragment'],
+    [{ apiUrl: `https://${'x'.repeat(2_049)}` }, 'apiUrl cannot exceed 2048 characters'],
     [{ apiUrl: 'https://api.box.test', domain: ' ' }, 'domain cannot be empty'],
+    [{ apiUrl: 'https://api.box.test', domain: 'https://box.test' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'box.test/path' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'user@box.test' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: '-box.test' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'box_test.invalid' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'box..test' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'x'.repeat(254) }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'box.test:99999' }, 'valid hostname with an optional port'],
+    [{ apiUrl: 'https://api.box.test', domain: 'x'.repeat(513) }, 'domain cannot exceed 512 characters'],
     [{ apiUrl: 'https://api.box.test', apiKey: ' ' }, 'apiKey cannot be empty'],
+    [{ apiUrl: 'https://api.box.test', apiKey: ' key' }, 'apiKey cannot contain leading or trailing whitespace'],
+    [{ apiUrl: 'https://api.box.test', apiKey: 'x'.repeat(8_193) }, 'apiKey cannot exceed 8192 characters'],
     [{ apiUrl: 'https://api.box.test', sandboxUrl: ' ' }, 'sandboxUrl cannot be empty'],
+    [{ apiUrl: 'https://api.box.test', sandboxUrl: 'file:///tmp/box' }, 'absolute HTTP or HTTPS URL'],
+    [{ apiUrl: 'https://api.box.test', sandboxUrl: 'https://user:secret@box.test' }, 'embedded credentials'],
+    [{ apiUrl: 'https://api.box.test', sandboxUrl: `https://${'x'.repeat(2_049)}` }, 'cannot exceed 2048'],
 ];
 
 describe('createA3SBoxConnectionConfig', () => {
@@ -27,27 +45,46 @@ describe('createA3SBoxConnectionConfig', () => {
     });
 
     it('uses an explicit domain and preserves a single-sandbox fixture URL', () => {
-        expect(
-            createA3SBoxConnectionConfig({
-                apiUrl: 'http://control.internal:3000',
-                domain: 'sandboxes.example.test',
-                sandboxUrl: 'https://fixture.example.test',
-            }),
-        ).toEqual({
-            apiUrl: 'http://control.internal:3000',
-            domain: 'sandboxes.example.test',
-            validateApiKey: false,
-            sandboxUrl: 'https://fixture.example.test',
+        const connection = createA3SBoxConnectionConfig({
+            apiUrl: '  http://control.internal:3000  ',
+            domain: '  Sandboxes.Example.Test:443  ',
+            sandboxUrl: '  https://fixture.example.test/run?token=fixture  ',
         });
+
+        expect(connection).toEqual({
+            apiUrl: 'http://control.internal:3000',
+            domain: 'sandboxes.example.test:443',
+            validateApiKey: false,
+            sandboxUrl: 'https://fixture.example.test/run?token=fixture',
+        });
+        expect(Object.isFrozen(connection)).toBe(true);
     });
 
     it('uses a non-api endpoint hostname as the derived domain', () => {
         expect(createA3SBoxConnectionConfig({ apiUrl: 'https://box.test/control' }).domain).toBe('box.test');
     });
 
+    it('accepts IP literals and optional ports for explicit domains', () => {
+        expect(createA3SBoxConnectionConfig({ apiUrl: 'https://api.box.test', domain: '127.0.0.1:3000' }).domain).toBe(
+            '127.0.0.1:3000',
+        );
+        expect(createA3SBoxConnectionConfig({ apiUrl: 'https://api.box.test', domain: '[::1]:3000' }).domain).toBe(
+            '[::1]:3000',
+        );
+    });
+
     it.each(invalidConnections)('rejects invalid connection options %#', (options, message) => {
         expect(() => createA3SBoxConnectionConfig(options)).toThrow(SandboxConfigurationError);
         expect(() => createA3SBoxConnectionConfig(options)).toThrow(message);
+    });
+
+    it('requires an object connection configuration', () => {
+        expect(() => createA3SBoxConnectionConfig(undefined as unknown as A3SConnectionOptions)).toThrow(
+            'connection options are required',
+        );
+        expect(() => createA3SBoxConnectionConfig({ apiUrl: 42 as unknown as string })).toThrow(
+            'apiUrl cannot be empty',
+        );
     });
 
     it('does not consult E2B environment variables', () => {

--- a/packages/sandbox/src/__tests__/sandbox.entrypoint.spec.ts
+++ b/packages/sandbox/src/__tests__/sandbox.entrypoint.spec.ts
@@ -1,0 +1,25 @@
+import {
+    createA3SBoxConnectionConfig,
+    DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS,
+    SandboxCleanupError,
+    SandboxConfigurationError,
+    SandboxModule,
+    SandboxSdkError,
+    SandboxService,
+    SandboxServiceClosedError,
+    SandboxShutdownTimeoutError,
+} from '../index';
+
+describe('@a3s-lab/sandbox entrypoint', () => {
+    it('exports its public runtime surface', () => {
+        expect(createA3SBoxConnectionConfig).toEqual(expect.any(Function));
+        expect(DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS).toBe(30_000);
+        expect(SandboxModule).toEqual(expect.any(Function));
+        expect(SandboxService).toEqual(expect.any(Function));
+        expect(SandboxCleanupError).toEqual(expect.any(Function));
+        expect(SandboxConfigurationError).toEqual(expect.any(Function));
+        expect(SandboxSdkError).toEqual(expect.any(Function));
+        expect(SandboxServiceClosedError).toEqual(expect.any(Function));
+        expect(SandboxShutdownTimeoutError).toEqual(expect.any(Function));
+    });
+});

--- a/packages/sandbox/src/__tests__/sandbox.service.spec.ts
+++ b/packages/sandbox/src/__tests__/sandbox.service.spec.ts
@@ -1,4 +1,10 @@
-import { SandboxConfigurationError, SandboxSdkError, SandboxServiceClosedError } from '../sandbox.errors';
+import {
+    SandboxCleanupError,
+    SandboxConfigurationError,
+    SandboxSdkError,
+    SandboxServiceClosedError,
+    SandboxShutdownTimeoutError,
+} from '../sandbox.errors';
 import { SandboxService } from '../sandbox.service';
 import type {
     CodeInterpreterCreateOptions,
@@ -161,19 +167,45 @@ describe('SandboxService', () => {
         expect(harness.loadSandboxSdk).not.toHaveBeenCalled();
     });
 
-    it('settles every shutdown kill once and rejects new operations afterward', async () => {
+    it('connects to an unowned code-interpreter instance through the native entrypoint', async () => {
         const harness = createHarness();
-        harness.sandboxKill.mockRejectedValueOnce(new Error('already unavailable'));
         const service = createService(harness.loader);
-        await service.create('node-v1');
+
+        const connected = await service.connectCodeInterpreter('  interpreter-id  ', {
+            timeoutMs: 15_000,
+        });
+
+        expect(connected).toBe(harness.connectedCodeInterpreter);
+        expect(service.owns(connected)).toBe(false);
+        expect(harness.codeInterpreterConnect).toHaveBeenCalledWith(
+            'interpreter-id',
+            expect.objectContaining({ timeoutMs: 15_000, apiUrl: 'https://api.box.test' }),
+        );
+    });
+
+    it('settles every shutdown kill, reports failures, and rejects new operations afterward', async () => {
+        const harness = createHarness();
+        const killFailure = new Error('already unavailable');
+        harness.sandboxKill.mockRejectedValueOnce(killFailure);
+        const service = createService(harness.loader);
+        const sandbox = await service.create('node-v1');
         await service.createCodeInterpreter();
 
-        await expect(service.onModuleDestroy()).resolves.toBeUndefined();
-        await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+        const shutdown = service.onModuleDestroy();
+        await expect(shutdown).rejects.toMatchObject({
+            name: 'SandboxCleanupError',
+            errors: [killFailure],
+        });
+        expect(service.onModuleDestroy()).toBe(shutdown);
+        await expect(service.onModuleDestroy()).rejects.toBeInstanceOf(SandboxCleanupError);
 
         expect(harness.sandboxKill).toHaveBeenCalledTimes(1);
         expect(harness.codeInterpreterKill).toHaveBeenCalledTimes(1);
+        expect(service.owns(sandbox)).toBe(true);
+        expect(service.isClosed).toBe(true);
         await expect(service.create('node-v1')).rejects.toBeInstanceOf(SandboxServiceClosedError);
+        await expect(service.kill(sandbox)).resolves.toBe(true);
+        expect(service.owns(sandbox)).toBe(false);
     });
 
     it('waits for a create that finishes during shutdown and kills the unreturned instance', async () => {
@@ -239,7 +271,10 @@ describe('SandboxService', () => {
         harness.loadSandboxSdk.mockRejectedValueOnce(loadFailure);
         const service = createService(harness.loader);
 
-        await expect(service.create('node-v1')).rejects.toBe(loadFailure);
+        await expect(service.create('node-v1')).rejects.toMatchObject({
+            name: 'SandboxSdkError',
+            cause: loadFailure,
+        });
         await expect(service.create('node-v1')).resolves.toBe(harness.sandbox);
         expect(harness.loadSandboxSdk).toHaveBeenCalledTimes(2);
 
@@ -255,10 +290,262 @@ describe('SandboxService', () => {
         const harness = createHarness();
         expect(() => createService(harness.loader, { defaultTemplate: ' ' })).toThrow(SandboxConfigurationError);
         expect(() => createService(harness.loader, { defaultTimeoutMs: 0 })).toThrow(SandboxConfigurationError);
+        expect(() => createService(harness.loader, { shutdownTimeoutMs: 0 })).toThrow(SandboxConfigurationError);
+        expect(() =>
+            createService(harness.loader, {
+                cleanupFailurePolicy: 'invalid' as SandboxModuleOptions['cleanupFailurePolicy'],
+            }),
+        ).toThrow(SandboxConfigurationError);
+        expect(() => createService(harness.loader, { killOnShutdown: 'yes' as unknown as boolean })).toThrow(
+            SandboxConfigurationError,
+        );
 
         const service = createService(harness.loader);
         await expect(service.create(' ')).rejects.toThrow('template cannot be empty');
         await expect(service.connect(' ')).rejects.toThrow('sandboxId cannot be empty');
+        await expect(service.connect(`box-${'x'.repeat(512)}`)).rejects.toThrow('cannot exceed 512 characters');
+        await expect(service.connect('box\nheader')).rejects.toThrow('cannot contain control characters');
+    });
+
+    it('drains the entire withSandbox callback scope before shutdown cleanup', async () => {
+        const harness = createHarness();
+        const callbackStarted = deferred<void>();
+        const callbackResult = deferred<string>();
+        const service = createService(harness.loader);
+
+        const operation = service.withSandbox('node-v1', async () => {
+            callbackStarted.resolve(undefined);
+            return callbackResult.promise;
+        });
+        await callbackStarted.promise;
+
+        let shutdownSettled = false;
+        const shutdown = service.shutdown().finally(() => {
+            shutdownSettled = true;
+        });
+        await Promise.resolve();
+
+        expect(shutdownSettled).toBe(false);
+        expect(harness.sandboxKill).not.toHaveBeenCalled();
+
+        callbackResult.resolve('complete');
+        await expect(operation).resolves.toBe('complete');
+        await expect(shutdown).resolves.toBeUndefined();
+        expect(harness.sandboxKill).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries a managed-scope kill that fails while shutdown is draining', async () => {
+        const harness = createHarness();
+        const callbackStarted = deferred<void>();
+        const callbackResult = deferred<string>();
+        const killFailure = new Error('first kill failed');
+        harness.sandboxKill.mockRejectedValueOnce(killFailure).mockResolvedValueOnce(true);
+        const service = createService(harness.loader);
+
+        const operation = service.withSandbox('node-v1', async () => {
+            callbackStarted.resolve(undefined);
+            return callbackResult.promise;
+        });
+        await callbackStarted.promise;
+        const shutdown = service.shutdown();
+        callbackResult.resolve('ignored');
+
+        await expect(operation).rejects.toBe(killFailure);
+        await expect(shutdown).resolves.toBeUndefined();
+        expect(harness.sandboxKill).toHaveBeenCalledTimes(2);
+    });
+
+    it('waits for an unowned connect already in flight without killing its result', async () => {
+        const harness = createHarness();
+        const connectResult = deferred<SandboxInstance>();
+        harness.sandboxConnect.mockImplementationOnce(() => connectResult.promise);
+        const service = createService(harness.loader);
+
+        const connecting = service.connect('existing');
+        await waitForMock(harness.sandboxConnect);
+        let shutdownSettled = false;
+        const shutdown = service.shutdown().finally(() => {
+            shutdownSettled = true;
+        });
+        await Promise.resolve();
+
+        expect(shutdownSettled).toBe(false);
+        connectResult.resolve(harness.sandbox);
+        await expect(connecting).resolves.toBe(harness.sandbox);
+        await expect(shutdown).resolves.toBeUndefined();
+        expect(harness.sandboxKill).not.toHaveBeenCalled();
+    });
+
+    it('reports a late-create cleanup failure to both the create and shutdown callers', async () => {
+        const harness = createHarness();
+        const createResult = deferred<SandboxInstance>();
+        const killFailure = new Error('late cleanup failed');
+        harness.sandboxCreate.mockImplementationOnce(() => createResult.promise);
+        harness.sandboxKill.mockRejectedValue(killFailure);
+        const service = createService(harness.loader);
+
+        const creating = service.create('node-v1');
+        await waitForMock(harness.sandboxCreate);
+        const shutdown = service.shutdown();
+        createResult.resolve(harness.sandbox);
+
+        await expect(creating).rejects.toMatchObject({
+            name: 'SandboxServiceClosedError',
+            cause: killFailure,
+            unreleasedInstance: harness.sandbox,
+        });
+        await expect(shutdown).rejects.toMatchObject({
+            name: 'SandboxCleanupError',
+            errors: [killFailure],
+        });
+        expect(service.owns(harness.sandbox)).toBe(true);
+        expect(harness.sandboxKill).toHaveBeenCalledTimes(2);
+    });
+
+    it('bounds shutdown draining and still performs final owned cleanup', async () => {
+        const harness = createHarness();
+        const callbackStarted = deferred<void>();
+        const callbackResult = deferred<string>();
+        const service = createService(harness.loader, { shutdownTimeoutMs: 10 });
+
+        const operation = service.withSandbox('node-v1', async () => {
+            callbackStarted.resolve(undefined);
+            return callbackResult.promise;
+        });
+        await callbackStarted.promise;
+
+        let shutdownError: unknown;
+        try {
+            await service.shutdown();
+        } catch (error) {
+            shutdownError = error;
+        }
+        expect(shutdownError).toBeInstanceOf(SandboxCleanupError);
+        expect((shutdownError as AggregateError).errors).toEqual([expect.any(SandboxShutdownTimeoutError)]);
+        expect(harness.sandboxKill).toHaveBeenCalledTimes(1);
+
+        callbackResult.resolve('eventually complete');
+        await expect(operation).resolves.toBe('eventually complete');
+    });
+
+    it('supports explicit best-effort shutdown cleanup', async () => {
+        const harness = createHarness();
+        harness.sandboxKill.mockRejectedValueOnce(new Error('unavailable'));
+        const service = createService(harness.loader, { cleanupFailurePolicy: 'ignore' });
+        await service.create('node-v1');
+
+        await expect(service.shutdown()).resolves.toBeUndefined();
+        await expect(service.shutdown()).resolves.toBeUndefined();
+        expect(harness.sandboxKill).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves callback and cleanup failures without losing either cause', async () => {
+        const harness = createHarness();
+        const callbackFailure = new Error('callback failed');
+        const cleanupFailure = new Error('cleanup failed');
+        harness.sandboxKill.mockRejectedValueOnce(cleanupFailure);
+        const service = createService(harness.loader);
+
+        await expect(
+            service.withSandbox('node-v1', async () => {
+                throw callbackFailure;
+            }),
+        ).rejects.toMatchObject({
+            name: 'AggregateError',
+            errors: [callbackFailure, cleanupFailure],
+        });
+    });
+
+    it('surfaces automatic cleanup failure after a successful callback', async () => {
+        const harness = createHarness();
+        const cleanupFailure = new Error('cleanup failed');
+        harness.sandboxKill.mockRejectedValueOnce(cleanupFailure);
+        const service = createService(harness.loader);
+
+        await expect(service.withSandbox('node-v1', () => 'result')).rejects.toBe(cleanupFailure);
+        expect(service.owns(harness.sandbox)).toBe(true);
+    });
+
+    it('validates callbacks and operation options before invoking an SDK operation', async () => {
+        const harness = createHarness();
+        const service = createService(harness.loader);
+
+        await expect(
+            (service.withSandbox as unknown as (template: string) => Promise<unknown>)('node-v1'),
+        ).rejects.toThrow('withSandbox requires a callback');
+        await expect(service.withCodeInterpreter(undefined as never)).rejects.toThrow(
+            'withCodeInterpreter requires a callback',
+        );
+        await expect(service.create('node-v1', { timeoutMs: 0 } as SandboxCreateOptions)).rejects.toThrow(
+            'timeoutMs must be a positive safe integer',
+        );
+
+        const readFailure = new Error('getter failed');
+        const unreadable = Object.defineProperty({}, 'metadata', {
+            enumerable: true,
+            get: () => {
+                throw readFailure;
+            },
+        });
+        await expect(service.create('node-v1', unreadable as SandboxCreateOptions)).rejects.toMatchObject({
+            name: 'SandboxConfigurationError',
+            cause: readFailure,
+        });
+    });
+
+    it('normalizes templates and freezes a fresh SDK option object', async () => {
+        const harness = createHarness();
+        const service = createService(harness.loader);
+        const callerOptions = { metadata: { source: 'caller' } } as SandboxCreateOptions;
+
+        await service.create('  node-v1  ', callerOptions);
+
+        const passedOptions = harness.sandboxCreate.mock.calls[0]?.[1] as SandboxCreateOptions;
+        expect(harness.sandboxCreate).toHaveBeenCalledWith('node-v1', passedOptions);
+        expect(passedOptions).not.toBe(callerOptions);
+        expect(Object.isFrozen(passedOptions)).toBe(true);
+        expect(Object.isFrozen(callerOptions)).toBe(false);
+    });
+
+    it('wraps synchronous loader failures and rejects malformed SDK results', async () => {
+        const harness = createHarness();
+        const syncFailure = new Error('sync import failed');
+        const syncLoader: SandboxSdkLoader = {
+            loadSandboxSdk: () => {
+                throw syncFailure;
+            },
+            loadCodeInterpreterSdk: harness.loader.loadCodeInterpreterSdk,
+        };
+        await expect(createService(syncLoader).create('node-v1')).rejects.toMatchObject({
+            name: 'SandboxSdkError',
+            cause: syncFailure,
+        });
+
+        harness.sandboxCreate.mockResolvedValueOnce({});
+        await expect(createService(harness.loader).create('node-v1')).rejects.toThrow(
+            'did not return a native sandbox instance',
+        );
+
+        const malformedCodeLoader: SandboxSdkLoader = {
+            loadSandboxSdk: harness.loader.loadSandboxSdk,
+            loadCodeInterpreterSdk: async () => ({}) as CodeInterpreterSdkModule,
+        };
+        await expect(createService(malformedCodeLoader).createCodeInterpreter()).rejects.toThrow(
+            '@a3s-lab/box/code-interpreter',
+        );
+    });
+
+    it('rejects missing options and malformed custom loaders during construction', () => {
+        const harness = createHarness();
+        expect(() => new SandboxService(undefined as unknown as SandboxModuleOptions)).toThrow(
+            'SandboxModule options are required',
+        );
+        expect(() => createService({} as SandboxSdkLoader)).toThrow(
+            'sdkLoader must provide loadSandboxSdk and loadCodeInterpreterSdk',
+        );
+        expect(() => createService(harness.loader, { shutdownTimeoutMs: Number.MAX_SAFE_INTEGER + 1 })).toThrow(
+            SandboxConfigurationError,
+        );
     });
 });
 
@@ -266,9 +553,11 @@ interface Harness {
     loader: SandboxSdkLoader;
     sandbox: SandboxInstance;
     codeInterpreter: CodeInterpreterInstance;
+    connectedCodeInterpreter: CodeInterpreterInstance;
     sandboxCreate: jest.Mock;
     sandboxConnect: jest.Mock;
     codeInterpreterCreate: jest.Mock;
+    codeInterpreterConnect: jest.Mock;
     sandboxKill: jest.Mock;
     codeInterpreterKill: jest.Mock;
     loadSandboxSdk: jest.Mock;
@@ -318,9 +607,11 @@ function createHarness(): Harness {
         loader: { loadSandboxSdk, loadCodeInterpreterSdk },
         sandbox,
         codeInterpreter,
+        connectedCodeInterpreter,
         sandboxCreate,
         sandboxConnect,
         codeInterpreterCreate,
+        codeInterpreterConnect,
         sandboxKill,
         codeInterpreterKill,
         loadSandboxSdk,

--- a/packages/sandbox/src/sandbox.connection.ts
+++ b/packages/sandbox/src/sandbox.connection.ts
@@ -1,6 +1,10 @@
 import { SandboxConfigurationError } from './sandbox.errors';
 import type { A3SBoxConnectionConfig, A3SConnectionOptions } from './sandbox.types';
 
+const MAX_URL_LENGTH = 2_048;
+const MAX_DOMAIN_LENGTH = 512;
+const MAX_API_KEY_LENGTH = 8_192;
+
 /**
  * Build the connection options consumed by the first-party A3S Box SDK.
  *
@@ -11,36 +15,37 @@ export function createA3SBoxConnectionConfig(options: A3SConnectionOptions): A3S
     if (!options || typeof options !== 'object') {
         throw new SandboxConfigurationError('connection options are required');
     }
-    if (typeof options.apiUrl !== 'string' || !options.apiUrl.trim()) {
-        throw new SandboxConfigurationError('apiUrl cannot be empty');
+    const apiUrl = normalizeUrl('apiUrl', options.apiUrl);
+    const endpoint = parseEndpoint(apiUrl, 'apiUrl');
+    if (endpoint.search || endpoint.hash) {
+        throw new SandboxConfigurationError('apiUrl cannot contain a query string or fragment');
     }
+    const domain = normalizeDomain(options.domain ?? domainFromEndpoint(endpoint));
+    const apiKey = normalizeApiKey(options.apiKey);
+    const sandboxUrl = options.sandboxUrl === undefined ? undefined : normalizeUrl('sandboxUrl', options.sandboxUrl);
+    if (sandboxUrl !== undefined) parseEndpoint(sandboxUrl, 'sandboxUrl');
 
-    const endpoint = parseEndpoint(options.apiUrl);
-    const domain = options.domain ?? domainFromEndpoint(endpoint);
-    if (typeof domain !== 'string' || !domain.trim()) {
-        throw new SandboxConfigurationError('domain cannot be empty when provided');
-    }
-    validateOptionalSecret('apiKey', options.apiKey);
-    validateOptionalSecret('sandboxUrl', options.sandboxUrl);
-
-    return {
-        apiUrl: options.apiUrl,
+    return Object.freeze({
+        apiUrl,
         domain,
         validateApiKey: false,
-        ...(options.apiKey === undefined ? {} : { apiKey: options.apiKey }),
-        ...(options.sandboxUrl === undefined ? {} : { sandboxUrl: options.sandboxUrl }),
-    };
+        ...(apiKey === undefined ? {} : { apiKey }),
+        ...(sandboxUrl === undefined ? {} : { sandboxUrl }),
+    });
 }
 
-function parseEndpoint(apiUrl: string): URL {
+function parseEndpoint(url: string, name: 'apiUrl' | 'sandboxUrl'): URL {
     let endpoint: URL;
     try {
-        endpoint = new URL(apiUrl);
+        endpoint = new URL(url);
     } catch {
-        throw new SandboxConfigurationError('apiUrl must be an absolute HTTP or HTTPS URL');
+        throw new SandboxConfigurationError(`${name} must be an absolute HTTP or HTTPS URL`);
     }
     if (endpoint.protocol !== 'http:' && endpoint.protocol !== 'https:') {
-        throw new SandboxConfigurationError('apiUrl must be an absolute HTTP or HTTPS URL');
+        throw new SandboxConfigurationError(`${name} must be an absolute HTTP or HTTPS URL`);
+    }
+    if (endpoint.username || endpoint.password) {
+        throw new SandboxConfigurationError(`${name} cannot contain embedded credentials`);
     }
     return endpoint;
 }
@@ -49,8 +54,63 @@ function domainFromEndpoint(endpoint: URL): string {
     return endpoint.hostname.startsWith('api.') ? endpoint.hostname.slice(4) : endpoint.hostname;
 }
 
-function validateOptionalSecret(name: 'apiKey' | 'sandboxUrl', value: string | undefined): void {
-    if (value !== undefined && (typeof value !== 'string' || !value.trim())) {
-        throw new SandboxConfigurationError(`${name} cannot be empty when provided`);
+function normalizeUrl(name: 'apiUrl' | 'sandboxUrl', value: string): string {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new SandboxConfigurationError(`${name} cannot be empty${name === 'sandboxUrl' ? ' when provided' : ''}`);
     }
+    const normalized = value.trim();
+    if (normalized.length > MAX_URL_LENGTH) {
+        throw new SandboxConfigurationError(`${name} cannot exceed ${MAX_URL_LENGTH} characters`);
+    }
+    return normalized;
+}
+
+function normalizeDomain(value: string): string {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new SandboxConfigurationError('domain cannot be empty when provided');
+    }
+    const normalized = value.trim();
+    if (normalized.length > MAX_DOMAIN_LENGTH) {
+        throw new SandboxConfigurationError(`domain cannot exceed ${MAX_DOMAIN_LENGTH} characters`);
+    }
+    let endpoint: URL;
+    try {
+        endpoint = new URL(`http://${normalized}`);
+    } catch {
+        throw new SandboxConfigurationError('domain must be a valid hostname with an optional port');
+    }
+    if (
+        !endpoint.hostname ||
+        !isValidDomainHostname(endpoint.hostname) ||
+        endpoint.username ||
+        endpoint.password ||
+        endpoint.pathname !== '/' ||
+        endpoint.search ||
+        endpoint.hash
+    ) {
+        throw new SandboxConfigurationError('domain must be a valid hostname with an optional port');
+    }
+    return endpoint.host;
+}
+
+function isValidDomainHostname(hostname: string): boolean {
+    if (hostname.startsWith('[') && hostname.endsWith(']')) return true;
+    if (hostname.length > 253) return false;
+    return hostname
+        .split('.')
+        .every(label => label.length > 0 && label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/iu.test(label));
+}
+
+function normalizeApiKey(value: string | undefined): string | undefined {
+    if (value === undefined) return undefined;
+    if (typeof value !== 'string' || !value.trim()) {
+        throw new SandboxConfigurationError('apiKey cannot be empty when provided');
+    }
+    if (value !== value.trim()) {
+        throw new SandboxConfigurationError('apiKey cannot contain leading or trailing whitespace');
+    }
+    if (value.length > MAX_API_KEY_LENGTH) {
+        throw new SandboxConfigurationError(`apiKey cannot exceed ${MAX_API_KEY_LENGTH} characters`);
+    }
+    return value;
 }

--- a/packages/sandbox/src/sandbox.errors.ts
+++ b/packages/sandbox/src/sandbox.errors.ts
@@ -1,15 +1,40 @@
+import type { OwnedSandboxInstance } from './sandbox.types';
+
 export class SandboxConfigurationError extends Error {
     override readonly name = 'SandboxConfigurationError';
 }
 
+export interface SandboxServiceClosedErrorOptions extends ErrorOptions {
+    /** Native instance that could not be cleaned up while its create operation was closing. */
+    readonly unreleasedInstance?: OwnedSandboxInstance;
+}
+
 export class SandboxServiceClosedError extends Error {
     override readonly name = 'SandboxServiceClosedError';
+    readonly unreleasedInstance?: OwnedSandboxInstance;
 
-    constructor() {
-        super('SandboxService is shutting down and cannot start new operations');
+    constructor(options?: SandboxServiceClosedErrorOptions) {
+        super('SandboxService is shutting down and cannot start new operations', options);
+        this.unreleasedInstance = options?.unreleasedInstance;
     }
 }
 
 export class SandboxSdkError extends Error {
     override readonly name = 'SandboxSdkError';
+}
+
+export class SandboxShutdownTimeoutError extends Error {
+    override readonly name = 'SandboxShutdownTimeoutError';
+
+    constructor(readonly timeoutMs: number) {
+        super(`Sandbox shutdown timed out after ${timeoutMs}ms while draining in-flight operations`);
+    }
+}
+
+export class SandboxCleanupError extends AggregateError {
+    override readonly name = 'SandboxCleanupError';
+
+    constructor(errors: readonly unknown[]) {
+        super([...errors], `Sandbox shutdown cleanup failed with ${errors.length} error(s)`);
+    }
 }

--- a/packages/sandbox/src/sandbox.service.ts
+++ b/packages/sandbox/src/sandbox.service.ts
@@ -1,6 +1,12 @@
 import { Inject, Injectable, type OnModuleDestroy } from '@nestjs/common';
 import { createA3SBoxConnectionConfig } from './sandbox.connection';
-import { SandboxConfigurationError, SandboxSdkError, SandboxServiceClosedError } from './sandbox.errors';
+import {
+    SandboxCleanupError,
+    SandboxConfigurationError,
+    SandboxSdkError,
+    SandboxServiceClosedError,
+    SandboxShutdownTimeoutError,
+} from './sandbox.errors';
 import { MODULE_OPTIONS_TOKEN } from './sandbox.module-definition';
 import type {
     A3SBoxConnectionConfig,
@@ -21,6 +27,10 @@ import type {
 
 const NO_ERROR = Symbol('no-error');
 const CONNECTION_OPTION_KEYS = ['apiUrl', 'domain', 'apiKey', 'sandboxUrl', 'validateApiKey'] as const;
+const MAX_IDENTIFIER_LENGTH = 512;
+const IDENTIFIER_CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/u;
+
+export const DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS = 30_000;
 
 const DEFAULT_SDK_LOADER: SandboxSdkLoader = {
     async loadSandboxSdk(): Promise<SandboxSdkModule> {
@@ -37,12 +47,15 @@ export class SandboxService implements OnModuleDestroy {
     private readonly defaultTemplate?: string;
     private readonly defaultTimeoutMs?: number;
     private readonly killOnShutdown: boolean;
+    private readonly cleanupFailurePolicy: 'throw' | 'ignore';
+    private readonly shutdownTimeoutMs: number;
     private readonly sdkLoader: SandboxSdkLoader;
     private readonly owned = new Set<OwnedSandboxInstance>();
     private readonly inFlight = new Set<Promise<unknown>>();
     private sandboxSdkPromise?: Promise<SandboxSdkModule>;
     private codeInterpreterSdkPromise?: Promise<CodeInterpreterSdkModule>;
     private shutdownPromise?: Promise<void>;
+    private readonly shutdownCleanupFailures: unknown[] = [];
     private shuttingDown = false;
 
     constructor(@Inject(MODULE_OPTIONS_TOKEN) options: SandboxModuleOptions) {
@@ -56,7 +69,12 @@ export class SandboxService implements OnModuleDestroy {
         if (typeof this.killOnShutdown !== 'boolean') {
             throw new SandboxConfigurationError('killOnShutdown must be a boolean');
         }
-        this.sdkLoader = options.sdkLoader ?? DEFAULT_SDK_LOADER;
+        this.cleanupFailurePolicy = validateCleanupFailurePolicy(options.cleanupFailurePolicy);
+        this.shutdownTimeoutMs = validateTimeout(
+            'shutdownTimeoutMs',
+            options.shutdownTimeoutMs ?? DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS,
+        );
+        this.sdkLoader = normalizeSdkLoader(options.sdkLoader ?? DEFAULT_SDK_LOADER);
     }
 
     create(options?: SandboxCreateOptions): Promise<SandboxInstance>;
@@ -89,8 +107,15 @@ export class SandboxService implements OnModuleDestroy {
     async connect(sandboxId: string, options?: SandboxConnectOptions): Promise<SandboxInstance> {
         this.assertActive();
         const resolvedId = requiredValue('sandboxId', sandboxId);
+        return this.trackInFlight(this.connectSandbox(resolvedId, options));
+    }
+
+    private async connectSandbox(sandboxId: string, options?: SandboxConnectOptions): Promise<SandboxInstance> {
         const sdk = await this.loadSandboxSdk();
-        return sdk.Sandbox.connect(resolvedId, this.withConnection(options));
+        return validateOwnedInstance(
+            await sdk.Sandbox.connect(sandboxId, this.withConnection(options)),
+            '@a3s-lab/box Sandbox.connect',
+        );
     }
 
     async createCodeInterpreter(options?: CodeInterpreterCreateOptions): Promise<CodeInterpreterInstance> {
@@ -112,8 +137,18 @@ export class SandboxService implements OnModuleDestroy {
     ): Promise<CodeInterpreterInstance> {
         this.assertActive();
         const resolvedId = requiredValue('sandboxId', sandboxId);
+        return this.trackInFlight(this.connectCodeInterpreterSandbox(resolvedId, options));
+    }
+
+    private async connectCodeInterpreterSandbox(
+        sandboxId: string,
+        options?: CodeInterpreterConnectOptions,
+    ): Promise<CodeInterpreterInstance> {
         const sdk = await this.loadCodeInterpreterSdk();
-        return sdk.Sandbox.connect(resolvedId, this.withConnection(options));
+        return validateOwnedInstance(
+            await sdk.Sandbox.connect(sandboxId, this.withConnection(options)),
+            '@a3s-lab/box/code-interpreter Sandbox.connect',
+        );
     }
 
     async withSandbox<TResult>(callback: SandboxCallback<TResult>, options?: SandboxCreateOptions): Promise<TResult>;
@@ -123,6 +158,16 @@ export class SandboxService implements OnModuleDestroy {
         options?: SandboxCreateOptions,
     ): Promise<TResult>;
     async withSandbox<TResult>(
+        templateOrCallback: string | SandboxCallback<TResult>,
+        callbackOrOptions?: SandboxCallback<TResult> | SandboxCreateOptions,
+        options?: SandboxCreateOptions,
+    ): Promise<TResult> {
+        this.assertActive();
+        const operation = this.withSandboxScope(templateOrCallback, callbackOrOptions, options);
+        return this.trackInFlight(operation);
+    }
+
+    private async withSandboxScope<TResult>(
         templateOrCallback: string | SandboxCallback<TResult>,
         callbackOrOptions?: SandboxCallback<TResult> | SandboxCreateOptions,
         options?: SandboxCreateOptions,
@@ -142,6 +187,14 @@ export class SandboxService implements OnModuleDestroy {
     }
 
     async withCodeInterpreter<TResult>(
+        callback: CodeInterpreterCallback<TResult>,
+        options?: CodeInterpreterCreateOptions,
+    ): Promise<TResult> {
+        this.assertActive();
+        return this.trackInFlight(this.withCodeInterpreterScope(callback, options));
+    }
+
+    private async withCodeInterpreterScope<TResult>(
         callback: CodeInterpreterCallback<TResult>,
         options?: CodeInterpreterCreateOptions,
     ): Promise<TResult> {
@@ -174,29 +227,58 @@ export class SandboxService implements OnModuleDestroy {
         try {
             return await sandbox.kill();
         } catch (error) {
-            if (!this.shuttingDown) {
-                this.owned.add(sandbox);
-            }
+            this.owned.add(sandbox);
             throw error;
         }
     }
 
     onModuleDestroy(): Promise<void> {
+        return this.shutdown();
+    }
+
+    /** Stop new operations, drain managed scopes, and dispose remaining owned instances exactly once. */
+    shutdown(): Promise<void> {
         if (!this.shutdownPromise) {
             this.shuttingDown = true;
-            const instances = [...this.owned];
-            const inFlight = [...this.inFlight];
-            this.owned.clear();
-            this.shutdownPromise = this.cleanupOnShutdown(instances, inFlight);
+            this.shutdownPromise = this.cleanupOnShutdown();
         }
         return this.shutdownPromise;
     }
 
-    private async cleanupOnShutdown(instances: OwnedSandboxInstance[], inFlight: Promise<unknown>[]): Promise<void> {
-        const shutdownKills = this.killOnShutdown
-            ? instances.map(instance => Promise.resolve().then(() => instance.kill()))
-            : [];
-        await Promise.allSettled([...inFlight, ...shutdownKills]);
+    /** Whether shutdown has started. A closed service never becomes active again. */
+    get isClosed(): boolean {
+        return this.shuttingDown;
+    }
+
+    private async cleanupOnShutdown(): Promise<void> {
+        try {
+            await withTimeout(this.drainInFlight(), this.shutdownTimeoutMs);
+        } catch (error) {
+            this.shutdownCleanupFailures.push(error);
+        }
+        const instances = [...this.owned];
+        this.owned.clear();
+        if (this.killOnShutdown) {
+            const results = await Promise.allSettled(
+                instances.map(instance => Promise.resolve().then(() => instance.kill())),
+            );
+            for (const [index, result] of results.entries()) {
+                if (result.status === 'rejected') {
+                    const instance = instances[index];
+                    if (instance) this.owned.add(instance);
+                    this.shutdownCleanupFailures.push(result.reason);
+                }
+            }
+        }
+        if (this.cleanupFailurePolicy === 'throw' && this.shutdownCleanupFailures.length > 0) {
+            throw new SandboxCleanupError(this.shutdownCleanupFailures);
+        }
+    }
+
+    private async drainInFlight(): Promise<void> {
+        while (this.inFlight.size > 0) {
+            await Promise.allSettled([...this.inFlight]);
+        }
     }
 
     private async runWithCleanup<TResult, TInstance extends OwnedSandboxInstance>(
@@ -234,11 +316,16 @@ export class SandboxService implements OnModuleDestroy {
     }
 
     private async trackCreated<TInstance extends OwnedSandboxInstance>(sandbox: TInstance): Promise<TInstance> {
+        validateOwnedInstance(sandbox, 'A3S Box create');
         if (!this.shuttingDown) {
             this.owned.add(sandbox);
             return sandbox;
         }
-        await Promise.allSettled([Promise.resolve().then(() => sandbox.kill())]);
+        const [cleanup] = await Promise.allSettled([Promise.resolve().then(() => sandbox.kill())]);
+        if (cleanup.status === 'rejected') {
+            this.owned.add(sandbox);
+            throw new SandboxServiceClosedError({ cause: cleanup.reason, unreleasedInstance: sandbox });
+        }
         throw new SandboxServiceClosedError();
     }
 
@@ -252,14 +339,22 @@ export class SandboxService implements OnModuleDestroy {
     }
 
     private withConnection<TOptions extends object>(options?: TOptions): TOptions {
-        const merged: Record<string, unknown> = options ? { ...(options as unknown as Record<string, unknown>) } : {};
+        let merged: Record<string, unknown>;
+        try {
+            merged = options ? { ...(options as unknown as Record<string, unknown>) } : {};
+        } catch (error) {
+            throw new SandboxConfigurationError('Sandbox operation options could not be read', { cause: error });
+        }
         for (const key of CONNECTION_OPTION_KEYS) {
             delete merged[key];
         }
         if (merged.timeoutMs === undefined && this.defaultTimeoutMs !== undefined) {
             merged.timeoutMs = this.defaultTimeoutMs;
         }
-        return { ...merged, ...this.connection } as unknown as TOptions;
+        if (merged.timeoutMs !== undefined) {
+            merged.timeoutMs = validateTimeout('timeoutMs', merged.timeoutMs);
+        }
+        return Object.freeze({ ...merged, ...this.connection }) as unknown as TOptions;
     }
 
     private assertActive(): void {
@@ -270,12 +365,11 @@ export class SandboxService implements OnModuleDestroy {
 
     private loadSandboxSdk(): Promise<SandboxSdkModule> {
         if (!this.sandboxSdkPromise) {
-            this.sandboxSdkPromise = this.sdkLoader
-                .loadSandboxSdk()
+            this.sandboxSdkPromise = invokeSdkLoader(() => this.sdkLoader.loadSandboxSdk())
                 .then(validateSandboxSdk)
                 .catch(error => {
                     this.sandboxSdkPromise = undefined;
-                    throw error;
+                    throw normalizeSdkLoadError('@a3s-lab/box', error);
                 });
         }
         return this.sandboxSdkPromise;
@@ -283,12 +377,11 @@ export class SandboxService implements OnModuleDestroy {
 
     private loadCodeInterpreterSdk(): Promise<CodeInterpreterSdkModule> {
         if (!this.codeInterpreterSdkPromise) {
-            this.codeInterpreterSdkPromise = this.sdkLoader
-                .loadCodeInterpreterSdk()
+            this.codeInterpreterSdkPromise = invokeSdkLoader(() => this.sdkLoader.loadCodeInterpreterSdk())
                 .then(validateCodeInterpreterSdk)
                 .catch(error => {
                     this.codeInterpreterSdkPromise = undefined;
-                    throw error;
+                    throw normalizeSdkLoadError('@a3s-lab/box/code-interpreter', error);
                 });
         }
         return this.codeInterpreterSdkPromise;
@@ -306,17 +399,87 @@ function validateDefaultTimeout(timeoutMs: number | undefined): number | undefin
     if (timeoutMs === undefined) {
         return undefined;
     }
-    if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0) {
-        throw new SandboxConfigurationError('defaultTimeoutMs must be a positive safe integer');
-    }
-    return timeoutMs;
+    return validateTimeout('defaultTimeoutMs', timeoutMs);
 }
 
 function requiredValue(name: string, value: string | undefined): string {
     if (typeof value !== 'string' || !value.trim()) {
         throw new SandboxConfigurationError(`${name} cannot be empty`);
     }
-    return value;
+    const normalized = value.trim();
+    if (normalized.length > MAX_IDENTIFIER_LENGTH) {
+        throw new SandboxConfigurationError(`${name} cannot exceed ${MAX_IDENTIFIER_LENGTH} characters`);
+    }
+    if (IDENTIFIER_CONTROL_CHARACTERS.test(normalized)) {
+        throw new SandboxConfigurationError(`${name} cannot contain control characters`);
+    }
+    return normalized;
+}
+
+function validateTimeout(name: string, timeoutMs: unknown): number {
+    if (!Number.isSafeInteger(timeoutMs) || (timeoutMs as number) <= 0) {
+        throw new SandboxConfigurationError(`${name} must be a positive safe integer`);
+    }
+    return timeoutMs as number;
+}
+
+function validateCleanupFailurePolicy(policy: SandboxModuleOptions['cleanupFailurePolicy']): 'throw' | 'ignore' {
+    if (policy === undefined) return 'throw';
+    if (policy !== 'throw' && policy !== 'ignore') {
+        throw new SandboxConfigurationError('cleanupFailurePolicy must be either throw or ignore');
+    }
+    return policy;
+}
+
+function normalizeSdkLoader(loader: SandboxSdkLoader): SandboxSdkLoader {
+    if (
+        !loader ||
+        typeof loader !== 'object' ||
+        typeof loader.loadSandboxSdk !== 'function' ||
+        typeof loader.loadCodeInterpreterSdk !== 'function'
+    ) {
+        throw new SandboxConfigurationError('sdkLoader must provide loadSandboxSdk and loadCodeInterpreterSdk');
+    }
+    return Object.freeze({
+        loadSandboxSdk: loader.loadSandboxSdk.bind(loader),
+        loadCodeInterpreterSdk: loader.loadCodeInterpreterSdk.bind(loader),
+    });
+}
+
+function invokeSdkLoader<TModule>(loader: () => Promise<TModule>): Promise<TModule> {
+    try {
+        return Promise.resolve(loader());
+    } catch (error) {
+        return Promise.reject(error);
+    }
+}
+
+async function withTimeout(operation: Promise<void>, timeoutMs: number): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new SandboxShutdownTimeoutError(timeoutMs)), timeoutMs);
+    });
+    try {
+        await Promise.race([operation, timeout]);
+    } finally {
+        if (timer !== undefined) clearTimeout(timer);
+    }
+}
+
+function normalizeSdkLoadError(entrypoint: string, error: unknown): SandboxSdkError {
+    return error instanceof SandboxSdkError
+        ? error
+        : new SandboxSdkError(`Failed to load the ${entrypoint} SDK entrypoint`, { cause: error });
+}
+
+function validateOwnedInstance<TInstance extends OwnedSandboxInstance>(
+    instance: TInstance,
+    operation: string,
+): TInstance {
+    if (!instance || typeof instance !== 'object' || typeof instance.kill !== 'function') {
+        throw new SandboxSdkError(`${operation} did not return a native sandbox instance with kill()`);
+    }
+    return instance;
 }
 
 function validateSandboxSdk(sdk: SandboxSdkModule): SandboxSdkModule {

--- a/packages/sandbox/src/sandbox.types.ts
+++ b/packages/sandbox/src/sandbox.types.ts
@@ -52,6 +52,10 @@ export interface SandboxModuleOptions {
     defaultTimeoutMs?: number;
     /** Kill service-owned instances during Nest shutdown. Defaults to `true`. */
     killOnShutdown?: boolean;
+    /** Surface settled shutdown cleanup failures. Defaults to `throw`; use `ignore` only for best-effort shutdown. */
+    cleanupFailurePolicy?: 'throw' | 'ignore';
+    /** Maximum time to drain managed operations before final cleanup. Defaults to 30 seconds. */
+    shutdownTimeoutMs?: number;
     /** Optional lazy loader override, primarily for isolated tests. */
     sdkLoader?: SandboxSdkLoader;
 }

--- a/scripts/smoke-core-install.mjs
+++ b/scripts/smoke-core-install.mjs
@@ -158,6 +158,8 @@ import { CLICKHOUSE_OPTIONS_TOKEN, ClickHouseModule } from '@a3s-lab/clickhouse'
 import { MigrationModule, NON_TRANSACTIONAL_MIGRATION_NAME } from '@a3s-lab/migrations';
 import { FileUploadModule, getExtension } from '@a3s-lab/files';
 import {
+    DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS,
+    SandboxCleanupError,
     SandboxModule,
     SandboxService,
     createA3SBoxConnectionConfig,
@@ -200,6 +202,7 @@ const moduleRefs = [
     SandboxModule,
 ];
 const serviceRefs = [AiService, SandboxService];
+const sandboxRuntimeRefs = [DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS, SandboxCleanupError];
 
 void event;
 void envelope;
@@ -214,6 +217,7 @@ void redis;
 void provider;
 void moduleRefs;
 void serviceRefs;
+void sandboxRuntimeRefs;
 void Public;
 void StatusCode;
 void DEFAULT_HISTOGRAM_BUCKETS;
@@ -256,7 +260,14 @@ const expectedExports = {
     '@a3s-lab/clickhouse': ['CLICKHOUSE_OPTIONS_TOKEN', 'ClickHouseModule', 'ClickHouseService'],
     '@a3s-lab/migrations': ['MigrationModule', 'createFileMigrationProvider'],
     '@a3s-lab/files': ['FileUploadModule', 'FileUploadService', 'getExtension'],
-    '@a3s-lab/sandbox': ['SandboxModule', 'SandboxService', 'createA3SBoxConnectionConfig'],
+    '@a3s-lab/sandbox': [
+        'DEFAULT_SANDBOX_SHUTDOWN_TIMEOUT_MS',
+        'SandboxCleanupError',
+        'SandboxModule',
+        'SandboxService',
+        'SandboxShutdownTimeoutError',
+        'createA3SBoxConnectionConfig',
+    ],
 };
 
 for (const [packageName, exportNames] of Object.entries(expectedExports)) {


### PR DESCRIPTION
## Summary

- harden A3S Box endpoint, domain, API-key, SDK-loader, result, identifier, and per-operation timeout validation
- make sandbox shutdown idempotent, scope-aware, bounded, and observable while preserving failed-cleanup ownership for retry
- track complete managed callbacks and connects, safely handle late creates, and expose aggregate/timeout recovery errors
- expand the package and root README guidance, public export smoke coverage, and the Sandbox changeset

## Verification

- `pnpm --filter @a3s-lab/sandbox exec jest --runInBand --coverage` (58 tests)
- `pnpm release:publish:dry-run`
- `pnpm audit:prod`
- `pnpm install --offline --frozen-lockfile`
- `pnpm changeset status --since=origin/main`