### PR TITLE
fix: run release publish through package script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           branch: main
           version: pnpm version-packages
-          publish: pnpm release:publish:dry-run && pnpm release:publish
+          publish: pnpm release:publish:ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "publish:core:dry-run": "node scripts/publish-core.mjs --dry-run",
         "release:check": "pnpm format:check && pnpm lint:check && pnpm build:core && pnpm test:core && pnpm pack:core && pnpm verify:core-packages",
         "release:publish:dry-run": "pnpm release:check && pnpm smoke:core-install && pnpm publish:core:dry-run",
+        "release:publish:ci": "pnpm release:publish:dry-run && pnpm release:publish",
         "release:publish": "pnpm publish:core && changeset tag"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

- invoke Changesets with one package script instead of a shell expression
- keep the verified dry-run and real publish sequence inside pnpm, where `&&` is interpreted correctly

## Root cause

`changesets/action` parses the configured publish command directly rather than through a shell. The previous `pnpm release:publish:dry-run && pnpm release:publish` value passed `&& pnpm release:publish` as arguments to `scripts/publish-core.mjs`, so publishing stopped before npm authentication was attempted.

## Validation

- JSON manifest parses successfully
- `git diff --check` passes
- repository CI will run the release checks, smoke install, workspace build, and tests