### PR TITLE
feat(cqrs): make event publication deterministic

### DIFF
--- a/.changeset/harden-cqrs-publication.md
+++ b/.changeset/harden-cqrs-publication.md
@@ -1,0 +1,5 @@
+---
+"@a3s-lab/cqrs": minor
+---
+
+Add deterministic and bounded domain-event batch publication, configurable Nest module wiring, ordered/parallel/native strategies, runtime validation, and complete multi-failure reporting.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Nestify currently contains 18 publishable framework packages:
 | Package | Responsibility |
 | --- | --- |
 | `@a3s-lab/ddd` | Framework-independent DDD primitives: entities, aggregate roots, value objects, domain events, repositories, unit of work contracts, guards, and `Result`. |
-| `@a3s-lab/cqrs` | NestJS CQRS adapter for publishing `@a3s-lab/ddd` domain events through the Nest event bus. |
+| `@a3s-lab/cqrs` | Deterministic NestJS CQRS adapter for `@a3s-lab/ddd` events, with validated batches, ordered defaults, bounded parallelism, native batch delegation, and configurable module wiring. |
 | `@a3s-lab/http` | API envelopes, business errors, validation, request ids, pagination, DTO serialization, key transforms, filters, interceptors, API versioning, and OpenAPI helpers. |
 | `@a3s-lab/security` | Default-deny guard primitives, public/role/permission metadata, local/dev guard helpers, path validation, sensitive operation metadata, JWT helpers, and role-permission checks. |
 | `@a3s-lab/observability` | Request tracking context, SQL and external-call collectors, metrics service, Prometheus output, HTTP metrics interceptor, and health check module. |
@@ -176,6 +176,9 @@ an `NPM_TOKEN` secret with access to the `@a3s-lab` scope.
 - HTTP metrics use route templates rather than raw URLs. Histogram memory is constant per series, and counters, gauges,
   and histograms cap label cardinality with an explicit overflow series.
 - Startup database migrations remain disabled in every environment unless the application explicitly opts in.
+- CQRS domain-event batches are validated and bounded before admission. Ordered publication is the default; parallel
+  publication requires an explicit concurrency limit and preserves every failure instead of leaving rejected work in
+  the background.
 
 ## Design Boundaries
 

--- a/apps/api/src/modules/order/order.module.ts
+++ b/apps/api/src/modules/order/order.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
-import { CqrsModule } from '@nestjs/cqrs';
-import { createNestCqrsDomainEventPublisherProvider } from '@a3s-lab/cqrs';
+import { NestCqrsDomainEventsModule } from '@a3s-lab/cqrs';
 import { OrderController } from './presentation/order.controller';
 import { OrderRepository } from './infrastructure/persistence/kysely-order.repository';
 import { OrderCacheService } from './infrastructure/cache/order-cache.service';
@@ -19,7 +18,7 @@ const QueryHandlers = [GetOrderHandler, ListOrdersHandler];
 const EventHandlers = [OrderCreatedHandler, OrderConfirmedHandler];
 
 @Module({
-    imports: [CqrsModule],
+    imports: [NestCqrsDomainEventsModule.register()],
     controllers: [OrderController],
     providers: [
         ...CommandHandlers,
@@ -31,7 +30,6 @@ const EventHandlers = [OrderCreatedHandler, OrderConfirmedHandler];
             provide: ORDER_REPOSITORY,
             useClass: OrderRepository,
         },
-        createNestCqrsDomainEventPublisherProvider(),
     ],
     exports: [OrderCacheService],
 })

--- a/docs/framework-core.md
+++ b/docs/framework-core.md
@@ -7,7 +7,7 @@ Nestify separates reusable backend API capabilities from the sample application.
 | Package | Responsibility |
 | --- | --- |
 | `@a3s-lab/ddd` | Framework-independent DDD primitives: entities, aggregate roots, value objects, domain events, repositories, unit of work contracts, guards, and `Result`. |
-| `@a3s-lab/cqrs` | NestJS CQRS adapter for publishing `@a3s-lab/ddd` domain events through the Nest event bus. |
+| `@a3s-lab/cqrs` | Deterministic NestJS CQRS adapter for `@a3s-lab/ddd` events, with validated bounded batches, ordered/parallel/native strategies, and configurable module wiring. |
 | `@a3s-lab/http` | API response envelopes, business errors, validation pipes, request/correlation ids, pagination helpers, DTO serialization helpers, key/response transforms, presentation filters/interceptors, and OpenAPI decorators. |
 | `@a3s-lab/security` | Default-deny guard primitives, public/role/permission route metadata, local/dev-only guards, path validation, sensitive operation metadata, JWT payload/token helpers, and role-permission checks. |
 | `@a3s-lab/observability` | Request tracking context, SQL and external-call collectors, metrics service, Prometheus output, HTTP metrics interceptor, and health check module. |
@@ -63,6 +63,8 @@ The NestJS integration packages accept NestJS 10 and 11 peers. Workspace builds,
   excess labels aggregate into a fixed overflow series, and HTTP paths come only from route templates or a fixed
   unmatched label.
 - Automatic migrations are fail-closed and require an explicit module or environment opt-in in production.
+- CQRS event batches default to ordered, fail-fast admission and a finite batch limit. Parallel mode is explicit,
+  concurrency-bounded, waits for all admitted publications, and preserves multiple failures with event indexes.
 
 ## Sample API Wiring
 
@@ -118,7 +120,8 @@ export async function up(db: Kysely<unknown>) {
 The framework core is covered by package tests for:
 
 - DDD primitives, persistence contracts, and `Result`
-- CQRS domain event publisher adapter
+- CQRS module/provider wiring, event validation, ordered fail-fast publication, bounded parallel scheduling, native
+  batch delegation, async publisher completion, and multi-failure preservation
 - HTTP envelopes, errors, request ids, and pagination
 - HTTP interceptors and filters with Nest `Reflector` metadata
 - HTTP presentation filters and logging interceptor

--- a/packages/cqrs/README.md
+++ b/packages/cqrs/README.md
@@ -1,6 +1,8 @@
 # @a3s-lab/cqrs
 
-NestJS CQRS adapters for DDD-style backend APIs.
+Deterministic NestJS CQRS adapters for the domain-event contracts in `@a3s-lab/ddd`. The package validates and bounds
+event batches, supports ordered, bounded-parallel, and native Nest publication, and keeps the DDD injection token
+decoupled from Nest CQRS.
 
 ## Install
 
@@ -9,22 +11,23 @@ pnpm add @a3s-lab/cqrs @a3s-lab/ddd
 pnpm add @nestjs/common @nestjs/cqrs
 ```
 
+The package supports NestJS 10 and 11.
+
 ## Use
 
+### Register the module
+
+`NestCqrsDomainEventsModule` imports and re-exports Nest's `CqrsModule`, provides `NestCqrsDomainEventPublisher`, and aliases
+`DOMAIN_EVENT_PUBLISHER` to that same instance. Registration is non-global, ordered, and limited to 1,000 events per
+batch by default.
+
 ```ts
+import { DOMAIN_EVENT_PUBLISHER, type IDomainEventPublisher } from '@a3s-lab/ddd';
 import { Inject, Module } from '@nestjs/common';
-import { CqrsModule } from '@nestjs/cqrs';
-import { DOMAIN_EVENT_PUBLISHER, IDomainEventPublisher } from '@a3s-lab/ddd';
-import { NestCqrsDomainEventPublisher } from '@a3s-lab/cqrs';
+import { NestCqrsDomainEventsModule } from '@a3s-lab/cqrs';
 
 @Module({
-    imports: [CqrsModule],
-    providers: [
-        {
-            provide: DOMAIN_EVENT_PUBLISHER,
-            useClass: NestCqrsDomainEventPublisher,
-        },
-    ],
+    imports: [NestCqrsDomainEventsModule.register()],
 })
 export class ResourceModule {}
 
@@ -33,13 +36,79 @@ class CompleteUseCase {
 }
 ```
 
+Use asynchronous registration when policy comes from configuration:
+
+```ts
+NestCqrsDomainEventsModule.registerAsync({
+    imports: [ConfigModule],
+    inject: [ConfigService],
+    useFactory: (config: ConfigService) => ({
+        mode: config.get('DOMAIN_EVENT_BATCH_MODE', 'ordered'),
+        maxConcurrency: config.get('DOMAIN_EVENT_CONCURRENCY', 8),
+        maxBatchSize: config.get('DOMAIN_EVENT_MAX_BATCH_SIZE', 1_000),
+    }),
+})
+```
+
+Set `isGlobal: true` on the `register` or `registerAsync` argument only when the publisher should be application-wide.
+
+### Choose batch semantics
+
+`publish(event)` validates the domain-event shape and awaits a Promise returned by a custom Nest event publisher.
+`publishAll(events)` snapshots and validates the whole array before it publishes anything.
+
+| Mode | Semantics | Failure behavior |
+| --- | --- | --- |
+| `ordered` (default) | Publishes one event at a time in array order. | Stops before admitting later events and rethrows the original error. |
+| `parallel` | Publishes up to `maxConcurrency` events at once and waits for every admitted event. | Rethrows one original error; multiple failures become `DomainEventBatchPublicationError` in event order. |
+| `native` | Calls `EventBus.publishAll()` once and awaits a returned Promise or Promise array. | Preserves one error and aggregates multiple returned failures. |
+
+```ts
+NestCqrsDomainEventsModule.register({
+    mode: 'parallel',
+    maxConcurrency: 4,
+    maxBatchSize: 250,
+})
+```
+
+Prefer `ordered` for events from one aggregate. Select `parallel` only when handlers or a custom publisher do not depend
+on cross-event ordering. Select `native` only when the configured Nest event publisher defines meaningful batch
+semantics.
+
+### Compatibility provider
+
+Existing modules that already import Nest's `CqrsModule` can keep the original provider helper. It uses the safe default
+options:
+
+```ts
+@Module({
+    imports: [CqrsModule],
+    providers: [createNestCqrsDomainEventPublisherProvider()],
+})
+export class ResourceModule {}
+```
+
+For manual configurable composition, `createNestCqrsDomainEventPublisherProviders(options)` returns an options provider,
+the concrete publisher, and a `useExisting` alias for `DOMAIN_EVENT_PUBLISHER`.
+
 ## Exports
 
-- `NestCqrsDomainEventPublisher`
-- `createNestCqrsDomainEventPublisherProvider`
+- `NestCqrsDomainEventsModule`: synchronous/asynchronous Nest module registration.
+- `NestCqrsDomainEventPublisher`: the `IDomainEventPublisher` adapter.
+- `createNestCqrsDomainEventPublisherProvider`: backward-compatible default provider.
+- `createNestCqrsDomainEventPublisherProviders`: configurable provider set with a single shared instance.
+- `NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS` and default constants.
+- Publisher/module option and batch-mode types.
+- `CqrsDomainEventConfigurationError` and `DomainEventBatchPublicationError` with ordered failure metadata.
 
 ## Notes
 
-This package adapts `@a3s-lab/ddd` domain event publisher contracts to NestJS CQRS. It does not define domain events, command handlers, event names, or transport/broker policy.
+The adapter preserves the configured Nest event publisher's completion model. Nest's default in-memory publisher
+synchronously admits events to its RxJS stream; awaiting this adapter does not turn asynchronous event handlers into a
+database transaction or delivery acknowledgement. Configure Nest CQRS error policy deliberately.
+
+This package does not provide durable delivery, exactly-once processing, an outbox, retries, broker transport, domain
+event definitions, or handler naming policy. Persist state and an outbox atomically when delivery must survive process
+failure; use `@a3s-lab/nats` or another transport at that boundary.
 
 See the [framework core guide](../../docs/framework-core.md) for package boundaries.

--- a/packages/cqrs/package.json
+++ b/packages/cqrs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@a3s-lab/cqrs",
     "version": "0.1.0",
-    "description": "NestJS CQRS adapters for DDD-style backend APIs",
+    "description": "Deterministic, bounded NestJS CQRS domain-event publishing for DDD-style APIs",
     "author": "A3S Lab",
     "license": "MIT",
     "homepage": "https://github.com/A3S-Lab/nestify/tree/main/packages/cqrs#readme",
@@ -43,6 +43,9 @@
     "scripts": {
         "build": "rimraf dist && tsc",
         "test": "jest --passWithNoTests",
+        "test:cov": "jest --coverage",
+        "lint": "biome lint .",
+        "format:check": "biome format .",
         "clean": "rimraf dist && rimraf node_modules",
         "prepublishOnly": "pnpm run build"
     },
@@ -54,8 +57,10 @@
         "@nestjs/cqrs": "^10.0.0 || ^11.0.0"
     },
     "devDependencies": {
+        "@biomejs/biome": "^2.3.14",
         "@nestjs/common": "^11.1.28",
         "@nestjs/cqrs": "^11.0.3",
+        "@nestjs/testing": "^11.1.28",
         "@types/jest": "^29.5.0",
         "jest": "^29.5.0",
         "reflect-metadata": "^0.1.13",
@@ -77,6 +82,12 @@
         "transform": {
             "^.+\\.(t|j)s$": "ts-jest"
         },
+        "collectCoverageFrom": [
+            "**/*.(t|j)s",
+            "!**/__tests__/**",
+            "!coverage/**"
+        ],
+        "coverageDirectory": "../coverage",
         "testEnvironment": "node"
     }
 }

--- a/packages/cqrs/src/__tests__/nest-cqrs-domain-event-publisher.spec.ts
+++ b/packages/cqrs/src/__tests__/nest-cqrs-domain-event-publisher.spec.ts
@@ -1,5 +1,12 @@
 import { DOMAIN_EVENT_PUBLISHER, DomainEvent } from '@a3s-lab/ddd';
-import { createNestCqrsDomainEventPublisherProvider, NestCqrsDomainEventPublisher } from '../index';
+import {
+    CqrsDomainEventConfigurationError,
+    createNestCqrsDomainEventPublisherProvider,
+    createNestCqrsDomainEventPublisherProviders,
+    DomainEventBatchPublicationError,
+    NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+    NestCqrsDomainEventPublisher,
+} from '../index';
 
 class TestDomainEvent extends DomainEvent {
     constructor(private readonly aggregateId: string) {
@@ -11,33 +18,277 @@ class TestDomainEvent extends DomainEvent {
     }
 }
 
+function deferred<T = void>() {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+        resolve = resolvePromise;
+        reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+}
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (predicate()) {
+            return;
+        }
+        await Promise.resolve();
+    }
+    throw new Error('condition was not reached');
+}
+
+function createEventBus() {
+    return {
+        publish: jest.fn(),
+        publishAll: jest.fn(),
+    };
+}
+
 describe('NestCqrsDomainEventPublisher', () => {
-    it('publishes one domain event through the Nest CQRS event bus', async () => {
-        const eventBus = { publish: jest.fn() };
+    it('publishes one domain event and awaits a custom asynchronous publisher', async () => {
+        const eventBus = createEventBus();
+        const publication = deferred();
+        eventBus.publish.mockReturnValue(publication.promise);
         const publisher = new NestCqrsDomainEventPublisher(eventBus as never);
         const event = new TestDomainEvent('resource-1');
 
-        await publisher.publish(event);
+        let settled = false;
+        const result = publisher.publish(event).then(() => {
+            settled = true;
+        });
+        await Promise.resolve();
 
         expect(eventBus.publish).toHaveBeenCalledWith(event);
+        expect(settled).toBe(false);
+        publication.resolve();
+        await result;
+        expect(settled).toBe(true);
     });
 
-    it('publishes all domain events', async () => {
-        const eventBus = { publish: jest.fn() };
+    it('publishes batches in order by default and snapshots the input', async () => {
+        const eventBus = createEventBus();
+        const firstPublication = deferred();
+        eventBus.publish.mockImplementationOnce(() => firstPublication.promise).mockResolvedValue(undefined);
         const publisher = new NestCqrsDomainEventPublisher(eventBus as never);
         const events = [new TestDomainEvent('resource-1'), new TestDomainEvent('resource-2')];
 
-        await publisher.publishAll(events);
+        const publication = publisher.publishAll(events);
+        events.push(new TestDomainEvent('late-mutation'));
+        await Promise.resolve();
+        expect(eventBus.publish).toHaveBeenCalledTimes(1);
+
+        firstPublication.resolve();
+        await publication;
 
         expect(eventBus.publish).toHaveBeenCalledTimes(2);
         expect(eventBus.publish).toHaveBeenNthCalledWith(1, events[0]);
         expect(eventBus.publish).toHaveBeenNthCalledWith(2, events[1]);
+        expect(eventBus.publish).not.toHaveBeenCalledWith(events[2]);
+        expect(eventBus.publishAll).not.toHaveBeenCalled();
     });
 
-    it('creates a provider for the DDD publisher token', () => {
+    it('stops an ordered batch after the original publication failure', async () => {
+        const eventBus = createEventBus();
+        const publicationError = new Error('publisher unavailable');
+        eventBus.publish.mockResolvedValueOnce(undefined).mockRejectedValueOnce(publicationError);
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never);
+        const events = [
+            new TestDomainEvent('resource-1'),
+            new TestDomainEvent('resource-2'),
+            new TestDomainEvent('resource-3'),
+        ];
+
+        await expect(publisher.publishAll(events)).rejects.toBe(publicationError);
+        expect(eventBus.publish).toHaveBeenCalledTimes(2);
+        expect(eventBus.publish).not.toHaveBeenCalledWith(events[2]);
+    });
+
+    it('bounds explicitly parallel publication and waits for every admitted event', async () => {
+        const eventBus = createEventBus();
+        const gates = Array.from({ length: 4 }, () => deferred());
+        eventBus.publish.mockImplementation((event: TestDomainEvent) => gates[Number(event.getAggregateId())].promise);
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, {
+            mode: 'parallel',
+            maxConcurrency: 2,
+        });
+        const events = Array.from({ length: 4 }, (_, index) => new TestDomainEvent(String(index)));
+
+        const publication = publisher.publishAll(events);
+        await waitUntil(() => eventBus.publish.mock.calls.length === 2);
+        expect(eventBus.publish).toHaveBeenCalledTimes(2);
+
+        gates[0].resolve();
+        await waitUntil(() => eventBus.publish.mock.calls.length === 3);
+        expect(eventBus.publish).toHaveBeenCalledTimes(3);
+
+        gates[1].resolve();
+        gates[2].resolve();
+        await waitUntil(() => eventBus.publish.mock.calls.length === 4);
+        gates[3].resolve();
+        await publication;
+    });
+
+    it('preserves all failures from a parallel batch in event order', async () => {
+        const eventBus = createEventBus();
+        const firstError = new Error('first failed');
+        const thirdError = new Error('third failed');
+        eventBus.publish.mockImplementation((event: TestDomainEvent) => {
+            if (event.getAggregateId() === '0') {
+                return Promise.reject(firstError);
+            }
+            if (event.getAggregateId() === '2') {
+                return Promise.reject(thirdError);
+            }
+            return Promise.resolve();
+        });
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, {
+            mode: 'parallel',
+            maxConcurrency: 3,
+        });
+        const events = Array.from({ length: 3 }, (_, index) => new TestDomainEvent(String(index)));
+
+        let received: unknown;
+        try {
+            await publisher.publishAll(events);
+        } catch (error) {
+            received = error;
+        }
+
+        expect(received).toBeInstanceOf(DomainEventBatchPublicationError);
+        expect(received).toMatchObject({
+            failures: [
+                { index: 0, event: events[0], error: firstError },
+                { index: 2, event: events[2], error: thirdError },
+            ],
+        });
+        expect(eventBus.publish).toHaveBeenCalledTimes(3);
+    });
+
+    it('preserves the original error when only one parallel publication fails', async () => {
+        const eventBus = createEventBus();
+        const publicationError = new Error('one failed');
+        eventBus.publish.mockRejectedValueOnce(publicationError).mockResolvedValue(undefined);
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, { mode: 'parallel' });
+
+        await expect(
+            publisher.publishAll([new TestDomainEvent('resource-1'), new TestDomainEvent('resource-2')]),
+        ).rejects.toBe(publicationError);
+    });
+
+    it('delegates native batches and awaits every array result', async () => {
+        const eventBus = createEventBus();
+        const secondPublication = deferred();
+        eventBus.publishAll.mockReturnValue([Promise.resolve(), secondPublication.promise]);
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, { mode: 'native' });
+        const events = [new TestDomainEvent('resource-1'), new TestDomainEvent('resource-2')];
+
+        let settled = false;
+        const publication = publisher.publishAll(events).then(() => {
+            settled = true;
+        });
+        await Promise.resolve();
+
+        expect(eventBus.publishAll).toHaveBeenCalledWith(events);
+        expect(eventBus.publish).not.toHaveBeenCalled();
+        expect(settled).toBe(false);
+        secondPublication.resolve();
+        await publication;
+        expect(settled).toBe(true);
+    });
+
+    it('awaits a promise returned directly by native batch publication', async () => {
+        const eventBus = createEventBus();
+        const nativePublication = deferred();
+        eventBus.publishAll.mockReturnValue(nativePublication.promise);
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, { mode: 'native' });
+
+        let settled = false;
+        const publication = publisher.publishAll([new TestDomainEvent('resource-1')]).then(() => {
+            settled = true;
+        });
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        nativePublication.resolve();
+        await publication;
+        expect(settled).toBe(true);
+    });
+
+    it('preserves multiple failures returned by a native batch', async () => {
+        const eventBus = createEventBus();
+        const firstError = new Error('first native failure');
+        const secondError = new Error('second native failure');
+        eventBus.publishAll.mockReturnValue([Promise.reject(firstError), Promise.reject(secondError)]);
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, { mode: 'native' });
+        const events = [new TestDomainEvent('resource-1'), new TestDomainEvent('resource-2')];
+
+        await expect(publisher.publishAll(events)).rejects.toMatchObject({
+            failures: [
+                { index: 0, event: events[0], error: firstError },
+                { index: 1, event: events[1], error: secondError },
+            ],
+        });
+    });
+
+    it('validates the EventBus native batch contract', async () => {
+        const event = new TestDomainEvent('resource-1');
+        const missingNative = new NestCqrsDomainEventPublisher({ publish: jest.fn() } as never, { mode: 'native' });
+        await expect(missingNative.publishAll([event])).rejects.toThrow('requires Nest CQRS EventBus.publishAll');
+
+        const eventBus = createEventBus();
+        eventBus.publishAll.mockReturnValue([undefined, undefined]);
+        const oversizedResult = new NestCqrsDomainEventPublisher(eventBus as never, { mode: 'native' });
+        await expect(oversizedResult.publishAll([event])).rejects.toThrow('more results than submitted events');
+    });
+
+    it('validates events and batch limits before publishing anything', async () => {
+        const eventBus = createEventBus();
+        const publisher = new NestCqrsDomainEventPublisher(eventBus as never, { maxBatchSize: 1 });
+
+        await expect(publisher.publish({ occurredOn: new Date('invalid') } as never)).rejects.toThrow(
+            CqrsDomainEventConfigurationError,
+        );
+        await expect(publisher.publishAll(null as never)).rejects.toThrow('events must be an array');
+        await expect(
+            publisher.publishAll([new TestDomainEvent('resource-1'), new TestDomainEvent('resource-2')]),
+        ).rejects.toThrow('maxBatchSize');
+        await expect(publisher.publishAll([{} as never])).rejects.toThrow('events[0]');
+        await expect(publisher.publishAll([])).resolves.toBeUndefined();
+        expect(eventBus.publish).not.toHaveBeenCalled();
+        expect(eventBus.publishAll).not.toHaveBeenCalled();
+    });
+
+    it('validates EventBus and publisher options at construction', () => {
+        const eventBus = createEventBus();
+
+        expect(() => new NestCqrsDomainEventPublisher({} as never)).toThrow('must provide publish');
+        expect(() => new NestCqrsDomainEventPublisher(eventBus as never, null as never)).toThrow('must be an object');
+        expect(() => new NestCqrsDomainEventPublisher(eventBus as never, { mode: 'fast' as never })).toThrow('mode');
+        expect(() => new NestCqrsDomainEventPublisher(eventBus as never, { maxConcurrency: 0 })).toThrow(
+            'maxConcurrency',
+        );
+        expect(() => new NestCqrsDomainEventPublisher(eventBus as never, { maxBatchSize: 1.5 })).toThrow(
+            'maxBatchSize',
+        );
+    });
+
+    it('creates backward-compatible and configurable providers', () => {
         expect(createNestCqrsDomainEventPublisherProvider()).toEqual({
             provide: DOMAIN_EVENT_PUBLISHER,
             useClass: NestCqrsDomainEventPublisher,
         });
+
+        const providers = createNestCqrsDomainEventPublisherProviders({ mode: 'parallel', maxConcurrency: 2 });
+        expect(providers).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    provide: NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+                    useValue: expect.objectContaining({ mode: 'parallel', maxConcurrency: 2, maxBatchSize: 1000 }),
+                }),
+                NestCqrsDomainEventPublisher,
+                { provide: DOMAIN_EVENT_PUBLISHER, useExisting: NestCqrsDomainEventPublisher },
+            ]),
+        );
     });
 });

--- a/packages/cqrs/src/__tests__/nest-cqrs-domain-events.module.spec.ts
+++ b/packages/cqrs/src/__tests__/nest-cqrs-domain-events.module.spec.ts
@@ -1,0 +1,100 @@
+import 'reflect-metadata';
+import { DOMAIN_EVENT_PUBLISHER } from '@a3s-lab/ddd';
+import { Injectable, Module } from '@nestjs/common';
+import { CommandBus, CqrsModule } from '@nestjs/cqrs';
+import { Test } from '@nestjs/testing';
+import {
+    CqrsDomainEventConfigurationError,
+    NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+    NestCqrsDomainEventPublisher,
+    NestCqrsDomainEventsModule,
+} from '../index';
+
+@Module({
+    providers: [{ provide: 'BATCH_MODE', useValue: 'parallel' }],
+    exports: ['BATCH_MODE'],
+})
+class ConfigFixtureModule {}
+
+@Injectable()
+class CqrsConsumer {
+    constructor(readonly commandBus: CommandBus) {}
+}
+
+describe('NestCqrsDomainEventsModule', () => {
+    it('registers a non-global ordered publisher by default', () => {
+        const definition = NestCqrsDomainEventsModule.register();
+
+        expect(definition.global).toBe(false);
+        expect(definition.imports).toContain(CqrsModule);
+        expect(definition.providers).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    provide: NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+                    useValue: { mode: 'ordered', maxConcurrency: 8, maxBatchSize: 1000 },
+                }),
+                NestCqrsDomainEventPublisher,
+                { provide: DOMAIN_EVENT_PUBLISHER, useExisting: NestCqrsDomainEventPublisher },
+            ]),
+        );
+        expect(definition.exports).toEqual(
+            expect.arrayContaining([CqrsModule, NestCqrsDomainEventPublisher, DOMAIN_EVENT_PUBLISHER]),
+        );
+    });
+
+    it('wires the class and DDD token to the same configured instance', async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [NestCqrsDomainEventsModule.register({ mode: 'parallel', maxConcurrency: 3 })],
+            providers: [CqrsConsumer],
+        }).compile();
+
+        expect(moduleRef.get(DOMAIN_EVENT_PUBLISHER)).toBe(moduleRef.get(NestCqrsDomainEventPublisher));
+        expect(moduleRef.get(CqrsConsumer).commandBus).toBeInstanceOf(CommandBus);
+        expect(moduleRef.get(NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS)).toEqual({
+            mode: 'parallel',
+            maxConcurrency: 3,
+            maxBatchSize: 1000,
+        });
+        await moduleRef.close();
+    });
+
+    it('resolves async options through Nest dependency injection', async () => {
+        const moduleRef = await Test.createTestingModule({
+            imports: [
+                NestCqrsDomainEventsModule.registerAsync({
+                    imports: [ConfigFixtureModule],
+                    inject: ['BATCH_MODE'],
+                    useFactory: (mode: 'parallel') => ({ mode, maxConcurrency: 4 }),
+                }),
+            ],
+        }).compile();
+
+        expect(moduleRef.get(NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS)).toEqual({
+            mode: 'parallel',
+            maxConcurrency: 4,
+            maxBatchSize: 1000,
+        });
+        await moduleRef.close();
+    });
+
+    it('supports explicit global registration and rejects invalid module options', () => {
+        expect(NestCqrsDomainEventsModule.register({ isGlobal: true }).global).toBe(true);
+        expect(
+            NestCqrsDomainEventsModule.registerAsync({ useFactory: () => ({ mode: 'ordered' }), isGlobal: true })
+                .global,
+        ).toBe(true);
+
+        expect(() => NestCqrsDomainEventsModule.register(null as never)).toThrow(CqrsDomainEventConfigurationError);
+        expect(() => NestCqrsDomainEventsModule.register({ isGlobal: 'yes' as never })).toThrow('isGlobal');
+        expect(() => NestCqrsDomainEventsModule.registerAsync(null as never)).toThrow('async module options');
+        expect(() => NestCqrsDomainEventsModule.registerAsync({ useFactory: undefined as never })).toThrow(
+            'useFactory',
+        );
+        expect(() =>
+            NestCqrsDomainEventsModule.registerAsync({
+                useFactory: () => ({ mode: 'ordered' }),
+                isGlobal: 'yes' as never,
+            }),
+        ).toThrow('isGlobal');
+    });
+});

--- a/packages/cqrs/src/cqrs-domain-events.errors.ts
+++ b/packages/cqrs/src/cqrs-domain-events.errors.ts
@@ -1,0 +1,26 @@
+import type { DomainEvent } from '@a3s-lab/ddd';
+
+/** Invalid publisher/module configuration or invalid runtime input. */
+export class CqrsDomainEventConfigurationError extends TypeError {
+    override readonly name = 'CqrsDomainEventConfigurationError';
+}
+
+export interface DomainEventPublicationFailure {
+    readonly index: number;
+    readonly event: DomainEvent;
+    readonly error: unknown;
+}
+
+/** Every failure from a parallel/native batch, in original event order. */
+export class DomainEventBatchPublicationError extends AggregateError {
+    override readonly name = 'DomainEventBatchPublicationError';
+    readonly failures: readonly DomainEventPublicationFailure[];
+
+    constructor(failures: readonly DomainEventPublicationFailure[]) {
+        super(
+            failures.map(failure => failure.error),
+            `Failed to publish ${failures.length} domain events`,
+        );
+        this.failures = Object.freeze([...failures]);
+    }
+}

--- a/packages/cqrs/src/cqrs-domain-events.options.ts
+++ b/packages/cqrs/src/cqrs-domain-events.options.ts
@@ -1,0 +1,42 @@
+import { CqrsDomainEventConfigurationError } from './cqrs-domain-events.errors';
+import type {
+    DomainEventBatchMode,
+    NestCqrsDomainEventPublisherOptions,
+    ResolvedNestCqrsDomainEventPublisherOptions,
+} from './cqrs-domain-events.types';
+
+export const NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS = Symbol.for('@a3s-lab/cqrs/domain-event-publisher-options');
+export const DEFAULT_DOMAIN_EVENT_BATCH_MODE: DomainEventBatchMode = 'ordered';
+export const DEFAULT_DOMAIN_EVENT_MAX_CONCURRENCY = 8;
+export const DEFAULT_DOMAIN_EVENT_MAX_BATCH_SIZE = 1000;
+
+const BATCH_MODES = new Set<DomainEventBatchMode>(['ordered', 'parallel', 'native']);
+
+export function normalizeNestCqrsDomainEventPublisherOptions(
+    options: NestCqrsDomainEventPublisherOptions | undefined = {},
+): ResolvedNestCqrsDomainEventPublisherOptions {
+    if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+        throw new CqrsDomainEventConfigurationError('CQRS domain-event publisher options must be an object');
+    }
+
+    const mode = options.mode ?? DEFAULT_DOMAIN_EVENT_BATCH_MODE;
+    if (!BATCH_MODES.has(mode)) {
+        throw new CqrsDomainEventConfigurationError('mode must be ordered, parallel, or native');
+    }
+
+    return Object.freeze({
+        mode,
+        maxConcurrency: positiveInteger(
+            'maxConcurrency',
+            options.maxConcurrency ?? DEFAULT_DOMAIN_EVENT_MAX_CONCURRENCY,
+        ),
+        maxBatchSize: positiveInteger('maxBatchSize', options.maxBatchSize ?? DEFAULT_DOMAIN_EVENT_MAX_BATCH_SIZE),
+    });
+}
+
+function positiveInteger(name: string, value: unknown): number {
+    if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+        throw new CqrsDomainEventConfigurationError(`${name} must be a positive safe integer`);
+    }
+    return value as number;
+}

--- a/packages/cqrs/src/cqrs-domain-events.types.ts
+++ b/packages/cqrs/src/cqrs-domain-events.types.ts
@@ -1,0 +1,30 @@
+import type { FactoryProvider, ModuleMetadata } from '@nestjs/common';
+
+export type DomainEventBatchMode = 'ordered' | 'parallel' | 'native';
+
+export interface NestCqrsDomainEventPublisherOptions {
+    /** Batch strategy. Ordered is deterministic and fail-fast. Defaults to ordered. */
+    mode?: DomainEventBatchMode;
+    /** Maximum simultaneously pending publishes in parallel mode. Defaults to 8. */
+    maxConcurrency?: number;
+    /** Reject larger batches before any event is published. Defaults to 1000. */
+    maxBatchSize?: number;
+}
+
+export interface NestCqrsDomainEventsModuleOptions extends NestCqrsDomainEventPublisherOptions {
+    /** Make the dynamic module global. Defaults to false. */
+    isGlobal?: boolean;
+}
+
+export interface NestCqrsDomainEventsModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+    /** Make the dynamic module global. Defaults to false. */
+    isGlobal?: boolean;
+    inject?: FactoryProvider['inject'];
+    useFactory: (...args: any[]) => NestCqrsDomainEventPublisherOptions | Promise<NestCqrsDomainEventPublisherOptions>;
+}
+
+export interface ResolvedNestCqrsDomainEventPublisherOptions {
+    readonly mode: DomainEventBatchMode;
+    readonly maxConcurrency: number;
+    readonly maxBatchSize: number;
+}

--- a/packages/cqrs/src/index.ts
+++ b/packages/cqrs/src/index.ts
@@ -1,1 +1,24 @@
-export * from './nest-cqrs-domain-event-publisher';
+export {
+    CqrsDomainEventConfigurationError,
+    DomainEventBatchPublicationError,
+    type DomainEventPublicationFailure,
+} from './cqrs-domain-events.errors';
+export {
+    DEFAULT_DOMAIN_EVENT_BATCH_MODE,
+    DEFAULT_DOMAIN_EVENT_MAX_BATCH_SIZE,
+    DEFAULT_DOMAIN_EVENT_MAX_CONCURRENCY,
+    NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+} from './cqrs-domain-events.options';
+export type {
+    DomainEventBatchMode,
+    NestCqrsDomainEventPublisherOptions,
+    NestCqrsDomainEventsModuleAsyncOptions,
+    NestCqrsDomainEventsModuleOptions,
+    ResolvedNestCqrsDomainEventPublisherOptions,
+} from './cqrs-domain-events.types';
+export { NestCqrsDomainEventsModule } from './nest-cqrs-domain-events.module';
+export {
+    createNestCqrsDomainEventPublisherProvider,
+    createNestCqrsDomainEventPublisherProviders,
+    NestCqrsDomainEventPublisher,
+} from './nest-cqrs-domain-event-publisher';

--- a/packages/cqrs/src/nest-cqrs-domain-event-publisher.ts
+++ b/packages/cqrs/src/nest-cqrs-domain-event-publisher.ts
@@ -1,23 +1,191 @@
-import { Injectable, type Provider } from '@nestjs/common';
-import { EventBus as NestEventBus } from '@nestjs/cqrs';
 import { DOMAIN_EVENT_PUBLISHER, type DomainEvent, type IDomainEventPublisher } from '@a3s-lab/ddd';
+import { Inject, Injectable, Optional, type Provider } from '@nestjs/common';
+import { EventBus as NestEventBus } from '@nestjs/cqrs';
+import {
+    CqrsDomainEventConfigurationError,
+    DomainEventBatchPublicationError,
+    type DomainEventPublicationFailure,
+} from './cqrs-domain-events.errors';
+import {
+    NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+    normalizeNestCqrsDomainEventPublisherOptions,
+} from './cqrs-domain-events.options';
+import type {
+    NestCqrsDomainEventPublisherOptions,
+    ResolvedNestCqrsDomainEventPublisherOptions,
+} from './cqrs-domain-events.types';
 
 @Injectable()
 export class NestCqrsDomainEventPublisher implements IDomainEventPublisher {
-    constructor(private readonly eventBus: NestEventBus) {}
+    private readonly options: ResolvedNestCqrsDomainEventPublisherOptions;
 
+    constructor(
+        private readonly eventBus: NestEventBus,
+        @Optional()
+        @Inject(NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS)
+        options?: NestCqrsDomainEventPublisherOptions,
+    ) {
+        if (!isObject(eventBus) || typeof eventBus.publish !== 'function') {
+            throw new CqrsDomainEventConfigurationError('Nest CQRS EventBus must provide publish()');
+        }
+        this.options = normalizeNestCqrsDomainEventPublisherOptions(options);
+    }
+
+    /** Publish one structurally valid domain event and await custom async publishers. */
     async publish(event: DomainEvent): Promise<void> {
+        this.assertDomainEvent(event, 'event');
+        await this.publishValidated(event);
+    }
+
+    /**
+     * Publish a bounded snapshot using the configured batch strategy. Ordered
+     * mode is deterministic and stops admitting events after the first error.
+     */
+    async publishAll(events: DomainEvent[]): Promise<void> {
+        const batch = this.normalizeBatch(events);
+        if (batch.length === 0) {
+            return;
+        }
+
+        switch (this.options.mode) {
+            case 'ordered':
+                await this.publishOrdered(batch);
+                return;
+            case 'parallel':
+                await this.publishParallel(batch);
+                return;
+            case 'native':
+                await this.publishNative(batch);
+                return;
+        }
+    }
+
+    private async publishOrdered(events: readonly DomainEvent[]): Promise<void> {
+        for (const event of events) {
+            await this.publishValidated(event);
+        }
+    }
+
+    private async publishParallel(events: readonly DomainEvent[]): Promise<void> {
+        const failures: Array<DomainEventPublicationFailure | undefined> = new Array(events.length);
+        let nextIndex = 0;
+        const worker = async () => {
+            while (true) {
+                const index = nextIndex;
+                nextIndex += 1;
+                if (index >= events.length) {
+                    return;
+                }
+                try {
+                    await this.publishValidated(events[index]);
+                } catch (error) {
+                    failures[index] = { index, event: events[index], error };
+                }
+            }
+        };
+
+        const workerCount = Math.min(this.options.maxConcurrency, events.length);
+        await Promise.all(Array.from({ length: workerCount }, worker));
+        this.throwFailures(
+            failures.filter((failure): failure is DomainEventPublicationFailure => failure !== undefined),
+        );
+    }
+
+    private async publishNative(events: readonly DomainEvent[]): Promise<void> {
+        const publishAll = this.eventBus.publishAll;
+        if (typeof publishAll !== 'function') {
+            throw new CqrsDomainEventConfigurationError('native mode requires Nest CQRS EventBus.publishAll()');
+        }
+
+        const result = this.eventBus.publishAll([...events]) as unknown;
+        if (!Array.isArray(result)) {
+            await result;
+            return;
+        }
+        if (result.length > events.length) {
+            throw new CqrsDomainEventConfigurationError(
+                'Nest CQRS EventBus.publishAll returned more results than submitted events',
+            );
+        }
+
+        const settled = await Promise.allSettled(result.map(value => Promise.resolve(value)));
+        const failures: DomainEventPublicationFailure[] = [];
+        for (let index = 0; index < settled.length; index += 1) {
+            const outcome = settled[index];
+            if (outcome.status === 'rejected') {
+                failures.push({ index, event: events[index], error: outcome.reason });
+            }
+        }
+        this.throwFailures(failures);
+    }
+
+    private async publishValidated(event: DomainEvent): Promise<void> {
         await this.eventBus.publish(event);
     }
 
-    async publishAll(events: DomainEvent[]): Promise<void> {
-        await Promise.all(events.map(event => this.publish(event)));
+    private normalizeBatch(events: DomainEvent[]): readonly DomainEvent[] {
+        if (!Array.isArray(events)) {
+            throw new CqrsDomainEventConfigurationError('events must be an array');
+        }
+        if (events.length > this.options.maxBatchSize) {
+            throw new CqrsDomainEventConfigurationError(
+                `events exceeds the configured maxBatchSize of ${this.options.maxBatchSize}`,
+            );
+        }
+
+        const snapshot = [...events];
+        for (let index = 0; index < snapshot.length; index += 1) {
+            this.assertDomainEvent(snapshot[index], `events[${index}]`);
+        }
+        return snapshot;
+    }
+
+    private assertDomainEvent(event: unknown, label: string): asserts event is DomainEvent {
+        if (
+            !isObject(event) ||
+            !(event.occurredOn instanceof Date) ||
+            Number.isNaN(event.occurredOn.getTime()) ||
+            typeof event.getAggregateId !== 'function'
+        ) {
+            throw new CqrsDomainEventConfigurationError(
+                `${label} must provide a valid occurredOn Date and getAggregateId()`,
+            );
+        }
+    }
+
+    private throwFailures(failures: readonly DomainEventPublicationFailure[]): void {
+        if (failures.length === 1) {
+            throw failures[0].error;
+        }
+        if (failures.length > 1) {
+            throw new DomainEventBatchPublicationError(failures);
+        }
     }
 }
 
+/** Backward-compatible, unconfigured provider for the DDD publisher token. */
 export function createNestCqrsDomainEventPublisherProvider(): Provider {
     return {
         provide: DOMAIN_EVENT_PUBLISHER,
         useClass: NestCqrsDomainEventPublisher,
     };
+}
+
+/** Providers for direct configurable module composition. */
+export function createNestCqrsDomainEventPublisherProviders(options?: NestCqrsDomainEventPublisherOptions): Provider[] {
+    return [
+        {
+            provide: NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+            useValue: normalizeNestCqrsDomainEventPublisherOptions(options),
+        },
+        NestCqrsDomainEventPublisher,
+        {
+            provide: DOMAIN_EVENT_PUBLISHER,
+            useExisting: NestCqrsDomainEventPublisher,
+        },
+    ];
+}
+
+function isObject(value: unknown): value is Record<PropertyKey, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/cqrs/src/nest-cqrs-domain-events.module.ts
+++ b/packages/cqrs/src/nest-cqrs-domain-events.module.ts
@@ -1,0 +1,68 @@
+import { DOMAIN_EVENT_PUBLISHER } from '@a3s-lab/ddd';
+import { type DynamicModule, Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+import { CqrsDomainEventConfigurationError } from './cqrs-domain-events.errors';
+import {
+    NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+    normalizeNestCqrsDomainEventPublisherOptions,
+} from './cqrs-domain-events.options';
+import type {
+    NestCqrsDomainEventsModuleAsyncOptions,
+    NestCqrsDomainEventsModuleOptions,
+} from './cqrs-domain-events.types';
+import { NestCqrsDomainEventPublisher } from './nest-cqrs-domain-event-publisher';
+
+@Module({})
+export class NestCqrsDomainEventsModule {
+    static register(options: NestCqrsDomainEventsModuleOptions = {}): DynamicModule {
+        if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+            throw new CqrsDomainEventConfigurationError('CQRS domain-events module options must be an object');
+        }
+        if (options.isGlobal !== undefined && typeof options.isGlobal !== 'boolean') {
+            throw new CqrsDomainEventConfigurationError('isGlobal must be a boolean');
+        }
+
+        const publisherOptions = normalizeNestCqrsDomainEventPublisherOptions(options);
+        return {
+            module: NestCqrsDomainEventsModule,
+            global: options.isGlobal ?? false,
+            imports: [CqrsModule],
+            providers: [
+                { provide: NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS, useValue: publisherOptions },
+                NestCqrsDomainEventPublisher,
+                { provide: DOMAIN_EVENT_PUBLISHER, useExisting: NestCqrsDomainEventPublisher },
+            ],
+            exports: [CqrsModule, NestCqrsDomainEventPublisher, DOMAIN_EVENT_PUBLISHER],
+        };
+    }
+
+    static registerAsync(options: NestCqrsDomainEventsModuleAsyncOptions): DynamicModule {
+        if (typeof options !== 'object' || options === null || Array.isArray(options)) {
+            throw new CqrsDomainEventConfigurationError('CQRS domain-events async module options must be an object');
+        }
+        if (typeof options.useFactory !== 'function') {
+            throw new CqrsDomainEventConfigurationError('registerAsync requires a useFactory function');
+        }
+        if (options.isGlobal !== undefined && typeof options.isGlobal !== 'boolean') {
+            throw new CqrsDomainEventConfigurationError('isGlobal must be a boolean');
+        }
+
+        const optionsFactory = options.useFactory;
+        return {
+            module: NestCqrsDomainEventsModule,
+            global: options.isGlobal ?? false,
+            imports: [CqrsModule, ...(options.imports ?? [])],
+            providers: [
+                {
+                    provide: NEST_CQRS_DOMAIN_EVENT_PUBLISHER_OPTIONS,
+                    inject: options.inject ?? [],
+                    useFactory: async (...args: unknown[]) =>
+                        normalizeNestCqrsDomainEventPublisherOptions(await optionsFactory(...args)),
+                },
+                NestCqrsDomainEventPublisher,
+                { provide: DOMAIN_EVENT_PUBLISHER, useExisting: NestCqrsDomainEventPublisher },
+            ],
+            exports: [CqrsModule, NestCqrsDomainEventPublisher, DOMAIN_EVENT_PUBLISHER],
+        };
+    }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       ts-loader:
         specifier: ^9.4.3
         version: 9.5.4(typescript@5.9.3)(webpack@5.106.2(@swc/core@1.15.11))
@@ -179,7 +179,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -210,7 +210,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -241,7 +241,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -252,12 +252,18 @@ importers:
         specifier: workspace:*
         version: link:../ddd
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.3.14
+        version: 2.3.14
       '@nestjs/common':
         specifier: ^11.1.28
         version: 11.1.28(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/cqrs':
         specifier: ^11.0.3
         version: 11.0.3(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.28)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/testing':
+        specifier: ^11.1.28
+        version: 11.1.28(@nestjs/common@11.1.28(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@11.1.28)(@nestjs/platform-express@11.1.28)
       '@types/jest':
         specifier: ^29.5.0
         version: 29.5.14
@@ -272,7 +278,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -290,7 +296,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -321,7 +327,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -360,7 +366,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -412,7 +418,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -461,7 +467,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -510,7 +516,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -544,7 +550,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -575,7 +581,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -627,7 +633,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -667,7 +673,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -707,7 +713,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -741,7 +747,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -772,7 +778,7 @@ importers:
         version: 6.1.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
@@ -827,7 +833,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.1.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.1.3
         version: 5.9.3
@@ -9140,7 +9146,7 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.19.31)(ts-node@10.9.2(@swc/core@1.15.11)(@types/node@20.19.31)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0


### PR DESCRIPTION
## Summary

- replace unbounded `Promise.all` event batches with validated, snapshotted, size-bounded publication and a deterministic ordered default
- add explicit bounded-parallel and Nest-native batch modes, preserving one original error and aggregating multiple failures in event order
- add sync/async `NestCqrsDomainEventsModule` wiring that re-exports Nest CQRS and aliases the DDD token to one shared publisher instance
- migrate the sample Order module, expand package/root/framework documentation, and add a minor changeset

## Verification

- `pnpm --filter @a3s-lab/cqrs test:cov` (17 tests; 100% lines, 98.5% branches)
- `pnpm --filter @a3s-lab/api exec jest --runInBand` (118 tests)
- `pnpm release:check` (format, lint, build, test, pack, and manifest/tarball verification for all 18 core packages)
- `pnpm smoke:core-install` (installed, type-checked, and imported all 18 packed packages in a temporary consumer)
- `pnpm publish:core:dry-run` (verified npm publication for the exact packed artifacts)
