### PR TITLE
feat(ai): harden agent session lifecycle

### DIFF
--- a/.changeset/harden-ai-lifecycle.md
+++ b/.changeset/harden-ai-lifecycle.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/ai": minor
+---
+
+Harden A3S Code configuration and lifecycle boundaries, add named-agent and worker sessions, disposable session callbacks, session control-plane helpers, AbortSignal cancellation, and race-safe shutdown draining.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Nestify currently contains 18 publishable framework packages:
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run NestJS module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
-| `@a3s-lab/ai` | NestJS integration for the A3S coding-agent runtime through `@a3s-lab/code`, with injectable configuration and lifecycle-safe agent access. |
+| `@a3s-lab/ai` | Strict NestJS lifecycle integration for `@a3s-lab/code`, including lazy validated loading, standard/named/worker sessions, disposable runs and streams, cancellation, and race-safe shutdown. |
 | `@a3s-lab/sandbox` | NestJS integration for A3S Box sandbox and code-interpreter workflows through the lazily loaded first-party `@a3s-lab/box` TypeScript SDK. |
 
 The shared package list is dependency-ordered in `scripts/core-packages.mjs`. Build, test, pack, smoke install, and publish rehearsal commands all use that same list.
@@ -176,6 +176,9 @@ an `NPM_TOKEN` secret with access to the `@a3s-lab` scope.
 - HTTP metrics use route templates rather than raw URLs. Histogram memory is constant per series, and counters, gauges,
   and histograms cap label cardinality with an explicit overflow series.
 - Startup database migrations remain disabled in every environment unless the application explicitly opts in.
+- AI module options and native SDK contracts fail fast at the Nest boundary. Disposable AI sessions preserve operation
+  and cleanup failures together, support request-scoped aborts, and session construction is drained before Agent
+  shutdown.
 
 ## Design Boundaries
 

--- a/docs/framework-core.md
+++ b/docs/framework-core.md
@@ -22,7 +22,7 @@ Nestify separates reusable backend API capabilities from the sample application.
 | `@a3s-lab/clickhouse` | NestJS module and service wrapper around the official ClickHouse JavaScript client. |
 | `@a3s-lab/migrations` | Kysely migration helpers, auto-run module integration, and concurrent-safe non-transactional migration support. |
 | `@a3s-lab/files` | File upload validation, storage client contracts, upload decorators, and NestJS upload interceptors. |
-| `@a3s-lab/ai` | NestJS module and service integration for the A3S coding-agent runtime provided by `@a3s-lab/code`. |
+| `@a3s-lab/ai` | Strict NestJS lifecycle integration for `@a3s-lab/code`, with validated lazy loading, standard/named/worker sessions, disposable operations, cancellation, and shutdown draining. |
 | `@a3s-lab/sandbox` | NestJS module, service, and connection helpers that lazily load the first-party `@a3s-lab/box` TypeScript SDK. |
 
 Each package has a package-level README with install notes, import examples, exported capabilities, and boundary notes:
@@ -50,7 +50,15 @@ Each package has a package-level README with install notes, import examples, exp
 
 The NestJS integration packages accept NestJS 10 and 11 peers. Workspace builds, tests, packed declarations, and the sample API run against NestJS 11; HTTP-facing package tests use Express 5 while their peer ranges continue to accept Express 4 and 5. Repository development requires Node.js 20.18.1 within the Node 20 line, or Node.js 22 and newer; Node 21 is excluded by the pinned A3S Box SDK dependency graph. The packed consumer smoke test pins TypeScript 5.3.3, the minimum compiler line supported by `@a3s-lab/sandbox` declarations.
 
-`@a3s-lab/ai` delegates coding-agent execution to `@a3s-lab/code` and keeps native runtime loading behind its configured service boundary. `@a3s-lab/sandbox` lazily loads both runtime values and types from the first-party `@a3s-lab/box@3.0.11` TypeScript SDK, so importing the Nestify package does not eagerly evaluate its ESM dependency. Until `@a3s-lab/box` is published to npm, the package consumes the verified GitHub Release tarball; that dependency should switch to a semver range after npm publication without changing the Nestify API.
+`@a3s-lab/ai` delegates coding-agent execution to `@a3s-lab/code` and keeps native runtime loading behind a validated,
+lazy service boundary. It exposes the SDK's asynchronous standard, named-agent, worker, resume, replace, list, close,
+run-scoped cancellation, and Agent shutdown paths without adding a transport or hidden operation queue. Disposable
+callbacks, runs, and streams close their sessions, preserve simultaneous operation/cleanup failures, and accept
+request-scoped aborts; shutdown drains session creation before closing the Agent. `@a3s-lab/sandbox` lazily loads both
+runtime values and types from the first-party `@a3s-lab/box@3.0.11` TypeScript SDK, so importing the Nestify package does
+not eagerly evaluate its ESM dependency. Until `@a3s-lab/box` is published to npm, the package consumes the verified
+GitHub Release tarball; that dependency should switch to a semver range after npm publication without changing the
+Nestify API.
 
 ## Runtime Safety Defaults
 
@@ -140,7 +148,9 @@ The framework core is covered by package tests for:
 - ClickHouse client routing and lifecycle
 - Migration provider wrapping and module registration
 - File upload validation, storage key handling, module registration, and upload interceptors
-- AI module registration, injected runtime access, session delegation, and lifecycle cleanup
+- AI option and SDK-contract validation, lazy/single-flight initialization, standard/named/worker session delegation,
+  disposable callback/run/stream cleanup, AbortSignal cancellation, run-scoped cancellation, session control-plane
+  helpers, and shutdown/session-creation race handling
 - Sandbox connection configuration, module registration, lazy SDK access, operation delegation, and lifecycle cleanup
 
 Run:

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -1,8 +1,8 @@
 # @a3s-lab/ai
 
-A thin NestJS lifecycle wrapper around the native [`@a3s-lab/code`](https://www.npmjs.com/package/@a3s-lab/code)
-SDK. It embeds the runtime in the Nest process; it does not proxy the A3S CLI or invent an HTTP, WebSocket, or JSON-RPC
-protocol.
+A strict NestJS lifecycle boundary around the native [`@a3s-lab/code`](https://www.npmjs.com/package/@a3s-lab/code)
+SDK. It embeds the first-party runtime in the Nest process, validates the SDK contract, and owns Agent/session cleanup; it
+does not proxy the A3S CLI or invent an HTTP, WebSocket, or JSON-RPC protocol.
 
 ## Install
 
@@ -53,7 +53,16 @@ AiModule.registerAsync({
 ```
 
 `runtimeLoader` can be supplied in module options for tests or controlled runtime loading. Production applications
-normally leave it unset.
+normally leave it unset. Both registration forms validate and detach their resolved options. Invalid `configSource`,
+`eager`, `isGlobal`, or loader values therefore fail during module construction or async provider resolution instead of
+waiting for the first request. Resolved options are frozen so later caller mutation cannot change runtime behavior.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `configSource` | Required | ACL path or inline ACL source passed unchanged to `Agent.create`. |
+| `eager` | `false` | Initialize the native Agent in `onModuleInit`; otherwise initialize on first use. |
+| `isGlobal` | `false` | Make the dynamic Nest module global. For `registerAsync`, set this on the registration object. |
+| `runtimeLoader` | Dynamic `import('@a3s-lab/code')` | Override lazy SDK loading for tests or controlled deployments. |
 
 ### Use sessions and one-shot runs
 
@@ -71,25 +80,58 @@ await session.closeAsync();
 ```
 
 `resumeSessionAsync` and `replaceSessionAsync` delegate to the corresponding native APIs. Resume requires a configured
-session store. For one request, `run` creates a disposable session and closes it in `finally` on success or failure:
+session store. Named definitions and in-memory worker definitions are available without dropping down to the Agent:
 
 ```ts
+const explorer = await ai.sessionForAgentAsync('/srv/workspaces/project', 'explore', ['/srv/agents']);
+const reviewer = await ai.sessionForWorkerAsync('/srv/workspaces/project', {
+    name: 'reviewer',
+    description: 'Review the current change without modifying files',
+    kind: 'reviewer',
+});
+
+const ids = await ai.listSessions();
+await ai.closeSession(ids[0]);
+```
+
+`withSession` is the safe escape hatch for multi-step work: it supplies the full native `Session` and closes it after the
+callback. If both work and cleanup fail, `AiResourceCleanupError` preserves both failures instead of silently discarding
+one.
+
+```ts
+const runs = await ai.withSession('/srv/workspaces/project', async session => {
+    await session.send('Inspect the failing tests');
+    return session.runs();
+});
+```
+
+For one request, `run` creates the same kind of disposable session and always closes it:
+
+```ts
+const requestAbortController = new AbortController();
 const result = await ai.run({
     workspace: '/srv/workspaces/project',
     request: { prompt: 'Run the relevant tests' },
     sessionOptions: { maxExecutionTimeMs: 300_000 },
+    signal: requestAbortController.signal,
 });
 ```
 
 The equivalent positional form is `ai.run(workspace, request, sessionOptions?)`. The wrapper does not queue overlapping
 operations. A native `SESSION_BUSY` error remains a `SESSION_BUSY` error; branch on its stable `code`, not its message.
+`AbortSignal` is supported by the object form for disposable `run` and `stream` calls. Aborting invokes the native async
+session cancellation path, rejects with `AiOperationAbortedError` (`code: 'AI_OPERATION_ABORTED'`), and still waits for
+session cleanup. Long-lived sessions should use `cancelRun` as described below.
 
 ## Exports
 
 - `AiModule`: synchronous and asynchronous NestJS module registration.
-- `AiService`: agent lifecycle, session, one-shot run, streaming, cancellation, and shutdown operations.
+- `AiService`: agent lifecycle, standard/named/worker sessions, control-plane helpers, disposable callbacks, one-shot
+  runs, streaming, cancellation, and shutdown operations.
 - `AI_MODULE_OPTIONS`: injection token for resolved module options.
-- Public option, runtime, agent, session, request, result, event, and error TypeScript types.
+- `AiConfigurationError`, `AiSdkContractError`, `AiServiceClosedError`, `AiOperationAbortedError`, and
+  `AiResourceCleanupError`: stable wrapper-boundary errors. Native SDK failures retain their native classes and codes.
+- Public option, runtime, agent, worker, session, callback, request, result, event, and error TypeScript types.
 
 ## Notes
 
@@ -120,5 +162,16 @@ and never falls back to cancelling a newer run. Without an ID, the service reads
 run-scoped cancellation; it returns `false` when no current run snapshot exists rather than racing a later run with
 broad session cancellation.
 
-Nest shutdown calls `Agent.close()` once, which closes all live sessions and agent-owned background resources. Calling
-`shutdown()` manually is also idempotent. After shutdown, initialization and new sessions are rejected.
+Nest shutdown stops admitting new operations, waits for any session construction already in flight, closes a session
+that finishes construction during that drain, and then calls `Agent.close()` once. The Agent closes all remaining live
+sessions and agent-owned background resources. Calling `shutdown()` manually is also idempotent. `isReady` and
+`isShuttingDown` expose lifecycle state; after shutdown begins, initialization and new sessions are rejected with
+`AiServiceClosedError`.
+
+### Validation and error boundaries
+
+The wrapper validates non-empty workspace/session/run identifiers, request prompts, session option shapes, custom SDK
+loader results, Agent methods, Session methods, stream iterables, and control-plane return values. This catches wiring or
+version errors at the Nest boundary while leaving evolving native option fields, event payloads, and native stable error
+codes untouched. A custom `runtimeLoader` must provide the supported `@a3s-lab/code` Agent contract, including the async
+session lifecycle and session control-plane methods.

--- a/packages/ai/src/__tests__/ai.module.spec.ts
+++ b/packages/ai/src/__tests__/ai.module.spec.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { Module } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { AiConfigurationError } from '../ai.errors';
 import { AiModule } from '../ai.module';
 import { AiService } from '../ai.service';
 import { AI_MODULE_OPTIONS, type AiModuleOptions } from '../ai.types';
@@ -18,14 +19,19 @@ describe('AiModule', () => {
             runtimeLoader: jest.fn(),
         };
         const definition = AiModule.register(options);
+        const provider = definition.providers?.find(
+            candidate => typeof candidate === 'object' && candidate !== null && 'provide' in candidate,
+        ) as { useValue: Readonly<AiModuleOptions> };
 
         expect(definition.global).toBe(false);
         expect(definition.providers).toEqual(
             expect.arrayContaining([
-                expect.objectContaining({ provide: AI_MODULE_OPTIONS, useValue: options }),
+                expect.objectContaining({ provide: AI_MODULE_OPTIONS, useValue: expect.objectContaining(options) }),
                 AiService,
             ]),
         );
+        expect(provider.useValue).not.toBe(options);
+        expect(Object.isFrozen(provider.useValue)).toBe(true);
         expect(definition.exports).toContain(AiService);
     });
 
@@ -47,6 +53,7 @@ describe('AiModule', () => {
         }).compile();
 
         expect(moduleRef.get(AI_MODULE_OPTIONS)).toEqual({ configSource });
+        expect(Object.isFrozen(moduleRef.get(AI_MODULE_OPTIONS))).toBe(true);
         expect(moduleRef.get(AiService)).toBeInstanceOf(AiService);
         await moduleRef.close();
     });
@@ -56,5 +63,26 @@ describe('AiModule', () => {
 
         expect(AiModule.registerAsync({ useFactory: factory }).global).toBe(false);
         expect(AiModule.registerAsync({ useFactory: factory, isGlobal: true }).global).toBe(true);
+    });
+
+    it('rejects invalid sync and async registration before native runtime loading', async () => {
+        expect(() => AiModule.register({ configSource: '' })).toThrow(AiConfigurationError);
+        expect(() => AiModule.register({ configSource: 'agent.acl', isGlobal: 'yes' as never })).toThrow(
+            'must be a boolean',
+        );
+        expect(() => AiModule.register({ configSource: 'agent.acl', runtimeLoader: 'loader' as never })).toThrow(
+            'runtimeLoader',
+        );
+        expect(() => AiModule.registerAsync(null as never)).toThrow('async options are required');
+        expect(() => AiModule.registerAsync({ useFactory: undefined as never })).toThrow('requires a useFactory');
+        expect(() =>
+            AiModule.registerAsync({ useFactory: () => ({ configSource: 'agent.acl' }), isGlobal: 'yes' as never }),
+        ).toThrow('isGlobal must be a boolean');
+
+        await expect(
+            Test.createTestingModule({
+                imports: [AiModule.registerAsync({ useFactory: async () => ({ configSource: ' ' }) })],
+            }).compile(),
+        ).rejects.toBeInstanceOf(AiConfigurationError);
     });
 });

--- a/packages/ai/src/__tests__/ai.service.spec.ts
+++ b/packages/ai/src/__tests__/ai.service.spec.ts
@@ -1,5 +1,32 @@
+import {
+    AiConfigurationError,
+    AiOperationAbortedError,
+    AiResourceCleanupError,
+    AiSdkContractError,
+    AiServiceClosedError,
+} from '../ai.errors';
 import { AiService } from '../ai.service';
-import type { AiAgent, AiAgentEvent, AiRuntime, AiSession, AiSessionRequest } from '../ai.types';
+import type { AiAgent, AiAgentEvent, AiRuntime, AiSession, AiSessionRequest, AiWorkerAgentSpec } from '../ai.types';
+
+function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (predicate()) {
+            return;
+        }
+        await Promise.resolve();
+    }
+    throw new Error('condition was not reached');
+}
 
 function asyncEvents(events: AiAgentEvent[]): AsyncIterable<AiAgentEvent> {
     return {
@@ -39,6 +66,10 @@ function createFixture(options: { createAgent?: () => Promise<AiAgent> } = {}) {
         sessionAsync: jest.fn(async () => session),
         resumeSessionAsync: jest.fn(async () => session),
         replaceSessionAsync: jest.fn(async () => replacement),
+        sessionForAgentAsync: jest.fn(async () => session),
+        sessionForWorkerAsync: jest.fn(async () => session),
+        listSessions: jest.fn(async () => ['session-1']),
+        closeSession: jest.fn(async () => true),
         close: jest.fn(async () => undefined),
     } as unknown as AiAgent;
     const create = jest.fn(options.createAgent ?? (async () => agent));
@@ -49,9 +80,11 @@ function createFixture(options: { createAgent?: () => Promise<AiAgent> } = {}) {
 }
 
 describe('AiService initialization', () => {
-    it('is lazy and coalesces concurrent initialization calls', async () => {
+    it('is lazy, observable, and coalesces concurrent initialization calls', async () => {
         const fixture = createFixture();
 
+        expect(fixture.service.isReady).toBe(false);
+        expect(fixture.service.isShuttingDown).toBe(false);
         await fixture.service.onModuleInit();
         expect(fixture.runtimeLoader).not.toHaveBeenCalled();
 
@@ -64,6 +97,7 @@ describe('AiService initialization', () => {
         expect(first).toBe(fixture.agent);
         expect(second).toBe(fixture.agent);
         expect(readyResult).toBeUndefined();
+        expect(fixture.service.isReady).toBe(true);
         expect(fixture.runtimeLoader).toHaveBeenCalledTimes(1);
         expect(fixture.create).toHaveBeenCalledTimes(1);
         expect(fixture.create).toHaveBeenCalledWith('agent.acl');
@@ -95,22 +129,48 @@ describe('AiService initialization', () => {
         expect(fixture.create).toHaveBeenCalledTimes(2);
     });
 
-    it('validates configuration and custom runtime loader results', async () => {
-        const emptyConfig = new AiService({ configSource: '   ', runtimeLoader: jest.fn() });
+    it('validates configuration before loading the native runtime', () => {
+        const runtimeLoader = jest.fn();
+
+        expect(() => new AiService({ configSource: '   ', runtimeLoader })).toThrow(AiConfigurationError);
+        expect(() => new AiService({ configSource: 'agent\0.acl', runtimeLoader })).toThrow('null byte');
+        expect(() => new AiService({ configSource: 'agent.acl', eager: 'yes' as never })).toThrow('must be a boolean');
+        expect(runtimeLoader).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed runtime and Agent contracts and closes a malformed Agent', async () => {
         const invalidRuntime = new AiService({
             configSource: 'agent.acl',
             runtimeLoader: async () => ({}) as AiRuntime,
         });
-
-        await expect(emptyConfig.ready()).rejects.toThrow('non-empty configSource');
         await expect(invalidRuntime.ready()).rejects.toThrow('did not provide Agent.create');
+
+        const close = jest.fn(async () => undefined);
+        const invalidAgent = new AiService({
+            configSource: 'agent.acl',
+            runtimeLoader: async () => ({ Agent: { create: async () => ({ close }) as unknown as AiAgent } }),
+        });
+        await expect(invalidAgent.ready()).rejects.toBeInstanceOf(AiSdkContractError);
+        expect(close).toHaveBeenCalledTimes(1);
+
+        const cleanupError = new Error('malformed agent close failed');
+        const failingClose = jest.fn(async () => Promise.reject(cleanupError));
+        const uncleanAgent = new AiService({
+            configSource: 'agent.acl',
+            runtimeLoader: async () => ({
+                Agent: { create: async () => ({ close: failingClose }) as unknown as AiAgent },
+            }),
+        });
+        await expect(uncleanAgent.ready()).rejects.toMatchObject({ cleanupError });
     });
 });
 
 describe('AiService sessions', () => {
-    it('delegates async create, resume, and replacement without adding a queue', async () => {
+    it('delegates native async session and control-plane APIs without adding a queue', async () => {
         const fixture = createFixture();
         const sessionOptions = { model: 'test/model' };
+        const worker: AiWorkerAgentSpec = { name: 'reviewer', description: 'Review changes' };
+        const agentDirs = ['/agents'];
 
         await expect(fixture.service.sessionAsync('/workspace', sessionOptions)).resolves.toBe(fixture.session);
         await expect(fixture.service.resumeSessionAsync('session-1', sessionOptions)).resolves.toBe(fixture.session);
@@ -118,11 +178,108 @@ describe('AiService sessions', () => {
             fixture.replacement,
         );
         await expect(fixture.service.replace(fixture.session, sessionOptions)).resolves.toBe(fixture.replacement);
+        await expect(
+            fixture.service.sessionForAgentAsync('/workspace', 'explore', agentDirs, sessionOptions),
+        ).resolves.toBe(fixture.session);
+        await expect(fixture.service.sessionForWorkerAsync('/workspace', worker, sessionOptions)).resolves.toBe(
+            fixture.session,
+        );
+        await expect(fixture.service.listSessions()).resolves.toEqual(['session-1']);
+        await expect(fixture.service.closeSession('session-1')).resolves.toBe(true);
 
         expect(fixture.agent.sessionAsync).toHaveBeenCalledWith('/workspace', sessionOptions);
         expect(fixture.agent.resumeSessionAsync).toHaveBeenCalledWith('session-1', sessionOptions);
         expect(fixture.agent.replaceSessionAsync).toHaveBeenNthCalledWith(1, fixture.session, sessionOptions);
         expect(fixture.agent.replaceSessionAsync).toHaveBeenNthCalledWith(2, fixture.session, sessionOptions);
+        expect(fixture.agent.sessionForAgentAsync).toHaveBeenCalledWith(
+            '/workspace',
+            'explore',
+            ['/agents'],
+            sessionOptions,
+        );
+        expect(fixture.agent.sessionForWorkerAsync).toHaveBeenCalledWith('/workspace', worker, sessionOptions);
+    });
+
+    it('fails fast on invalid session inputs without initializing the runtime', async () => {
+        const fixture = createFixture();
+
+        await expect(fixture.service.sessionAsync(' ')).rejects.toBeInstanceOf(AiConfigurationError);
+        await expect(fixture.service.resumeSessionAsync('', {})).rejects.toThrow('sessionId');
+        await expect(fixture.service.replaceSessionAsync({} as AiSession, {})).rejects.toBeInstanceOf(
+            AiSdkContractError,
+        );
+        await expect(fixture.service.sessionForAgentAsync('/workspace', '', [])).rejects.toThrow('agentName');
+        await expect(fixture.service.sessionForAgentAsync('/workspace', 'explore', 'agents' as never)).rejects.toThrow(
+            'agentDirs',
+        );
+        await expect(fixture.service.sessionForAgentAsync('/workspace', 'explore', [' '])).rejects.toThrow(
+            'agentDirs entry',
+        );
+        await expect(fixture.service.sessionForWorkerAsync('/workspace', null as never)).rejects.toThrow('worker');
+        await expect(fixture.service.closeSession('\0')).rejects.toThrow('null byte');
+        await expect(fixture.service.cancelRun(fixture.session, ' ')).rejects.toThrow('runId');
+        await expect(fixture.service.withSession('/workspace', null as never)).rejects.toThrow('requires a callback');
+        await expect(fixture.service.run(null as never)).rejects.toThrow('options must be an object');
+        await expect(fixture.service.run('/workspace', null as never)).rejects.toThrow('request must be');
+        await expect(fixture.service.run('/workspace', 'work', null as never)).rejects.toThrow('sessionOptions');
+        await expect(
+            fixture.service.run({ workspace: '/workspace', request: 'work', signal: {} as AbortSignal }),
+        ).rejects.toThrow('AbortSignal');
+        expect(fixture.runtimeLoader).not.toHaveBeenCalled();
+    });
+
+    it('validates control-plane results returned by custom runtimes', async () => {
+        const fixture = createFixture();
+        (fixture.agent.listSessions as jest.Mock).mockResolvedValue([42]);
+        (fixture.agent.closeSession as jest.Mock).mockResolvedValue('yes');
+
+        await expect(fixture.service.listSessions()).rejects.toThrow('invalid session ID list');
+        await expect(fixture.service.closeSession('session-1')).rejects.toThrow('non-boolean');
+    });
+
+    it('closes a malformed session result before rejecting its SDK contract', async () => {
+        const fixture = createFixture();
+        const closeAsync = jest.fn(async () => undefined);
+        (fixture.agent.sessionAsync as jest.Mock).mockResolvedValue({ closeAsync });
+
+        await expect(fixture.service.sessionAsync('/workspace')).rejects.toBeInstanceOf(AiSdkContractError);
+        expect(closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('runs arbitrary callbacks in a disposable session and always closes it', async () => {
+        const fixture = createFixture();
+        const result = await fixture.service.withSession('/workspace', async session => {
+            expect(session).toBe(fixture.session);
+            return 'complete';
+        });
+
+        expect(result).toBe('complete');
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves callback and cleanup failures together', async () => {
+        const fixture = createFixture();
+        const operationError = new Error('callback failed');
+        const cleanupError = new Error('close failed');
+        (fixture.session.closeAsync as jest.Mock).mockRejectedValue(cleanupError);
+
+        let received: unknown;
+        try {
+            await fixture.service.withSession('/workspace', () => Promise.reject(operationError));
+        } catch (error) {
+            received = error;
+        }
+
+        expect(received).toBeInstanceOf(AiResourceCleanupError);
+        expect(received).toMatchObject({ operationError, cleanupError });
+    });
+
+    it('propagates cleanup failure after a successful callback', async () => {
+        const fixture = createFixture();
+        const cleanupError = new Error('close failed');
+        (fixture.session.closeAsync as jest.Mock).mockRejectedValue(cleanupError);
+
+        await expect(fixture.service.withSession('/workspace', () => 'complete')).rejects.toBe(cleanupError);
     });
 
     it('runs a disposable session and always closes it', async () => {
@@ -137,24 +294,63 @@ describe('AiService sessions', () => {
         expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
     });
 
-    it('closes a disposable session when a run fails', async () => {
+    it('preserves run and close failures instead of suppressing cleanup failure', async () => {
         const runError = Object.assign(new Error('run failed'), { code: 'SESSION_BUSY' });
+        const closeError = new Error('close failed');
         const session = createSession({
             send: jest.fn(async () => Promise.reject(runError)),
-            closeAsync: jest.fn(async () => Promise.reject(new Error('close failed'))),
+            closeAsync: jest.fn(async () => Promise.reject(closeError)),
         });
         const fixture = createFixture();
         (fixture.agent.sessionAsync as jest.Mock).mockResolvedValue(session);
 
-        await expect(fixture.service.run('/workspace', 'fail')).rejects.toBe(runError);
+        await expect(fixture.service.run('/workspace', 'fail')).rejects.toMatchObject({
+            operationError: runError,
+            cleanupError: closeError,
+        });
         expect(session.closeAsync).toHaveBeenCalledTimes(1);
     });
 
-    it('requires a request for the positional one-shot form', async () => {
+    it('validates one-shot requests before creating a session', async () => {
         const fixture = createFixture();
 
         await expect(fixture.service.run('/workspace', undefined as never)).rejects.toThrow('requires a request');
+        await expect(fixture.service.run('/workspace', ' ')).rejects.toThrow('request');
+        await expect(fixture.service.run({ workspace: '/workspace', request: { prompt: '' } })).rejects.toThrow(
+            'request.prompt',
+        );
         expect(fixture.agent.sessionAsync).not.toHaveBeenCalled();
+    });
+
+    it('supports AbortSignal cancellation for a disposable run', async () => {
+        const fixture = createFixture();
+        const send = deferred<never>();
+        (fixture.session.send as jest.Mock).mockReturnValue(send.promise);
+        const controller = new AbortController();
+        const reason = new Error('request disconnected');
+
+        const running = fixture.service.run({ workspace: '/workspace', request: 'work', signal: controller.signal });
+        await waitUntil(() => (fixture.session.send as jest.Mock).mock.calls.length === 1);
+        controller.abort(reason);
+
+        await expect(running).rejects.toMatchObject({
+            name: 'AiOperationAbortedError',
+            code: 'AI_OPERATION_ABORTED',
+            reason,
+        });
+        await waitUntil(() => (fixture.session.cancelAsync as jest.Mock).mock.calls.length === 1);
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a pre-aborted invocation before initializing', async () => {
+        const fixture = createFixture();
+        const controller = new AbortController();
+        controller.abort('cancelled');
+
+        await expect(
+            fixture.service.run({ workspace: '/workspace', request: 'work', signal: controller.signal }),
+        ).rejects.toBeInstanceOf(AiOperationAbortedError);
+        expect(fixture.runtimeLoader).not.toHaveBeenCalled();
     });
 });
 
@@ -187,11 +383,12 @@ describe('AiService streaming', () => {
         expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
     });
 
-    it('closes the disposable session if native stream creation fails', async () => {
+    it('preserves stream creation and session cleanup failures together', async () => {
         const fixture = createFixture();
         const streamError = Object.assign(new Error('stream failed'), { code: 'SESSION_BUSY' });
+        const closeError = new Error('close failed');
         (fixture.session.stream as jest.Mock).mockRejectedValue(streamError);
-        (fixture.session.closeAsync as jest.Mock).mockRejectedValue(new Error('close failed'));
+        (fixture.session.closeAsync as jest.Mock).mockRejectedValue(closeError);
 
         const consume = async () => {
             for await (const _item of fixture.service.stream('/workspace', 'fail')) {
@@ -199,7 +396,83 @@ describe('AiService streaming', () => {
             }
         };
 
-        await expect(consume()).rejects.toBe(streamError);
+        await expect(consume()).rejects.toMatchObject({ operationError: streamError, cleanupError: closeError });
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels an in-flight iterator through AbortSignal and closes the session', async () => {
+        const fixture = createFixture();
+        const pendingEvent = deferred<IteratorResult<AiAgentEvent>>();
+        const iterator = {
+            next: jest.fn(() => pendingEvent.promise),
+            return: jest.fn(async () => ({ done: true, value: undefined })),
+        };
+        (fixture.session.stream as jest.Mock).mockResolvedValue({
+            [Symbol.asyncIterator]: () => iterator,
+        });
+        const controller = new AbortController();
+        const stream = fixture.service.stream({ workspace: '/workspace', request: 'work', signal: controller.signal });
+        const next = stream.next();
+        await waitUntil(() => iterator.next.mock.calls.length === 1);
+
+        controller.abort();
+
+        await expect(next).rejects.toBeInstanceOf(AiOperationAbortedError);
+        expect(iterator.return).toHaveBeenCalledTimes(1);
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a malformed native stream value and still closes the session', async () => {
+        const fixture = createFixture();
+        (fixture.session.stream as jest.Mock).mockResolvedValue({});
+
+        const consume = async () => {
+            for await (const _item of fixture.service.stream('/workspace', 'work')) {
+                // No values are expected.
+            }
+        };
+
+        await expect(consume()).rejects.toBeInstanceOf(AiSdkContractError);
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves iterator operation and iterator cleanup failures together', async () => {
+        const fixture = createFixture();
+        const iterationError = new Error('iterator failed');
+        const cleanupError = new Error('iterator return failed');
+        const iterator = {
+            next: jest.fn(async () => Promise.reject(iterationError)),
+            return: jest.fn(async () => Promise.reject(cleanupError)),
+        };
+        (fixture.session.stream as jest.Mock).mockResolvedValue({
+            [Symbol.asyncIterator]: () => iterator,
+        });
+
+        const consume = async () => {
+            for await (const _item of fixture.service.stream('/workspace', 'work')) {
+                // The iterator rejects before yielding.
+            }
+        };
+
+        await expect(consume()).rejects.toMatchObject({ operationError: iterationError, cleanupError });
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports native async iterators without an optional return method', async () => {
+        const fixture = createFixture();
+        const iterator = {
+            next: jest.fn(async () => ({ done: true, value: undefined })),
+            [Symbol.asyncIterator]() {
+                return this;
+            },
+        };
+        (fixture.session.stream as jest.Mock).mockResolvedValue(iterator);
+
+        for await (const _item of fixture.service.stream('/workspace', 'work')) {
+            // No values are expected.
+        }
+
+        expect(iterator.next).toHaveBeenCalledTimes(1);
         expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
     });
 });
@@ -236,7 +509,9 @@ describe('AiService cancellation and shutdown', () => {
 
         expect(fixture.runtimeLoader).not.toHaveBeenCalled();
         expect(fixture.agent.close).not.toHaveBeenCalled();
-        await expect(fixture.service.getAgent()).rejects.toThrow('has been shut down');
+        expect(fixture.service.isShuttingDown).toBe(true);
+        expect(fixture.service.isReady).toBe(false);
+        await expect(fixture.service.getAgent()).rejects.toBeInstanceOf(AiServiceClosedError);
     });
 
     it('closes the shared Agent exactly once during repeated shutdown', async () => {
@@ -249,35 +524,66 @@ describe('AiService cancellation and shutdown', () => {
     });
 
     it('closes an Agent that finishes initialization during shutdown', async () => {
-        let resolveAgent!: (agent: AiAgent) => void;
-        const pendingAgent = new Promise<AiAgent>(resolve => {
-            resolveAgent = resolve;
-        });
-        const fixture = createFixture({ createAgent: () => pendingAgent });
+        const pendingAgent = deferred<AiAgent>();
+        const fixture = createFixture({ createAgent: () => pendingAgent.promise });
         const initialization = fixture.service.getAgent();
         const shutdown = fixture.service.shutdown();
 
-        resolveAgent(fixture.agent);
+        pendingAgent.resolve(fixture.agent);
 
-        await expect(initialization).rejects.toThrow('has been shut down');
+        await expect(initialization).rejects.toBeInstanceOf(AiServiceClosedError);
+        await shutdown;
+        expect(fixture.agent.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for an in-flight session acquisition and closes its late result', async () => {
+        const fixture = createFixture();
+        const pendingSession = deferred<AiSession>();
+        (fixture.agent.sessionAsync as jest.Mock).mockReturnValue(pendingSession.promise);
+        await fixture.service.ready();
+
+        const acquisition = fixture.service.sessionAsync('/workspace');
+        await waitUntil(() => (fixture.agent.sessionAsync as jest.Mock).mock.calls.length === 1);
+        const shutdown = fixture.service.shutdown();
+        expect(fixture.agent.close).not.toHaveBeenCalled();
+
+        pendingSession.resolve(fixture.session);
+
+        await expect(acquisition).rejects.toBeInstanceOf(AiServiceClosedError);
+        await shutdown;
+        expect(fixture.session.closeAsync).toHaveBeenCalledTimes(1);
+        expect(fixture.agent.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('preserves a late-session cleanup failure while shutdown still closes the Agent', async () => {
+        const fixture = createFixture();
+        const pendingSession = deferred<AiSession>();
+        const cleanupError = new Error('late session close failed');
+        const session = createSession({ closeAsync: jest.fn(async () => Promise.reject(cleanupError)) });
+        (fixture.agent.sessionAsync as jest.Mock).mockReturnValue(pendingSession.promise);
+        await fixture.service.ready();
+
+        const acquisition = fixture.service.sessionAsync('/workspace');
+        await waitUntil(() => (fixture.agent.sessionAsync as jest.Mock).mock.calls.length === 1);
+        const shutdown = fixture.service.shutdown();
+        pendingSession.resolve(session);
+
+        await expect(acquisition).rejects.toMatchObject({ cleanupError });
         await shutdown;
         expect(fixture.agent.close).toHaveBeenCalledTimes(1);
     });
 
     it('propagates a close failure for an Agent that initializes during shutdown', async () => {
-        let resolveAgent!: (agent: AiAgent) => void;
-        const pendingAgent = new Promise<AiAgent>(resolve => {
-            resolveAgent = resolve;
-        });
-        const fixture = createFixture({ createAgent: () => pendingAgent });
+        const pendingAgent = deferred<AiAgent>();
+        const fixture = createFixture({ createAgent: () => pendingAgent.promise });
         const closeError = new Error('agent close failed');
         (fixture.agent.close as jest.Mock).mockRejectedValue(closeError);
         const initialization = fixture.service.getAgent();
         const shutdown = fixture.service.shutdown();
 
-        resolveAgent(fixture.agent);
+        pendingAgent.resolve(fixture.agent);
 
-        await expect(initialization).rejects.toThrow('has been shut down');
+        await expect(initialization).rejects.toBeInstanceOf(AiServiceClosedError);
         await expect(shutdown).rejects.toBe(closeError);
         expect(fixture.agent.close).toHaveBeenCalledTimes(1);
     });

--- a/packages/ai/src/ai.errors.ts
+++ b/packages/ai/src/ai.errors.ts
@@ -35,7 +35,11 @@ export class AiResourceCleanupError extends AggregateError {
     readonly operationError: unknown;
     readonly cleanupError: unknown;
 
-    constructor(operationError: unknown, cleanupError: unknown, message = 'AI operation and session cleanup both failed') {
+    constructor(
+        operationError: unknown,
+        cleanupError: unknown,
+        message = 'AI operation and session cleanup both failed',
+    ) {
         super([operationError, cleanupError], message);
         this.operationError = operationError;
         this.cleanupError = cleanupError;

--- a/packages/ai/src/ai.errors.ts
+++ b/packages/ai/src/ai.errors.ts
@@ -1,0 +1,43 @@
+/** Invalid Nest module or invocation configuration. */
+export class AiConfigurationError extends TypeError {
+    override readonly name = 'AiConfigurationError';
+}
+
+/** The loaded A3S Code SDK does not satisfy the supported public contract. */
+export class AiSdkContractError extends TypeError {
+    override readonly name = 'AiSdkContractError';
+}
+
+/** A new operation was attempted after service shutdown began. */
+export class AiServiceClosedError extends Error {
+    override readonly name = 'AiServiceClosedError';
+
+    constructor() {
+        super('AiService is shutting down and cannot start new operations');
+    }
+}
+
+/** A one-shot run or stream was cancelled through its AbortSignal. */
+export class AiOperationAbortedError extends Error {
+    override readonly name = 'AiOperationAbortedError';
+    readonly code = 'AI_OPERATION_ABORTED' as const;
+    readonly reason: unknown;
+
+    constructor(reason?: unknown) {
+        super('AI operation was aborted', reason === undefined ? undefined : { cause: reason });
+        this.reason = reason;
+    }
+}
+
+/** Preserves both an operation failure and the failure to clean up its session. */
+export class AiResourceCleanupError extends AggregateError {
+    override readonly name = 'AiResourceCleanupError';
+    readonly operationError: unknown;
+    readonly cleanupError: unknown;
+
+    constructor(operationError: unknown, cleanupError: unknown, message = 'AI operation and session cleanup both failed') {
+        super([operationError, cleanupError], message);
+        this.operationError = operationError;
+        this.cleanupError = cleanupError;
+    }
+}

--- a/packages/ai/src/ai.module.ts
+++ b/packages/ai/src/ai.module.ts
@@ -1,20 +1,34 @@
 import { type DynamicModule, Module, type Provider } from '@nestjs/common';
+import { AiConfigurationError } from './ai.errors';
+import { normalizeAiModuleOptions } from './ai.options';
 import { AiService } from './ai.service';
 import { AI_MODULE_OPTIONS, type AiModuleAsyncOptions, type AiModuleOptions } from './ai.types';
 
 @Module({})
 export class AiModule {
     static register(options: AiModuleOptions): DynamicModule {
+        const normalized = normalizeAiModuleOptions(options);
         return this.createDynamicModule(
             {
                 provide: AI_MODULE_OPTIONS,
-                useValue: options,
+                useValue: normalized,
             },
-            options.isGlobal,
+            normalized.isGlobal,
         );
     }
 
     static registerAsync(options: AiModuleAsyncOptions): DynamicModule {
+        if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+            throw new AiConfigurationError('AiModule async options are required');
+        }
+        if (typeof options.useFactory !== 'function') {
+            throw new AiConfigurationError('AiModule registerAsync requires a useFactory function');
+        }
+        if (options.isGlobal !== undefined && typeof options.isGlobal !== 'boolean') {
+            throw new AiConfigurationError('AiModule isGlobal must be a boolean');
+        }
+
+        const optionsFactory = options.useFactory;
         return {
             module: AiModule,
             global: options.isGlobal ?? false,
@@ -22,7 +36,7 @@ export class AiModule {
             providers: [
                 {
                     provide: AI_MODULE_OPTIONS,
-                    useFactory: options.useFactory,
+                    useFactory: async (...args: unknown[]) => normalizeAiModuleOptions(await optionsFactory(...args)),
                     inject: options.inject ?? [],
                 },
                 AiService,

--- a/packages/ai/src/ai.options.ts
+++ b/packages/ai/src/ai.options.ts
@@ -1,0 +1,37 @@
+import { AiConfigurationError } from './ai.errors';
+import type { AiModuleOptions } from './ai.types';
+
+/** Validate and detach module options from caller-owned mutable objects. */
+export function normalizeAiModuleOptions(options: AiModuleOptions): Readonly<AiModuleOptions> {
+    if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+        throw new AiConfigurationError('AiModule options are required');
+    }
+
+    const configSource = options.configSource;
+    if (typeof configSource !== 'string' || configSource.trim().length === 0) {
+        throw new AiConfigurationError('AiModule requires a non-empty configSource');
+    }
+    if (configSource.includes('\0')) {
+        throw new AiConfigurationError('AiModule configSource cannot contain a null byte');
+    }
+
+    const eager = optionalBoolean('eager', options.eager);
+    const isGlobal = optionalBoolean('isGlobal', options.isGlobal);
+    if (options.runtimeLoader !== undefined && typeof options.runtimeLoader !== 'function') {
+        throw new AiConfigurationError('AiModule runtimeLoader must be a function');
+    }
+
+    return Object.freeze({
+        configSource,
+        ...(eager === undefined ? {} : { eager }),
+        ...(isGlobal === undefined ? {} : { isGlobal }),
+        ...(options.runtimeLoader === undefined ? {} : { runtimeLoader: options.runtimeLoader }),
+    });
+}
+
+function optionalBoolean(name: string, value: unknown): boolean | undefined {
+    if (value !== undefined && typeof value !== 'boolean') {
+        throw new AiConfigurationError(`AiModule ${name} must be a boolean`);
+    }
+    return value as boolean | undefined;
+}

--- a/packages/ai/src/ai.service.ts
+++ b/packages/ai/src/ai.service.ts
@@ -33,14 +33,7 @@ const REQUIRED_AGENT_METHODS = [
     'closeSession',
     'close',
 ] as const;
-const REQUIRED_SESSION_METHODS = [
-    'send',
-    'stream',
-    'closeAsync',
-    'cancelAsync',
-    'cancelRun',
-    'currentRun',
-] as const;
+const REQUIRED_SESSION_METHODS = ['send', 'stream', 'closeAsync', 'cancelAsync', 'cancelRun', 'currentRun'] as const;
 
 interface NormalizedInvocation {
     workspace: string;
@@ -163,9 +156,7 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
             throw new AiConfigurationError('worker must be an object');
         }
         const resolvedOptions = this.sessionOptions(options);
-        return this.acquireSession(agent =>
-            agent.sessionForWorkerAsync(resolvedWorkspace, worker, resolvedOptions),
-        );
+        return this.acquireSession(agent => agent.sessionForWorkerAsync(resolvedWorkspace, worker, resolvedOptions));
     }
 
     /** List stable IDs for live sessions owned by the shared Agent. */
@@ -263,20 +254,7 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
                 iterationError = error;
                 throw error;
             } finally {
-                if (typeof iterator.return === 'function') {
-                    try {
-                        await iterator.return();
-                    } catch (cleanupError) {
-                        if (iterationError !== NO_ERROR) {
-                            throw new AiResourceCleanupError(
-                                iterationError,
-                                cleanupError,
-                                'AI stream iteration and iterator cleanup both failed',
-                            );
-                        }
-                        throw cleanupError;
-                    }
-                }
+                await this.closeStreamIterator(iterator, iterationError);
             }
         } catch (error) {
             operationError = error;
@@ -378,7 +356,22 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
         const agent = await this.activeAgent();
         const acquisition = (async () => {
             const session = await factory(agent);
-            this.assertSession(session, 'created session');
+            try {
+                this.assertSession(session, 'created session');
+            } catch (contractError) {
+                if (this.isObject(session) && typeof session.closeAsync === 'function') {
+                    try {
+                        await session.closeAsync();
+                    } catch (cleanupError) {
+                        throw new AiResourceCleanupError(
+                            contractError,
+                            cleanupError,
+                            'A3S Code Session validation and cleanup both failed',
+                        );
+                    }
+                }
+                throw contractError;
+            }
             if (!this.shuttingDown) {
                 return session;
             }
@@ -407,15 +400,33 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
         return operation;
     }
 
-    private async closeDisposableSession(
-        session: AiSession,
-        operationError: unknown | typeof NO_ERROR,
-    ): Promise<void> {
+    private async closeDisposableSession(session: AiSession, operationError: unknown | typeof NO_ERROR): Promise<void> {
         try {
             await session.closeAsync();
         } catch (cleanupError) {
             if (operationError !== NO_ERROR) {
                 throw new AiResourceCleanupError(operationError, cleanupError);
+            }
+            throw cleanupError;
+        }
+    }
+
+    private async closeStreamIterator(
+        iterator: AsyncIterator<AiAgentEvent>,
+        operationError: unknown | typeof NO_ERROR,
+    ): Promise<void> {
+        if (typeof iterator.return !== 'function') {
+            return;
+        }
+        try {
+            await iterator.return();
+        } catch (cleanupError) {
+            if (operationError !== NO_ERROR) {
+                throw new AiResourceCleanupError(
+                    operationError,
+                    cleanupError,
+                    'AI stream iteration and iterator cleanup both failed',
+                );
             }
             throw cleanupError;
         }

--- a/packages/ai/src/ai.service.ts
+++ b/packages/ai/src/ai.service.ts
@@ -1,5 +1,13 @@
 import { Inject, Injectable, type OnModuleDestroy, type OnModuleInit } from '@nestjs/common';
 import {
+    AiConfigurationError,
+    AiOperationAbortedError,
+    AiResourceCleanupError,
+    AiSdkContractError,
+    AiServiceClosedError,
+} from './ai.errors';
+import { normalizeAiModuleOptions } from './ai.options';
+import {
     AI_MODULE_OPTIONS,
     type AiAgent,
     type AiAgentEvent,
@@ -8,20 +16,53 @@ import {
     type AiRunResult,
     type AiRuntime,
     type AiSession,
+    type AiSessionCallback,
     type AiSessionOptions,
     type AiSessionRequest,
+    type AiWorkerAgentSpec,
 } from './ai.types';
+
+const NO_ERROR = Symbol('no-error');
+const REQUIRED_AGENT_METHODS = [
+    'sessionAsync',
+    'resumeSessionAsync',
+    'replaceSessionAsync',
+    'sessionForAgentAsync',
+    'sessionForWorkerAsync',
+    'listSessions',
+    'closeSession',
+    'close',
+] as const;
+const REQUIRED_SESSION_METHODS = [
+    'send',
+    'stream',
+    'closeAsync',
+    'cancelAsync',
+    'cancelRun',
+    'currentRun',
+] as const;
+
+interface NormalizedInvocation {
+    workspace: string;
+    request: AiSessionRequest;
+    sessionOptions?: AiSessionOptions;
+    signal?: AbortSignal;
+}
 
 const defaultRuntimeLoader = async (): Promise<AiRuntime> => import('@a3s-lab/code');
 
 @Injectable()
 export class AiService implements OnModuleInit, OnModuleDestroy {
+    private readonly options: Readonly<AiModuleOptions>;
+    private readonly sessionAcquisitions = new Set<Promise<unknown>>();
     private agent?: AiAgent;
     private initialization?: Promise<AiAgent>;
     private shutdownPromise?: Promise<void>;
     private shuttingDown = false;
 
-    constructor(@Inject(AI_MODULE_OPTIONS) private readonly options: AiModuleOptions) {}
+    constructor(@Inject(AI_MODULE_OPTIONS) options: AiModuleOptions) {
+        this.options = normalizeAiModuleOptions(options);
+    }
 
     async onModuleInit(): Promise<void> {
         if (this.options.eager === true) {
@@ -31,6 +72,16 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
 
     async onModuleDestroy(): Promise<void> {
         await this.shutdown();
+    }
+
+    /** Whether the native Agent has completed initialization. */
+    get isReady(): boolean {
+        return this.agent !== undefined && !this.shuttingDown;
+    }
+
+    /** Whether shutdown has begun. Once true, the service cannot be restarted. */
+    get isShuttingDown(): boolean {
+        return this.shuttingDown;
     }
 
     /** Ensure that the native Agent has been created. Safe to call repeatedly. */
@@ -61,25 +112,102 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
 
     /** Create a long-lived, workspace-bound session without blocking the event loop. */
     async sessionAsync(workspace: string, options?: AiSessionOptions): Promise<AiSession> {
-        const agent = await this.getAgent();
-        return agent.sessionAsync(workspace, options);
+        const resolvedWorkspace = this.requiredString('workspace', workspace);
+        const resolvedOptions = this.sessionOptions(options);
+        return this.acquireSession(agent => agent.sessionAsync(resolvedWorkspace, resolvedOptions));
     }
 
     /** Resume a saved session. The supplied options must configure its session store. */
     async resumeSessionAsync(sessionId: string, options: AiSessionOptions): Promise<AiSession> {
-        const agent = await this.getAgent();
-        return agent.resumeSessionAsync(sessionId, options);
+        const resolvedSessionId = this.requiredString('sessionId', sessionId);
+        const resolvedOptions = this.sessionOptions(options, true) as AiSessionOptions;
+        return this.acquireSession(agent => agent.resumeSessionAsync(resolvedSessionId, resolvedOptions));
     }
 
     /** Atomically replace an idle persisted session while retaining its session ID. */
     async replaceSessionAsync(current: AiSession, options: AiSessionOptions): Promise<AiSession> {
-        const agent = await this.getAgent();
-        return agent.replaceSessionAsync(current, options);
+        this.assertSession(current, 'current session');
+        const resolvedOptions = this.sessionOptions(options, true) as AiSessionOptions;
+        return this.acquireSession(agent => agent.replaceSessionAsync(current, resolvedOptions));
     }
 
     /** Short alias for `replaceSessionAsync`. */
     async replace(current: AiSession, options: AiSessionOptions): Promise<AiSession> {
         return this.replaceSessionAsync(current, options);
+    }
+
+    /** Create a session from a named A3S Code agent definition. */
+    async sessionForAgentAsync(
+        workspace: string,
+        agentName: string,
+        agentDirs?: string[] | null,
+        options?: AiSessionOptions,
+    ): Promise<AiSession> {
+        const resolvedWorkspace = this.requiredString('workspace', workspace);
+        const resolvedAgentName = this.requiredString('agentName', agentName);
+        const resolvedAgentDirs = this.agentDirectories(agentDirs);
+        const resolvedOptions = this.sessionOptions(options);
+        return this.acquireSession(agent =>
+            agent.sessionForAgentAsync(resolvedWorkspace, resolvedAgentName, resolvedAgentDirs, resolvedOptions),
+        );
+    }
+
+    /** Create a session from an in-memory disposable worker definition. */
+    async sessionForWorkerAsync(
+        workspace: string,
+        worker: AiWorkerAgentSpec,
+        options?: AiSessionOptions,
+    ): Promise<AiSession> {
+        const resolvedWorkspace = this.requiredString('workspace', workspace);
+        if (!this.isObject(worker)) {
+            throw new AiConfigurationError('worker must be an object');
+        }
+        const resolvedOptions = this.sessionOptions(options);
+        return this.acquireSession(agent =>
+            agent.sessionForWorkerAsync(resolvedWorkspace, worker, resolvedOptions),
+        );
+    }
+
+    /** List stable IDs for live sessions owned by the shared Agent. */
+    async listSessions(): Promise<string[]> {
+        const agent = await this.activeAgent();
+        const sessionIds = await agent.listSessions();
+        if (!Array.isArray(sessionIds) || sessionIds.some(value => typeof value !== 'string')) {
+            throw new AiSdkContractError('A3S Code Agent.listSessions returned an invalid session ID list');
+        }
+        return sessionIds;
+    }
+
+    /** Close one Agent-owned session by ID without retaining its native object. */
+    async closeSession(sessionId: string): Promise<boolean> {
+        const resolvedSessionId = this.requiredString('sessionId', sessionId);
+        const agent = await this.activeAgent();
+        const closed = await agent.closeSession(resolvedSessionId);
+        if (typeof closed !== 'boolean') {
+            throw new AiSdkContractError('A3S Code Agent.closeSession returned a non-boolean result');
+        }
+        return closed;
+    }
+
+    /** Run arbitrary work in a disposable session and always close that session. */
+    async withSession<TResult>(
+        workspace: string,
+        callback: AiSessionCallback<TResult>,
+        options?: AiSessionOptions,
+    ): Promise<TResult> {
+        if (typeof callback !== 'function') {
+            throw new AiConfigurationError('AiService.withSession requires a callback');
+        }
+        const session = await this.sessionAsync(workspace, options);
+        let operationError: unknown | typeof NO_ERROR = NO_ERROR;
+        try {
+            return await callback(session);
+        } catch (error) {
+            operationError = error;
+            throw error;
+        } finally {
+            await this.closeDisposableSession(session, operationError);
+        }
     }
 
     run(options: AiInvocationOptions): Promise<AiRunResult>;
@@ -90,16 +218,12 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
         sessionOptions?: AiSessionOptions,
     ): Promise<AiRunResult> {
         const invocation = this.normalizeInvocation(workspaceOrOptions, request, sessionOptions);
-        const session = await this.sessionAsync(invocation.workspace, invocation.sessionOptions);
-        let operationFailed = false;
-        try {
-            return await session.send(invocation.request);
-        } catch (error) {
-            operationFailed = true;
-            throw error;
-        } finally {
-            await this.closeDisposableSession(session, operationFailed);
-        }
+        this.throwIfAborted(invocation.signal);
+        return this.withSession(
+            invocation.workspace,
+            session => this.awaitWithSignal(session, invocation.signal, () => session.send(invocation.request)),
+            invocation.sessionOptions,
+        );
     }
 
     stream(options: AiInvocationOptions): AsyncGenerator<AiAgentEvent, void, void>;
@@ -114,18 +238,51 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
         sessionOptions?: AiSessionOptions,
     ): AsyncGenerator<AiAgentEvent, void, void> {
         const invocation = this.normalizeInvocation(workspaceOrOptions, request, sessionOptions);
+        this.throwIfAborted(invocation.signal);
         const session = await this.sessionAsync(invocation.workspace, invocation.sessionOptions);
-        let operationFailed = false;
+        let operationError: unknown | typeof NO_ERROR = NO_ERROR;
         try {
-            const events = await session.stream(invocation.request);
-            for await (const event of events) {
-                yield event;
+            const events = await this.awaitWithSignal(session, invocation.signal, () =>
+                session.stream(invocation.request),
+            );
+            if (!events || typeof events[Symbol.asyncIterator] !== 'function') {
+                throw new AiSdkContractError('A3S Code Session.stream returned a non-async-iterable value');
+            }
+
+            const iterator = events[Symbol.asyncIterator]();
+            let iterationError: unknown | typeof NO_ERROR = NO_ERROR;
+            try {
+                while (true) {
+                    const next = await this.awaitWithSignal(session, invocation.signal, () => iterator.next());
+                    if (next.done) {
+                        break;
+                    }
+                    yield next.value;
+                }
+            } catch (error) {
+                iterationError = error;
+                throw error;
+            } finally {
+                if (typeof iterator.return === 'function') {
+                    try {
+                        await iterator.return();
+                    } catch (cleanupError) {
+                        if (iterationError !== NO_ERROR) {
+                            throw new AiResourceCleanupError(
+                                iterationError,
+                                cleanupError,
+                                'AI stream iteration and iterator cleanup both failed',
+                            );
+                        }
+                        throw cleanupError;
+                    }
+                }
             }
         } catch (error) {
-            operationFailed = true;
+            operationError = error;
             throw error;
         } finally {
-            await this.closeDisposableSession(session, operationFailed);
+            await this.closeDisposableSession(session, operationError);
         }
     }
 
@@ -134,8 +291,9 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
      * falls back to broad cancellation, so it cannot cancel a newer run.
      */
     async cancelRun(session: AiSession, runId?: string): Promise<boolean> {
+        this.assertSession(session, 'session');
         if (runId !== undefined) {
-            return session.cancelRun(runId);
+            return session.cancelRun(this.requiredString('runId', runId));
         }
 
         const currentRun = (await session.currentRun()) as unknown;
@@ -153,91 +311,305 @@ export class AiService implements OnModuleInit, OnModuleDestroy {
         }
 
         this.shuttingDown = true;
-        const agent = this.agent;
-        const initialization = this.initialization;
-        this.shutdownPromise = (async () => {
-            let agentToClose = agent;
-            if (!agentToClose && initialization) {
-                try {
-                    agentToClose = await initialization;
-                } catch {
-                    // A service-closure rejection may still leave an initialized
-                    // agent for this shutdown operation to close.
-                    agentToClose = this.agent;
-                }
-            }
-            try {
-                await agentToClose?.close();
-            } finally {
-                this.agent = undefined;
-                this.initialization = undefined;
-            }
-        })();
+        this.shutdownPromise = this.performShutdown(this.agent, this.initialization);
         return this.shutdownPromise;
     }
 
-    private async initializeAgent(): Promise<AiAgent> {
-        const configSource = this.options.configSource;
-        if (typeof configSource !== 'string' || configSource.trim().length === 0) {
-            throw new TypeError('AiModule requires a non-empty configSource');
+    private async performShutdown(agent?: AiAgent, initialization?: Promise<AiAgent>): Promise<void> {
+        let agentToClose = agent;
+        if (!agentToClose && initialization) {
+            try {
+                agentToClose = await initialization;
+            } catch {
+                // Initialization may reject with AiServiceClosedError after it has
+                // installed the Agent for this shutdown operation to close.
+                agentToClose = this.agent;
+            }
         }
 
+        await Promise.allSettled([...this.sessionAcquisitions]);
+        agentToClose ??= this.agent;
+        try {
+            await agentToClose?.close();
+        } finally {
+            this.agent = undefined;
+            this.initialization = undefined;
+        }
+    }
+
+    private async initializeAgent(): Promise<AiAgent> {
         const runtime = await (this.options.runtimeLoader ?? defaultRuntimeLoader)();
         if (!runtime?.Agent || typeof runtime.Agent.create !== 'function') {
-            throw new TypeError('The A3S Code runtime loader did not provide Agent.create');
+            throw new AiSdkContractError('The A3S Code runtime loader did not provide Agent.create');
         }
 
-        const agent = await runtime.Agent.create(configSource);
+        const agent = await runtime.Agent.create(this.options.configSource);
+        try {
+            this.assertAgent(agent);
+        } catch (contractError) {
+            if (this.isObject(agent) && typeof agent.close === 'function') {
+                try {
+                    await agent.close();
+                } catch (cleanupError) {
+                    throw new AiResourceCleanupError(
+                        contractError,
+                        cleanupError,
+                        'A3S Code Agent validation and cleanup both failed',
+                    );
+                }
+            }
+            throw contractError;
+        }
+
         this.agent = agent;
         if (this.shuttingDown) {
-            throw this.closedError();
+            throw new AiServiceClosedError();
         }
         return agent;
     }
 
-    private async closeDisposableSession(session: AiSession, operationFailed: boolean): Promise<void> {
+    private async activeAgent(): Promise<AiAgent> {
+        const agent = await this.getAgent();
+        this.assertRunning();
+        return agent;
+    }
+
+    private async acquireSession(factory: (agent: AiAgent) => Promise<AiSession>): Promise<AiSession> {
+        const agent = await this.activeAgent();
+        const acquisition = (async () => {
+            const session = await factory(agent);
+            this.assertSession(session, 'created session');
+            if (!this.shuttingDown) {
+                return session;
+            }
+
+            const closedError = new AiServiceClosedError();
+            try {
+                await session.closeAsync();
+            } catch (cleanupError) {
+                throw new AiResourceCleanupError(
+                    closedError,
+                    cleanupError,
+                    'AI session creation completed during shutdown and cleanup failed',
+                );
+            }
+            throw closedError;
+        })();
+        return this.trackSessionAcquisition(acquisition);
+    }
+
+    private trackSessionAcquisition<TResult>(operation: Promise<TResult>): Promise<TResult> {
+        this.sessionAcquisitions.add(operation);
+        void operation.then(
+            () => this.sessionAcquisitions.delete(operation),
+            () => this.sessionAcquisitions.delete(operation),
+        );
+        return operation;
+    }
+
+    private async closeDisposableSession(
+        session: AiSession,
+        operationError: unknown | typeof NO_ERROR,
+    ): Promise<void> {
         try {
             await session.closeAsync();
-        } catch (error) {
-            if (!operationFailed) {
-                throw error;
+        } catch (cleanupError) {
+            if (operationError !== NO_ERROR) {
+                throw new AiResourceCleanupError(operationError, cleanupError);
             }
+            throw cleanupError;
         }
+    }
+
+    private awaitWithSignal<TResult>(
+        session: AiSession,
+        signal: AbortSignal | undefined,
+        operation: () => Promise<TResult>,
+    ): Promise<TResult> {
+        if (!signal) {
+            return Promise.resolve().then(operation);
+        }
+        if (signal.aborted) {
+            this.cancelDisposableSession(session);
+            return Promise.reject(new AiOperationAbortedError(signal.reason));
+        }
+
+        return new Promise<TResult>((resolve, reject) => {
+            let settled = false;
+            const removeAbortListener = () => signal.removeEventListener('abort', abort);
+            const abort = () => {
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                removeAbortListener();
+                this.cancelDisposableSession(session);
+                reject(new AiOperationAbortedError(signal.reason));
+            };
+
+            signal.addEventListener('abort', abort, { once: true });
+            if (signal.aborted) {
+                abort();
+                return;
+            }
+
+            void Promise.resolve()
+                .then(operation)
+                .then(
+                    result => {
+                        if (!settled) {
+                            settled = true;
+                            removeAbortListener();
+                            resolve(result);
+                        }
+                    },
+                    error => {
+                        if (!settled) {
+                            settled = true;
+                            removeAbortListener();
+                            reject(error);
+                        }
+                    },
+                );
+        });
+    }
+
+    private cancelDisposableSession(session: AiSession): void {
+        void Promise.resolve()
+            .then(() => session.cancelAsync())
+            .catch(() => undefined);
     }
 
     private normalizeInvocation(
         workspaceOrOptions: string | AiInvocationOptions,
         request?: AiSessionRequest,
         sessionOptions?: AiSessionOptions,
-    ): AiInvocationOptions {
-        if (typeof workspaceOrOptions !== 'string') {
-            return workspaceOrOptions;
+    ): NormalizedInvocation {
+        const invocation: AiInvocationOptions =
+            typeof workspaceOrOptions === 'string'
+                ? {
+                      workspace: workspaceOrOptions,
+                      request: request as AiSessionRequest,
+                      sessionOptions,
+                  }
+                : workspaceOrOptions;
+
+        if (!this.isObject(invocation)) {
+            throw new AiConfigurationError('AiService.run/stream options must be an object');
         }
-        if (request === undefined) {
-            throw new TypeError('AiService.run/stream requires a request');
+        if (invocation.request === undefined) {
+            throw new AiConfigurationError('AiService.run/stream requires a request');
         }
+
         return {
-            workspace: workspaceOrOptions,
-            request,
-            sessionOptions,
+            workspace: this.requiredString('workspace', invocation.workspace),
+            request: this.request(invocation.request),
+            sessionOptions: this.sessionOptions(invocation.sessionOptions),
+            signal: this.abortSignal(invocation.signal),
         };
     }
 
-    private readRunId(run: unknown): string | undefined {
-        if (typeof run !== 'object' || run === null || !('id' in run)) {
+    private request(request: AiSessionRequest): AiSessionRequest {
+        if (typeof request === 'string') {
+            this.requiredString('request', request);
+            return request;
+        }
+        if (!this.isObject(request)) {
+            throw new AiConfigurationError('request must be a non-empty string or an object with a prompt');
+        }
+        this.requiredString('request.prompt', request.prompt);
+        return request;
+    }
+
+    private sessionOptions(options: AiSessionOptions | undefined, required = false): AiSessionOptions | undefined {
+        if (options === undefined && !required) {
             return undefined;
         }
-        const id = (run as { id?: unknown }).id;
-        return typeof id === 'string' && id.length > 0 ? id : undefined;
+        if (!this.isObject(options)) {
+            throw new AiConfigurationError('sessionOptions must be an object');
+        }
+        return options;
+    }
+
+    private agentDirectories(agentDirs: string[] | null | undefined): string[] | null | undefined {
+        if (agentDirs === undefined || agentDirs === null) {
+            return agentDirs;
+        }
+        if (!Array.isArray(agentDirs)) {
+            throw new AiConfigurationError('agentDirs must be an array of non-empty strings');
+        }
+        for (const directory of agentDirs) {
+            this.requiredString('agentDirs entry', directory);
+        }
+        return [...agentDirs];
+    }
+
+    private abortSignal(signal: AbortSignal | undefined): AbortSignal | undefined {
+        if (
+            signal !== undefined &&
+            (!this.isObject(signal) ||
+                typeof signal.aborted !== 'boolean' ||
+                typeof signal.addEventListener !== 'function' ||
+                typeof signal.removeEventListener !== 'function')
+        ) {
+            throw new AiConfigurationError('signal must implement the AbortSignal contract');
+        }
+        return signal;
+    }
+
+    private throwIfAborted(signal?: AbortSignal): void {
+        if (signal?.aborted) {
+            throw new AiOperationAbortedError(signal.reason);
+        }
+    }
+
+    private requiredString(name: string, value: unknown): string {
+        if (typeof value !== 'string' || value.trim().length === 0) {
+            throw new AiConfigurationError(`${name} must be a non-empty string`);
+        }
+        if (value.includes('\0')) {
+            throw new AiConfigurationError(`${name} cannot contain a null byte`);
+        }
+        return value;
+    }
+
+    private readRunId(run: unknown): string | undefined {
+        if (!this.isObject(run) || !('id' in run)) {
+            return undefined;
+        }
+        const id = run.id;
+        return typeof id === 'string' && id.trim().length > 0 ? id : undefined;
+    }
+
+    private assertAgent(agent: unknown): asserts agent is AiAgent {
+        if (!this.isObject(agent)) {
+            throw new AiSdkContractError('A3S Code Agent.create returned an invalid Agent');
+        }
+        for (const method of REQUIRED_AGENT_METHODS) {
+            if (typeof agent[method] !== 'function') {
+                throw new AiSdkContractError(`A3S Code Agent is missing ${method}()`);
+            }
+        }
+    }
+
+    private assertSession(session: unknown, label: string): asserts session is AiSession {
+        if (!this.isObject(session)) {
+            throw new AiSdkContractError(`A3S Code ${label} is invalid`);
+        }
+        for (const method of REQUIRED_SESSION_METHODS) {
+            if (typeof session[method] !== 'function') {
+                throw new AiSdkContractError(`A3S Code ${label} is missing ${method}()`);
+            }
+        }
     }
 
     private assertRunning(): void {
         if (this.shuttingDown) {
-            throw this.closedError();
+            throw new AiServiceClosedError();
         }
     }
 
-    private closedError(): Error {
-        return new Error('AiService has been shut down');
+    private isObject(value: unknown): value is Record<PropertyKey, unknown> {
+        return typeof value === 'object' && value !== null && !Array.isArray(value);
     }
 }

--- a/packages/ai/src/ai.types.ts
+++ b/packages/ai/src/ai.types.ts
@@ -8,6 +8,7 @@ import type {
     Session,
     SessionOptions,
     SessionRequestOptions,
+    WorkerAgentSpec,
 } from '@a3s-lab/code';
 import type { FactoryProvider, ModuleMetadata } from '@nestjs/common';
 
@@ -28,6 +29,9 @@ export type AiSessionRequestOptions = SessionRequestOptions;
 
 /** The durable prompt request accepted by A3S Code. */
 export type AiSessionRequest = string | AiSessionRequestOptions;
+
+/** Disposable worker definition accepted by the native SDK. */
+export type AiWorkerAgentSpec = WorkerAgentSpec;
 
 /** The complete result returned by a non-streaming run. */
 export type AiRunResult = AgentResult;
@@ -77,4 +81,9 @@ export interface AiInvocationOptions {
     workspace: string;
     request: AiSessionRequest;
     sessionOptions?: AiSessionOptions;
+    /** Cancels only the disposable session owned by this invocation. */
+    signal?: AbortSignal;
 }
+
+/** Callback used by `AiService.withSession`; the session is always closed afterwards. */
+export type AiSessionCallback<TResult> = (session: AiSession) => TResult | Promise<TResult>;

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,4 +1,11 @@
 export { AiModule } from './ai.module';
+export {
+    AiConfigurationError,
+    AiOperationAbortedError,
+    AiResourceCleanupError,
+    AiSdkContractError,
+    AiServiceClosedError,
+} from './ai.errors';
 export { AiService } from './ai.service';
 export {
     AI_MODULE_OPTIONS,
@@ -14,7 +21,9 @@ export {
     type AiRuntime,
     type AiRuntimeLoader,
     type AiSession,
+    type AiSessionCallback,
     type AiSessionOptions,
     type AiSessionRequest,
     type AiSessionRequestOptions,
+    type AiWorkerAgentSpec,
 } from './ai.types';


### PR DESCRIPTION
## Summary

- validate and freeze sync/async AI module options, then verify custom `@a3s-lab/code` runtime, Agent, Session, stream, and control-plane contracts at the Nest boundary
- expose the first-party async named-agent and worker session APIs plus list/close helpers while preserving native events, stable errors, and fail-fast `SESSION_BUSY` behavior
- add `withSession`, request-scoped `AbortSignal` support for disposable runs/streams, dual-failure cleanup errors, and shutdown draining for in-flight session creation
- expand package/root/framework documentation and add a minor changeset

## Verification

- `pnpm --filter @a3s-lab/ai test:cov` (38 tests; 95.22% statements, 91.8% branches)
- `pnpm release:check` (format, lint, build, test, pack, and manifest/tarball verification for all 18 core packages)
- `pnpm smoke:core-install` (installed, type-checked, and imported all 18 packed packages in a temporary consumer)
- `pnpm publish:core:dry-run` (verified npm publication for the exact packed artifacts)
